### PR TITLE
Refresh character gallery characters on login bug fixed

### DIFF
--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/GalleryPanel.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/GalleryPanel.prefab
@@ -91,7 +91,6 @@ GameObject:
   - component: {fileID: 8548890098221207883}
   - component: {fileID: 7428943245344021282}
   - component: {fileID: 5166243680909419808}
-  - component: {fileID: 6792504709600775594}
   m_Layer: 5
   m_Name: Gallery
   m_TagString: Untagged
@@ -218,25 +217,6 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls: []
---- !u!114 &6792504709600775594
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4689490333519661579}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 307e6162b866c484d8f7440f3af3068c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _characterList:
-  - {fileID: 6712706073602126356, guid: 5dff9ac77871f574c916c5d00c8fe4bf, type: 3}
-  - {fileID: 6712706073602126356, guid: 8dc522cbdaed2a041aaa1cf230c4b2c9, type: 3}
-  - {fileID: 6712706073602126356, guid: b2b72b8652e824b4087bd217db606997, type: 3}
-  - {fileID: 6712706073602126356, guid: 190ce71ede1bb6b4d89a57d346ff77ca, type: 3}
-  - {fileID: 6712706073602126356, guid: 0f541a70f572a544bb816b1f055074b7, type: 3}
-  - {fileID: 6712706073602126356, guid: de41b8c757972174dbf2be3cb365a1d5, type: 3}
 --- !u!1 &6491821458906489138
 GameObject:
   m_ObjectHideFlags: 0
@@ -350,6 +330,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: DraggableCharacterGallery
       objectReference: {fileID: 0}
+    - target: {fileID: 1657837458230196602, guid: 7fe6fc90801a37d498444e0b9f3f734c,
+        type: 3}
+      propertyPath: _text1
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1657837458230196602, guid: 7fe6fc90801a37d498444e0b9f3f734c,
+        type: 3}
+      propertyPath: _selectedCharacterSlotText1
+      value: 
+      objectReference: {fileID: 8073001226690957906}
+    - target: {fileID: 1657837458230196602, guid: 7fe6fc90801a37d498444e0b9f3f734c,
+        type: 3}
+      propertyPath: _selectedCharacterSlotText2
+      value: 
+      objectReference: {fileID: 3535899290428015124}
+    - target: {fileID: 1657837458230196602, guid: 7fe6fc90801a37d498444e0b9f3f734c,
+        type: 3}
+      propertyPath: _selectedCharacterSlotText3
+      value: 
+      objectReference: {fileID: 963310784500745849}
     - target: {fileID: 1657837458230196602, guid: 7fe6fc90801a37d498444e0b9f3f734c,
         type: 3}
       propertyPath: _colorBlock.m_ColorMultiplier
@@ -505,9 +505,27 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7fe6fc90801a37d498444e0b9f3f734c, type: 3}
+--- !u!1 &963310784500745849 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2388269479839593268, guid: 7fe6fc90801a37d498444e0b9f3f734c,
+    type: 3}
+  m_PrefabInstance: {fileID: 3205024158698616141}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &3438347029337907810 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 274154540934240047, guid: 7fe6fc90801a37d498444e0b9f3f734c,
+    type: 3}
+  m_PrefabInstance: {fileID: 3205024158698616141}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3535899290428015124 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2119086382482863961, guid: 7fe6fc90801a37d498444e0b9f3f734c,
+    type: 3}
+  m_PrefabInstance: {fileID: 3205024158698616141}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8073001226690957906 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6661817438561347359, guid: 7fe6fc90801a37d498444e0b9f3f734c,
     type: 3}
   m_PrefabInstance: {fileID: 3205024158698616141}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/DraggableCharacter.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/DraggableCharacter.cs
@@ -40,16 +40,6 @@ namespace MenuUi.Scripts.CharacterGallery
 
         public CharacterID Id { get => _id; }
 
-        private GameObject _text1;
-        private GameObject _text2;
-        private GameObject _text3;
-
-        private void Awake()
-        {
-            _text1 = GameObject.FindGameObjectWithTag("TextSuoja1");
-            _text2 = GameObject.FindGameObjectWithTag("TextSuoja2");
-            _text3 = GameObject.FindGameObjectWithTag("TextSuoja3");
-        }
 
         private void Start()
         {
@@ -61,7 +51,6 @@ namespace MenuUi.Scripts.CharacterGallery
             {
                 initialSlot = transform.parent;
             }
-            CheckSelectedCharacterSlotText();
         }
 
         public void OnBeginDrag(PointerEventData eventData)
@@ -81,39 +70,12 @@ namespace MenuUi.Scripts.CharacterGallery
             GameObject.Find("EventSystem").GetComponent<EventSystem>().SetSelectedGameObject(null);
         }
 
+
         public void OnDrag(PointerEventData eventData)
         {
             transform.position = eventData.position;
         }
-        public void CheckSelectedCharacterSlotText()
-        {
-            if (_modelView._CurSelectedCharacterSlots[2].transform.childCount > 0)
-            {
-                _text3.SetActive(false);
-            }
-            else
-            {
-                _text3.SetActive(true);
-            }
 
-            if (_modelView._CurSelectedCharacterSlots[1].transform.childCount > 0)
-            {
-                _text2.SetActive(false);
-            }
-            else
-            {
-                _text2.SetActive(true);
-            }
-
-            if (_modelView._CurSelectedCharacterSlots[0].transform.childCount > 0)
-            {
-                _text1.SetActive(false);
-            }
-            else
-            {
-                _text1.SetActive(true);
-            }
-        }
 
         public void OnEndDrag(PointerEventData eventData)
         {
@@ -221,7 +183,6 @@ namespace MenuUi.Scripts.CharacterGallery
                 previousParent = transform.parent;
                 HandleParentChange(previousParent);
             }
-            CheckSelectedCharacterSlotText();
         }
 
 

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
@@ -20,7 +20,18 @@ namespace MenuUi.Scripts.CharacterGallery
         private void Awake()
         {
             ServerManager.OnLogInStatusChanged += StartLoading;
+        }
 
+
+        // When starting from 01-Loader OnLogInStatusChanged doesn't get called, so checking here in start function if player is already logged in to start loading.
+        // This is done in start because ModelView wasn't loaded yet during the Awake function. 
+        private void Start() 
+        {
+            ServerManager manager = ServerManager.Instance;
+            if (manager.isLoggedIn)
+            {
+                StartLoading(manager.isLoggedIn);
+            }
         }
 
 

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
@@ -42,8 +42,8 @@ namespace MenuUi.Scripts.CharacterGallery
         private IEnumerator Load()
         {
             Debug.Log("Start");
-            yield return new WaitUntil(() => _view.IsReady);
             _view.Reset();
+            yield return new WaitUntil(() => _view.IsReady);
             var gameConfig = GameConfig.Get();
             var playerSettings = gameConfig.PlayerSettings;
             var playerGuid = playerSettings.PlayerGuid;

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
@@ -7,10 +7,6 @@ using Altzone.Scripts.Model.Poco.Game;
 using Altzone.Scripts.Model.Poco.Player;
 using UnityEngine;
 
-//TODO: muokkaa HandleCurrentCharacterIdChanged metodia ottamaan parametrinä sisään sen paikan id johon
-// hahmo juuri laitettiin ja sitten sen perusteella tarkistaa ja tallentaa tieto.
-// Myöskin pitäisi olla mahdollista poistaa valittu hahmo listasta
-// niin kauan kunhan ainakin yksi hahmo on vielä listassa.
 
 namespace MenuUi.Scripts.CharacterGallery
 {
@@ -20,10 +16,28 @@ namespace MenuUi.Scripts.CharacterGallery
 
         private PlayerData _playerData;
 
-        private void Start()
+
+        private void Awake()
         {
-            StartCoroutine(Load());
+            ServerManager.OnLogInStatusChanged += StartLoading;
+
         }
+
+
+        private void OnDestroy()
+        {
+            ServerManager.OnLogInStatusChanged -= StartLoading;
+        }
+
+
+        private void StartLoading(bool isLoggedIn)
+        {
+            if (isLoggedIn)
+            {
+                StartCoroutine(Load());
+            }
+        }
+
 
         private IEnumerator Load()
         {
@@ -45,6 +59,8 @@ namespace MenuUi.Scripts.CharacterGallery
                 _view.SetCharacters(characters, currentCharacterId);
             });
         }
+
+
         private void HandleCurrentCharacterIdChanged(CharacterID newCharacterId, int slot)
         {
             if (slot < 0 || slot >= 3) return;

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
@@ -51,6 +51,7 @@ namespace MenuUi.Scripts.CharacterGallery
             store.GetPlayerData(playerGuid, playerData =>
             {
                 _playerData = playerData;
+                _view.OnCurrentCharacterIdChanged -= HandleCurrentCharacterIdChanged;
                 _view.OnCurrentCharacterIdChanged += HandleCurrentCharacterIdChanged;
                 var currentCharacterId = playerData.SelectedCharacterIds;
                 var characters = playerData.CustomCharacters.ToList();

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelView.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelView.cs
@@ -17,6 +17,10 @@ namespace MenuUi.Scripts.CharacterGallery
         [SerializeField] private GameObject _characterSlotprefab;
         [SerializeField] private GalleryCharacterReference _referenceSheet;
 
+        [SerializeField] private GameObject _selectedCharacterSlotText1;
+        [SerializeField] private GameObject _selectedCharacterSlotText2;
+        [SerializeField] private GameObject _selectedCharacterSlotText3;
+
         [SerializeField] private bool _isReady;
 
         // character buttons
@@ -72,6 +76,14 @@ namespace MenuUi.Scripts.CharacterGallery
 
         public void Reset()
         {
+            foreach (var slot in _CurSelectedCharacterSlots)
+            {
+                var topSlotCharacter = slot.transform.GetComponentInChildren<DraggableCharacter>();
+                if (topSlotCharacter != null)
+                {
+                    Destroy(topSlotCharacter.gameObject);
+                }
+            }
             foreach (var button in _characterButtons)
             {
                 if (!button.transform.IsChildOf(HorizontalContentPanel))
@@ -85,6 +97,7 @@ namespace MenuUi.Scripts.CharacterGallery
             }
             _characterButtons.Clear();
             _characterSlots.Clear();
+            CheckSelectedCharacterSlotTexts();
         }
 
 
@@ -118,6 +131,37 @@ namespace MenuUi.Scripts.CharacterGallery
                 VerticalContentPanel.transform;
 
             return content;
+        }
+
+
+        public void CheckSelectedCharacterSlotTexts()
+        {
+            if (_CurSelectedCharacterSlots[2].transform.childCount > 0)
+            {
+                _selectedCharacterSlotText3.SetActive(false);
+            }
+            else
+            {
+                _selectedCharacterSlotText3.SetActive(true);
+            }
+
+            if (_CurSelectedCharacterSlots[1].transform.childCount > 0)
+            {
+                _selectedCharacterSlotText2.SetActive(false);
+            }
+            else
+            {
+                _selectedCharacterSlotText2.SetActive(true);
+            }
+
+            if (_CurSelectedCharacterSlots[0].transform.childCount > 0)
+            {
+                _selectedCharacterSlotText1.SetActive(false);
+            }
+            else
+            {
+                _selectedCharacterSlotText1.SetActive(true);
+            }
         }
 
 
@@ -190,6 +234,8 @@ namespace MenuUi.Scripts.CharacterGallery
                             }
                             i++;
                         }
+
+                        CheckSelectedCharacterSlotTexts();
                     };
 
                     // subscribing to removed from top slot event
@@ -216,6 +262,8 @@ namespace MenuUi.Scripts.CharacterGallery
                     }
                 }
             }
+
+            CheckSelectedCharacterSlotTexts();
         }
 
 
@@ -251,6 +299,8 @@ namespace MenuUi.Scripts.CharacterGallery
                     CurrentCharacterId = CharacterID.None;
                 }
             }
+
+            CheckSelectedCharacterSlotTexts();
         }
     }
 }

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelView.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelView.cs
@@ -56,7 +56,6 @@ namespace MenuUi.Scripts.CharacterGallery
         private void Awake()
         {
             _CurSelectedCharacterSlots = HorizontalContentPanel.GetComponentsInChildren<CharacterSlot>();
-            LoadAndCachePrefabs();
         }
 
 
@@ -76,6 +75,8 @@ namespace MenuUi.Scripts.CharacterGallery
 
         public void Reset()
         {
+            _isReady = false;
+
             foreach (var slot in _CurSelectedCharacterSlots)
             {
                 var topSlotCharacter = slot.transform.GetComponentInChildren<DraggableCharacter>();
@@ -97,6 +98,7 @@ namespace MenuUi.Scripts.CharacterGallery
             }
             _characterButtons.Clear();
             _characterSlots.Clear();
+            LoadAndCachePrefabs();
             CheckSelectedCharacterSlotTexts();
         }
 


### PR DESCRIPTION
Solved a bug with gallery characters not refreshing on login. (It doesn't work currently as expected because of another bug in which the selected characters don't get saved to the server but PlayerPrefs. It should work after that bug is fixed.)

- Connected OnLogInStatusChanged event to ModelController.cs to start Load coroutine when logged in.
- Moved checking for selected character slot text visibility to ModelView instead of DraggableCharacter since that is a better place for it and solved some null reference bugs since I could set the text objects in SerializeField.
- In the commit "Moved checking for selected character slot text visibility to ModelView instead of DraggableCharacter" the three selected top slot characters get destroyed in the Reset function. I forgot to add it to the commit description.
- In the Load function ensured that OnCurrentCharacterIdChanged event has only one connection to HandleCurrentCharacterIdChanged function.
- Moved calling LoadAndCachePrefabs function from Awake to the Reset function. It solved a bug with placeholder texts not appearing when logging on to another account.