### PR TITLE
Battle/fix - runtime player character data

### DIFF
--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -479,12 +479,11 @@ namespace Altzone.Scripts.Lobby
 
         public void SetPlayerQuantumCharacters(List<CustomCharacter> characters)
         {
-            BattleCharacterBase[] list = new BattleCharacterBase[RuntimePlayer.BattleCharacterArraySize];
-            for (int i = 0; i < list.Length; i++) {
+            for (int i = 0; i < _player._characters.Length; i++) {
                 if (i < characters.Count)
                 {
                   CustomCharacter character = characters[i];
-                    list[i] = new BattleCharacterBase(
+                    _player._characters[i] = new BattleCharacterBase(
                     (int)character.Id,
                     (int)character.CharacterClassID,
                     BaseCharacter.GetStatValueFP(StatType.Hp, character.Hp),
@@ -495,7 +494,6 @@ namespace Altzone.Scripts.Lobby
                     );
                 }
             }
-            _player._characters = list;
         }
 
         public void OnDisconnected(DisconnectCause cause)

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -479,10 +479,12 @@ namespace Altzone.Scripts.Lobby
 
         public void SetPlayerQuantumCharacters(List<CustomCharacter> characters)
         {
-            List<BattleCharacterBase> list = new();
-            foreach(CustomCharacter character in characters)
-            {
-                list.Add(new(
+            BattleCharacterBase[] list = new BattleCharacterBase[RuntimePlayer.BattleCharacterArraySize];
+            for (int i = 0; i < list.Length; i++) {
+                if (i < characters.Count)
+                {
+                  CustomCharacter character = characters[i];
+                    list[i] = new BattleCharacterBase(
                     (int)character.Id,
                     (int)character.CharacterClassID,
                     BaseCharacter.GetStatValueFP(StatType.Hp, character.Hp),
@@ -490,7 +492,8 @@ namespace Altzone.Scripts.Lobby
                     BaseCharacter.GetStatValueFP(StatType.Defence, character.Defence),
                     BaseCharacter.GetStatValueFP(StatType.Resistance, character.Resistance),
                     BaseCharacter.GetStatValueFP(StatType.Speed, character.Speed)
-                ));
+                    );
+                }
             }
             _player._characters = list;
         }

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -417,7 +417,7 @@ namespace Altzone.Scripts.Lobby
             yield return new WaitUntil(() => task.IsCompleted);
             if(task.Result)
             {
-                _player.playerPos = playerPosition;
+                _player.PlayerPosition = playerPosition;
                 _runner?.Game.AddPlayer(_player);
             }
             else
@@ -479,20 +479,25 @@ namespace Altzone.Scripts.Lobby
 
         public void SetPlayerQuantumCharacters(List<CustomCharacter> characters)
         {
-            for (int i = 0; i < _player._characters.Length; i++) {
-                if (i < characters.Count)
+            Assert.IsTrue(
+                characters.Count == RuntimePlayer.CharacterCount,
+                string.Format("Invalid number of Characters (not {0})", RuntimePlayer.CharacterCount)
+            );
+
+            CustomCharacter character;
+            for (int i = 0; i < RuntimePlayer.CharacterCount; i++) {
+                character = characters[i];
+                _player.Characters[i] = new BattleCharacterBase()
                 {
-                  CustomCharacter character = characters[i];
-                    _player._characters[i] = new BattleCharacterBase() {
-                    _id = (int)character.Id,
-                    _characterClassID = (int)character.CharacterClassID,
-                    _hp = BaseCharacter.GetStatValueFP(StatType.Hp, character.Hp),
-                    _attack = BaseCharacter.GetStatValueFP(StatType.Attack, character.Attack),
-                    _defence = BaseCharacter.GetStatValueFP(StatType.Defence, character.Defence),
-                    _resistance = BaseCharacter.GetStatValueFP(StatType.Resistance, character.Resistance),
-                    _speed = BaseCharacter.GetStatValueFP(StatType.Speed, character.Speed)
-                    };
-                }
+                    Id         = (int)character.Id,
+                    ClassID    = (int)character.CharacterClassID,
+
+                    Hp         = BaseCharacter.GetStatValueFP(StatType.Hp, character.Hp),
+                    Attack     = BaseCharacter.GetStatValueFP(StatType.Attack, character.Attack),
+                    Defence    = BaseCharacter.GetStatValueFP(StatType.Defence, character.Defence),
+                    Resistance = BaseCharacter.GetStatValueFP(StatType.Resistance, character.Resistance),
+                    Speed      = BaseCharacter.GetStatValueFP(StatType.Speed, character.Speed)
+                };
             }
         }
 

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -483,15 +483,15 @@ namespace Altzone.Scripts.Lobby
                 if (i < characters.Count)
                 {
                   CustomCharacter character = characters[i];
-                    _player._characters[i] = new BattleCharacterBase(
-                    (int)character.Id,
-                    (int)character.CharacterClassID,
-                    BaseCharacter.GetStatValueFP(StatType.Hp, character.Hp),
-                    BaseCharacter.GetStatValueFP(StatType.Attack, character.Attack),
-                    BaseCharacter.GetStatValueFP(StatType.Defence, character.Defence),
-                    BaseCharacter.GetStatValueFP(StatType.Resistance, character.Resistance),
-                    BaseCharacter.GetStatValueFP(StatType.Speed, character.Speed)
-                    );
+                    _player._characters[i] = new BattleCharacterBase() {
+                    _id = (int)character.Id,
+                    _characterClassID = (int)character.CharacterClassID,
+                    _hp = BaseCharacter.GetStatValueFP(StatType.Hp, character.Hp),
+                    _attack = BaseCharacter.GetStatValueFP(StatType.Attack, character.Attack),
+                    _defence = BaseCharacter.GetStatValueFP(StatType.Defence, character.Defence),
+                    _resistance = BaseCharacter.GetStatValueFP(StatType.Resistance, character.Resistance),
+                    _speed = BaseCharacter.GetStatValueFP(StatType.Speed, character.Speed)
+                    };
                 }
             }
         }

--- a/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
+++ b/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
@@ -14,24 +14,5 @@ namespace Quantum
         public FP _resistance;
         public FP _attack;
         public FP _defence;
-
-       /* public int Id { get => _id; }
-        public int CharacterClassID { get => _characterClassID; }
-        public FP Hp { get => _hp; }
-        public FP Speed { get => _speed; }
-        public FP Resistance { get => _resistance; }
-        public FP Attack { get => _attack; }
-        public FP Defence { get => _defence; }*/
-
-        public BattleCharacterBase(int id, int classId, FP hp, FP attack, FP defence, FP resistance, FP speed)
-        {
-            _id = id;
-            _characterClassID = classId;
-            _hp = hp;
-            _attack = attack;
-            _defence = defence;
-            _resistance = resistance;
-            _speed = speed;
-        }
     }
 }

--- a/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
+++ b/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
@@ -1,28 +1,27 @@
-using System.Collections;
-using System.Collections.Generic;
+using System;
 using Photon.Deterministic;
-using UnityEngine;
 
 namespace Quantum
 {
+    [Serializable]
     public struct BattleCharacterBase
     {
-        private int _id;
-        private int _characterClassID;
+        public int _id;
+        public int _characterClassID;
 
-        private FP _hp;
-        private FP _speed;
-        private FP _resistance;
-        private FP _attack;
-        private FP _defence;
+        public FP _hp;
+        public FP _speed;
+        public FP _resistance;
+        public FP _attack;
+        public FP _defence;
 
-        public int Id { get => _id; }
+       /* public int Id { get => _id; }
         public int CharacterClassID { get => _characterClassID; }
         public FP Hp { get => _hp; }
         public FP Speed { get => _speed; }
         public FP Resistance { get => _resistance; }
         public FP Attack { get => _attack; }
-        public FP Defence { get => _defence; }
+        public FP Defence { get => _defence; }*/
 
         public BattleCharacterBase(int id, int classId, FP hp, FP attack, FP defence, FP resistance, FP speed)
         {

--- a/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
+++ b/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
@@ -6,13 +6,13 @@ namespace Quantum
     [Serializable]
     public struct BattleCharacterBase
     {
-        public int _id;
-        public int _characterClassID;
+        public int Id;
+        public int ClassID;
 
-        public FP _hp;
-        public FP _speed;
-        public FP _resistance;
-        public FP _attack;
-        public FP _defence;
+        public FP Hp;
+        public FP Speed;
+        public FP Resistance;
+        public FP Attack;
+        public FP Defence;
     }
 }

--- a/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
+++ b/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace Quantum
 {
-    public class BattleCharacterBase
+    public struct BattleCharacterBase
     {
         private int _id;
         private int _characterClassID;

--- a/Assets/QuantumUser/Simulation/RuntimePlayer.User.cs
+++ b/Assets/QuantumUser/Simulation/RuntimePlayer.User.cs
@@ -4,8 +4,9 @@ namespace Quantum
 {
     public partial class RuntimePlayer
     {
-        public const int BattleCharacterArraySize = 3;
-        public BattleCharacterBase[] _characters = new BattleCharacterBase[BattleCharacterArraySize];
-        public int playerPos;
+        public const int CharacterCount = 3;
+
+        public int PlayerPosition;
+        public BattleCharacterBase[] Characters = new BattleCharacterBase[CharacterCount];
     }
 }

--- a/Assets/QuantumUser/Simulation/RuntimePlayer.User.cs
+++ b/Assets/QuantumUser/Simulation/RuntimePlayer.User.cs
@@ -4,7 +4,8 @@ namespace Quantum
 {
     public partial class RuntimePlayer
     {
-        public List<BattleCharacterBase> _characters;
+        public const int BattleCharacterArraySize = 3;
+        public BattleCharacterBase[] _characters = new BattleCharacterBase[BattleCharacterArraySize];
         public int playerPos;
     }
 }


### PR DESCRIPTION
Made BattleCharacterBase Serializable by using fixed size struct array, since Quantum doesn't like dynamic data types like lists.

CharacterCount constant was added to define the correct number of characters in Simulation.
Added a check to ensure that the correct number of characters(real or dummy) gets passed to Simulation.



