### PR TITLE
The swipe blocker should now block correctly and redirect the data as needed

### DIFF
--- a/Assets/MenuUi/Scripts/SwipeNavigation/SwipeBlocker.cs
+++ b/Assets/MenuUi/Scripts/SwipeNavigation/SwipeBlocker.cs
@@ -5,30 +5,56 @@ using UnityEngine.EventSystems;
 
 namespace MenuUi.Scripts.SwipeNavigation
 {
-    public class SwipeBlocker : MonoBehaviour, IBeginDragHandler
+    public class SwipeBlocker : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
     {
         [SerializeField]
         private SwipeBlockType _blockType = SwipeBlockType.All;
         [SerializeField]
         private SwipeUI _swipe;
 
+        public BaseScrollRect parentScrollRect;
+
         // Start is called before the first frame update
         void Start()
         {
             if (_swipe == null)
                 _swipe = FindObjectOfType<SwipeUI>(true);
+            CacheParentContainerComponents();
         }
 
-        // Update is called once per frame
-        void Update()
+        private void OnEnable()
         {
-
+            CacheParentContainerComponents();
         }
 
-        public void OnBeginDrag(PointerEventData eventData)
+        private T GetComponentOnlyInParents<T>()
+        {
+            if (transform.parent != null)
+                return transform.parent.GetComponentInParent<T>();
+
+            return default(T);
+        }
+
+        private void CacheParentContainerComponents()
+        {
+            if(parentScrollRect == null) parentScrollRect = GetComponentOnlyInParents<BaseScrollRect>();
+        }
+
+        public virtual void OnBeginDrag(PointerEventData eventData)
         {
             if (_swipe != null)
                 _swipe.DragWithBlock(eventData, _blockType);
+            parentScrollRect.OnBeginDrag(eventData);
+        }
+
+        public virtual void OnDrag(PointerEventData eventData)
+        {
+            parentScrollRect.OnDrag(eventData);
+        }
+
+        public virtual void OnEndDrag(PointerEventData eventData)
+        {
+            parentScrollRect.OnEndDrag(eventData);
         }
     }
 }

--- a/Assets/MenuUi/Scripts/SwipeNavigation/SwipeBlocker.cs
+++ b/Assets/MenuUi/Scripts/SwipeNavigation/SwipeBlocker.cs
@@ -12,7 +12,9 @@ namespace MenuUi.Scripts.SwipeNavigation
         [SerializeField]
         private SwipeUI _swipe;
 
-        public BaseScrollRect parentScrollRect;
+        private IBeginDragHandler parentBeginDragHandler;
+        private IDragHandler parentDragHandler;
+        private IEndDragHandler parentEndDragHandler;
 
         // Start is called before the first frame update
         void Start()
@@ -37,24 +39,26 @@ namespace MenuUi.Scripts.SwipeNavigation
 
         private void CacheParentContainerComponents()
         {
-            if(parentScrollRect == null) parentScrollRect = GetComponentOnlyInParents<BaseScrollRect>();
+            parentBeginDragHandler = GetComponentOnlyInParents<IBeginDragHandler>();
+            parentDragHandler = GetComponentOnlyInParents<IDragHandler>();
+            parentEndDragHandler = GetComponentOnlyInParents<IEndDragHandler>();
         }
 
         public virtual void OnBeginDrag(PointerEventData eventData)
         {
             if (_swipe != null)
                 _swipe.DragWithBlock(eventData, _blockType);
-            parentScrollRect.OnBeginDrag(eventData);
+            parentBeginDragHandler.OnBeginDrag(eventData);
         }
 
         public virtual void OnDrag(PointerEventData eventData)
         {
-            parentScrollRect.OnDrag(eventData);
+            parentDragHandler.OnDrag(eventData);
         }
 
         public virtual void OnEndDrag(PointerEventData eventData)
         {
-            parentScrollRect.OnEndDrag(eventData);
+            parentEndDragHandler.OnEndDrag(eventData);
         }
     }
 }


### PR DESCRIPTION
The script will now search for the closest parent scrollrect and redirect the data towards it after blocking the SwipeUi from dragging. 
Swipe Blocker now also implements IDragHandler to make sure that OnBeginDrag works correctly.