### PR TITLE
Fixed clan heart color options to the right ones

### DIFF
--- a/Assets/MenuUi/Prefabs/Clan/CreateClan.prefab
+++ b/Assets/MenuUi/Prefabs/Clan/CreateClan.prefab
@@ -155,8 +155,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 632037597464505604}
   m_HandleRect: {fileID: 2717955754889810534}
   m_Direction: 2
-  m_Value: 1
-  m_Size: 0.9999859
+  m_Value: 0
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -397,6 +397,7 @@ GameObject:
   - component: {fileID: 4028352829616069883}
   - component: {fileID: 420932267491801807}
   - component: {fileID: 8697967325882986921}
+  - component: {fileID: 457319987012840024}
   m_Layer: 5
   m_Name: ColorOptions
   m_TagString: Untagged
@@ -459,6 +460,26 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &457319987012840024
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 492444408590621915}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 797bec71e4331474ab02f60730cd9927, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _colorButtons:
+  - {fileID: 4531398344010072679}
+  - {fileID: 6806759757416082643}
+  - {fileID: 5641411764991220000}
+  - {fileID: 6524731191806277414}
+  - {fileID: 472404936799050675}
+  - {fileID: 2168665064770011487}
+  - {fileID: 1089724477277751740}
 --- !u!1 &575847320488491555
 GameObject:
   m_ObjectHideFlags: 0
@@ -843,22 +864,20 @@ MonoBehaviour:
   _flagImage: {fileID: 7556415235480913640}
   _heartColorSetter: {fileID: 5791314762589661920}
   _colorButtons:
-  - button: {fileID: 2567383014906607533}
-    color: {r: 0.9686275, g: 0.454902, b: 0.76470596, a: 1}
   - button: {fileID: 3574150038676793963}
-    color: {r: 0.95294124, g: 0, b: 0, a: 1}
+    color: 0
   - button: {fileID: 386930062853223373}
-    color: {r: 0.9607844, g: 0.59607846, b: 0.003921569, a: 1}
+    color: 1
   - button: {fileID: 8091561114240667264}
-    color: {r: 0.9960785, g: 0.9960785, b: 0, a: 1}
+    color: 2
   - button: {fileID: 7909771216819333159}
-    color: {r: 0.14509805, g: 0.5058824, b: 0, a: 1}
+    color: 3
   - button: {fileID: 9090602550945519474}
-    color: {r: 0.27450982, g: 0.81568635, b: 0.8352942, a: 1}
+    color: 4
   - button: {fileID: 7490295930406875007}
-    color: {r: 0.08627451, g: 0.039215688, b: 0.8470589, a: 1}
+    color: 5
   - button: {fileID: 899771890150643822}
-    color: {r: 0.3019608, g: 0.027450982, b: 0.5019608, a: 1}
+    color: 6
   _nameWarningOutline: {fileID: 4394549059287662978}
   _passwordWarningOutline: {fileID: 5734001436455827807}
   _goalWarningOutline: {fileID: 8256111806386788650}
@@ -1038,7 +1057,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 45.15
+  m_fontSize: 29.95
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1295,7 +1314,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 62.15
+  m_fontSize: 41.2
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1565,7 +1584,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 50.15
+  m_fontSize: 33.25
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1876,7 +1895,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3466377242122676023
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1891,10 +1910,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7759068013307880218}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 116.89081, y: -43.14261}
+  m_SizeDelta: {x: 233.78162, y: 86.28522}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2808912524739383366
 CanvasRenderer:
@@ -2073,7 +2092,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 51.95
+  m_fontSize: 43.05
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -2518,7 +2537,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 72
+  m_fontSize: 53.2
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -2923,7 +2942,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 117.71362}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4662908405234522294
 CanvasRenderer:
@@ -3155,7 +3174,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -10, y: -278.3082}
+  m_AnchoredPosition: {x: -10, y: -184.57742}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &361381024245426928
@@ -3821,7 +3840,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 117.71362}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7842838227791008947
 CanvasRenderer:
@@ -4533,7 +4552,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 117.71362}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3001763986196794019
 CanvasRenderer:
@@ -5648,7 +5667,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 60.6
+  m_fontSize: 40.15
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -5703,6 +5722,7 @@ GameObject:
   - component: {fileID: 7759068013307880218}
   - component: {fileID: 3929448287996381204}
   - component: {fileID: 2276737035115032479}
+  - component: {fileID: 2658136964479141582}
   m_Layer: 5
   m_Name: Colors 1-4
   m_TagString: Untagged
@@ -5758,15 +5778,32 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 0
+  m_ChildAlignment: 3
   m_Spacing: 8
   m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
+  m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 1
-  m_ChildControlHeight: 1
+  m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &2658136964479141582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8524788342168156148}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 711e8ecaf27f10949b6340cc0bfcef6a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _referenceButton: {fileID: 6524731191806277414}
+  _colorButtons:
+  - {fileID: 4531398344010072679}
+  - {fileID: 6806759757416082643}
+  - {fileID: 5641411764991220000}
 --- !u!1 &8547530150921208277
 GameObject:
   m_ObjectHideFlags: 0
@@ -5975,7 +6012,7 @@ PrefabInstance:
     - target: {fileID: 4279458544638658286, guid: 6f690bb33c1bdce469a64adeaf8614db,
         type: 3}
       propertyPath: m_fontSize
-      value: 72
+      value: 54.8
       objectReference: {fileID: 0}
     - target: {fileID: 6563582005748136573, guid: 6f690bb33c1bdce469a64adeaf8614db,
         type: 3}
@@ -6216,7 +6253,7 @@ PrefabInstance:
     - target: {fileID: 5029625442628242303, guid: 1973ba674bd1e39488f5ad71181caf28,
         type: 3}
       propertyPath: m_fontSize
-      value: 57.55
+      value: 38.15
       objectReference: {fileID: 0}
     - target: {fileID: 5051431190338678266, guid: 1973ba674bd1e39488f5ad71181caf28,
         type: 3}

--- a/Assets/MenuUi/Prefabs/Clan/Heart/ClanHeartEditPanel.prefab
+++ b/Assets/MenuUi/Prefabs/Clan/Heart/ClanHeartEditPanel.prefab
@@ -258,22 +258,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _heartContainer: {fileID: 1148810789066716244}
   _colorButtons:
-  - button: {fileID: 6418387599964196504}
-    color: {r: 0.9686275, g: 0.454902, b: 0.76470596, a: 1}
   - button: {fileID: 518535192141787202}
-    color: {r: 0.95294124, g: 0, b: 0, a: 1}
+    color: 0
   - button: {fileID: 8733220824190269733}
-    color: {r: 0.96470594, g: 0.59607846, b: 0, a: 1}
+    color: 1
   - button: {fileID: 4238371461247461599}
-    color: {r: 0.9960785, g: 0.9960785, b: 0, a: 1}
+    color: 2
   - button: {fileID: 2077768867980622149}
-    color: {r: 0.14509805, g: 0.5058824, b: 0, a: 1}
+    color: 3
   - button: {fileID: 5859914769697188954}
-    color: {r: 0.27450982, g: 0.81568635, b: 0.8352942, a: 1}
+    color: 4
   - button: {fileID: 835425913494413715}
-    color: {r: 0.08627451, g: 0.039215688, b: 0.8470589, a: 1}
+    color: 5
   - button: {fileID: 260803920116042979}
-    color: {r: 0.3019608, g: 0.027450982, b: 0.5019608, a: 1}
+    color: 6
 --- !u!1 &1220556308626658758
 GameObject:
   m_ObjectHideFlags: 0
@@ -292,7 +290,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6868141092679955485
 RectTransform:
   m_ObjectHideFlags: 0
@@ -307,10 +305,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3407606614961760565}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 159, y: -73.93776}
+  m_SizeDelta: {x: 318, y: 147.87552}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4817370373784072876
 CanvasRenderer:
@@ -430,7 +428,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 318, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6866394130909693307
 CanvasRenderer:
@@ -682,7 +680,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 318, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4000462200065128281
 CanvasRenderer:
@@ -1042,7 +1040,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 318, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7662257366092878336
 CanvasRenderer:
@@ -1389,6 +1387,7 @@ GameObject:
   - component: {fileID: 3407606614961760565}
   - component: {fileID: 2647972606080491441}
   - component: {fileID: 4454856749236099730}
+  - component: {fileID: 3740896679096642425}
   m_Layer: 5
   m_Name: Colors 1-4
   m_TagString: Untagged
@@ -1444,15 +1443,32 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 0
+  m_ChildAlignment: 1
   m_Spacing: 8
-  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 1
+  m_ChildControlWidth: 0
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &3740896679096642425
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7955101814313242993}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 711e8ecaf27f10949b6340cc0bfcef6a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _referenceButton: {fileID: 6223417360220841709}
+  _colorButtons:
+  - {fileID: 2702899288848828926}
+  - {fileID: 5779501710277301179}
+  - {fileID: 3593509728377469838}
 --- !u!1 &8072617170334792158
 GameObject:
   m_ObjectHideFlags: 0
@@ -1464,6 +1480,7 @@ GameObject:
   - component: {fileID: 7871944522755080579}
   - component: {fileID: 5131985564894814302}
   - component: {fileID: 5820826121286435590}
+  - component: {fileID: 437082884797913951}
   m_Layer: 5
   m_Name: ColorOptions
   m_TagString: Untagged
@@ -1526,6 +1543,26 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &437082884797913951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8072617170334792158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 797bec71e4331474ab02f60730cd9927, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _colorButtons:
+  - {fileID: 2702899288848828926}
+  - {fileID: 5779501710277301179}
+  - {fileID: 3593509728377469838}
+  - {fileID: 6223417360220841709}
+  - {fileID: 4876049587587301623}
+  - {fileID: 4379180847233101789}
+  - {fileID: 431756345095887627}
 --- !u!1001 &2604047927892676868
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1747,6 +1784,11 @@ PrefabInstance:
     - target: {fileID: 3157597938240693584, guid: 71a38dbc9d18bd44f9de8793036dbead,
         type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3157597938240693584, guid: 71a38dbc9d18bd44f9de8793036dbead,
+        type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3157597938240693584, guid: 71a38dbc9d18bd44f9de8793036dbead,

--- a/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
+++ b/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
@@ -80,10 +80,10 @@ public class ClanCreateNew : MonoBehaviour
         _languageSelection.Initialize(Language.None);
         _closeLanguageSelect.onClick.AddListener(() => _flagImage.SetFlag(_languageSelection.SelectedLanguage));
 
-        SetHeartColor(_colorButtons[0].color);
+        SetHeartColor(ColorConstants.GetColorConstant(_colorButtons[0].color));
         foreach (ColorButton colorButton in _colorButtons)
         {
-            Color color = colorButton.color;
+            Color color = ColorConstants.GetColorConstant(colorButton.color);
             colorButton.button.onClick.AddListener(() => SetHeartColor(color));
         }
     }

--- a/Assets/MenuUi/Scripts/Clan/ClanHeartColorButton.cs
+++ b/Assets/MenuUi/Scripts/Clan/ClanHeartColorButton.cs
@@ -7,5 +7,5 @@ using UnityEngine.UI;
 public struct ColorButton
 {
     public Button button;
-    public Color color;
+    public ColorType color;
 }

--- a/Assets/MenuUi/Scripts/Clan/ClanHeartColorChanger.cs
+++ b/Assets/MenuUi/Scripts/Clan/ClanHeartColorChanger.cs
@@ -44,10 +44,10 @@ public class ClanHeartColorChanger : MonoBehaviour
             }
         }
 
-        _selectedColor = _colorButtons[0].color;
+        _selectedColor = ColorConstants.GetColorConstant(_colorButtons[0].color);
         foreach (ColorButton colorButton in _colorButtons)
         {
-            Color color = colorButton.color;
+            Color color = ColorConstants.GetColorConstant(colorButton.color);
             colorButton.button.onClick.RemoveAllListeners();
             colorButton.button.onClick.AddListener(() => SetSelectedColor(color));
         }

--- a/Assets/MenuUi/Scripts/Clan/ClanHeartColorOptionsInitialization.cs
+++ b/Assets/MenuUi/Scripts/Clan/ClanHeartColorOptionsInitialization.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ClanHeartColorOptionsInitialization : MonoBehaviour
+{
+    [SerializeField] private GameObject[] _colorButtons;
+
+    private Image _buttonImage;
+    private int _index = 0;
+
+    private void Start()
+    {
+        foreach (var colorButton in _colorButtons)
+        {
+            _buttonImage = colorButton.GetComponent<Image>();
+
+            switch (_index)
+            {
+                case 0:
+                    _buttonImage.color = ColorConstants.GetColorConstant(ColorType.Red);
+                    break;
+                case 1:
+                    _buttonImage.color = ColorConstants.GetColorConstant(ColorType.Orange);
+                    break;
+                case 2:
+                    _buttonImage.color = ColorConstants.GetColorConstant(ColorType.Yellow);
+                    break;
+                case 3:
+                    _buttonImage.color = ColorConstants.GetColorConstant(ColorType.Green);
+                    break;
+                case 4:
+                    _buttonImage.color = ColorConstants.GetColorConstant(ColorType.Turquoise);
+                    break;
+                case 5:
+                    _buttonImage.color = ColorConstants.GetColorConstant(ColorType.Indigo);
+                    break;
+                case 6:
+                    _buttonImage.color = ColorConstants.GetColorConstant(ColorType.Violet);
+                    break;
+                default:
+                    _buttonImage.color = Color.white;
+                    break;
+            }
+            
+            _index++;
+        }
+    }
+}

--- a/Assets/MenuUi/Scripts/Clan/ClanHeartColorOptionsInitialization.cs.meta
+++ b/Assets/MenuUi/Scripts/Clan/ClanHeartColorOptionsInitialization.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 797bec71e4331474ab02f60730cd9927
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Scripts/Clan/ColorConstants.cs
+++ b/Assets/MenuUi/Scripts/Clan/ColorConstants.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum ColorType
+{
+    Red,
+    Orange,
+    Yellow,
+    Green,
+    Turquoise,
+    Indigo,
+    Violet
+}
+
+public class ColorConstants
+{
+    public const string Red = "#FF0000";
+    public const string Orange = "#FF8E00";
+    public const string Yellow = "#FFFF00";
+    public const string Green = "#008E00";
+    public const string Turquoise = "#00C0C0";
+    public const string Indigo = "#400098";
+    public const string Violet = "#8E008E";
+
+    public static Color GetColorConstant(ColorType color)
+    {
+
+        Color myColor;
+
+        switch (color)
+        {
+            case ColorType.Red:
+                ColorUtility.TryParseHtmlString(Red, out myColor);
+                return myColor;
+            case ColorType.Orange:
+                ColorUtility.TryParseHtmlString(Orange, out myColor);
+                return myColor;
+            case ColorType.Yellow:
+                ColorUtility.TryParseHtmlString(Yellow, out myColor);
+                return myColor;
+            case ColorType.Green:
+                ColorUtility.TryParseHtmlString(Green, out myColor);
+                return myColor;
+            case ColorType.Turquoise:
+                ColorUtility.TryParseHtmlString(Turquoise, out myColor);
+                return myColor;
+            case ColorType.Indigo:
+                ColorUtility.TryParseHtmlString(Indigo, out myColor);
+                return myColor;
+            case ColorType.Violet:
+                ColorUtility.TryParseHtmlString(Violet, out myColor);
+                return myColor;
+            default:
+                return Color.white;
+        }
+    }
+}

--- a/Assets/MenuUi/Scripts/Clan/ColorConstants.cs.meta
+++ b/Assets/MenuUi/Scripts/Clan/ColorConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dfb5d0f0073e59543ab9b29041c0b75a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Scripts/Clan/SetColorOptionsButtonSizes.cs
+++ b/Assets/MenuUi/Scripts/Clan/SetColorOptionsButtonSizes.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SetColorOptionsButtonSizes : MonoBehaviour
+{
+    [SerializeField] private GameObject _referenceButton;
+    [SerializeField] private GameObject[] _colorButtons;
+
+    private void Start()
+    {
+        SetButtonSizes();
+    }
+
+    private void Update()
+    {
+#if UNITY_EDITOR
+        SetButtonSizes();
+#endif
+    }
+
+    private void SetButtonSizes()
+    {
+        Vector2 referenceSizeDelta = _referenceButton.GetComponent<RectTransform>().sizeDelta;
+
+        foreach (var button in _colorButtons)
+        {
+            button.GetComponent<RectTransform>().sizeDelta = referenceSizeDelta;
+        }
+    }
+}

--- a/Assets/MenuUi/Scripts/Clan/SetColorOptionsButtonSizes.cs.meta
+++ b/Assets/MenuUi/Scripts/Clan/SetColorOptionsButtonSizes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 711e8ecaf27f10949b6340cc0bfcef6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Created a ColorConstants-script with the right colors.
- Changed the ClanHeartColorChanger- and ClanCreateNew-scripts to work with the ColorConstants.
- Created ClanHearColorOptionsInitialization-script to set the colors for the buttons.
- Disabled the unnecessary color option button.
- Created a SetColorOptionSizes-script to adjust first row/column button sizes to match the second row/column.