### PR TITLE
Updated development number names to GalleryCharacterReference

### DIFF
--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/GalleryCharacterReference.asset
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/GalleryCharacterReference.asset
@@ -16,48 +16,48 @@ MonoBehaviour:
   - Name: Tunnottomat
     id: 256
     list:
-    - Name: Rauta-Rami
+    - Name: 111
       id: 257
       Image: {fileID: 21300000, guid: ee90161b5d39ec9418fa0aa77146b2f1, type: 3}
   - Name: "H\xE4m\xE4\xE4j\xE4t"
     id: 512
     list:
-    - Name: Vitsi-Ville
+    - Name: 202
       id: 513
       Image: {fileID: 21300000, guid: 95be75f57c8fa0348969e12a3058ec56, type: 3}
-    - Name: Lasse Liukas
+    - Name: 203
       id: 514
       Image: {fileID: 21300000, guid: cfee47f40c406b048980cbc48970234f, type: 3}
   - Name: Tottelijat
     id: 768
     list:
-    - Name: Sami Saarnaaja
+    - Name: 301
       id: 769
       Image: {fileID: 21300000, guid: a8195e5c386ed2345988b958495c4c19, type: 3}
   - Name: Peilaajat
     id: 1024
     list:
-    - Name: Graffiti-Gaya
+    - Name: 401
       id: 1025
       Image: {fileID: 21300000, guid: c3ccef0c9c6027b46848eb4ad73c7a2d, type: 3}
   - Name: Torjujat
     id: 1280
     list:
-    - Name: Hannu-Hodari
+    - Name: 501
       id: 1281
       Image: {fileID: 21300000, guid: dfdefd46f5298ca45bfe06badbfaa956, type: 3}
-    - Name: Pullo-Piraatti
+    - Name: 502
       id: 1282
       Image: {fileID: 21300000, guid: 1ad7ef75f9ecfb945b0d71f9b329269c, type: 3}
   - Name: Sulautujat
     id: 1536
     list:
-    - Name: "Tiimityt\xF6t"
+    - Name: 601-602
       id: 1537
       Image: {fileID: 21300000, guid: 13a8471a6fe8dfd42ac7926700a46b7d, type: 3}
   - Name: "\xC4lyllist\xE4j\xE4t"
     id: 768
     list:
-    - Name: "Albert \xC4lyp\xE4\xE4"
+    - Name: 701
       id: 1793
       Image: {fileID: 21300000, guid: 62536513ff41a774b944a9bad03052f0, type: 3}


### PR DESCRIPTION
- Changed the character names to numbers (which are used to identify the characters during development) in GalleryCharacterReference.
![kuva](https://github.com/user-attachments/assets/473af3b2-8b5c-402e-baf2-0439edd7b4ba)
