### PR TITLE
UI/daily task/feature/own task cancel repick&testing functionality

### DIFF
--- a/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskView.prefab
@@ -760,10 +760,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 6263373199715600180}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 8.8307, y: 15.6135}
-  m_SizeDelta: {x: 762.387, y: 400.4984}
+  m_AnchorMin: {x: 0.225, y: 0.425}
+  m_AnchorMax: {x: 0.775, y: 0.6}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4355725901775316698
 CanvasRenderer:
@@ -1598,7 +1598,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1579733717106750152}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1606,10 +1606,10 @@ RectTransform:
   - {fileID: 7382216144384611603}
   m_Father: {fileID: 6263373199715600180}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -170, y: -52}
-  m_SizeDelta: {x: 240.59, y: 100}
+  m_AnchorMin: {x: 0.235, y: 0.45}
+  m_AnchorMax: {x: 0.465, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1375593662685899581
 MonoBehaviour:
@@ -4116,10 +4116,10 @@ RectTransform:
   - {fileID: 8455352816295630078}
   m_Father: {fileID: 1599829439781971887}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 486, y: -1071.4292}
-  m_SizeDelta: {x: 972, y: 388.57166}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3744314934325758347
 GameObject:
@@ -4852,10 +4852,10 @@ RectTransform:
   - {fileID: 6680580770969020039}
   m_Father: {fileID: 1599829439781971887}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 486, y: -194.28583}
-  m_SizeDelta: {x: 972, y: 388.57166}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4447274651562961892
 GameObject:
@@ -6417,7 +6417,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5647521576900311731}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -6425,10 +6425,10 @@ RectTransform:
   - {fileID: 6322954312845969478}
   m_Father: {fileID: 6263373199715600180}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 170, y: -52}
-  m_SizeDelta: {x: 240.59, y: 100}
+  m_AnchorMin: {x: 0.535, y: 0.45}
+  m_AnchorMax: {x: 0.765, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7493811162226645346
 MonoBehaviour:
@@ -7317,10 +7317,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 6263373199715600180}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 177.2135}
-  m_SizeDelta: {x: 481.19, y: 46.0753}
+  m_AnchorMin: {x: 0.25, y: 0.515}
+  m_AnchorMax: {x: 0.75, y: 0.59}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8895934976037533919
 CanvasRenderer:
@@ -7378,10 +7378,10 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 40
+  m_fontSize: 72
   m_fontSizeBase: 40
   m_fontWeight: 400
-  m_enableAutoSizing: 0
+  m_enableAutoSizing: 1
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
@@ -7416,7 +7416,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: -62.79512, y: 0, z: -82.41853, w: -3.9247284}
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -8456,7 +8456,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &6263373199715600180
 RectTransform:
   m_ObjectHideFlags: 0
@@ -9259,7 +9259,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &108771750816015588
 RectTransform:
   m_ObjectHideFlags: 0
@@ -9276,7 +9276,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.0000076294, y: 110}
+  m_AnchoredPosition: {x: 0, y: 110}
   m_SizeDelta: {x: 481.19, y: 46.0753}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3728425684822542029
@@ -10265,10 +10265,10 @@ RectTransform:
   - {fileID: 1473214313960439479}
   m_Father: {fileID: 1599829439781971887}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 486, y: -632.8575}
-  m_SizeDelta: {x: 972, y: 388.57166}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8858500302479297864
 GameObject:

--- a/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskView.prefab
@@ -3061,6 +3061,139 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3049358092666029569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7332960961776778820}
+  - component: {fileID: 4542447384827279482}
+  - component: {fileID: 2736060357754866243}
+  - component: {fileID: 4898360262927565657}
+  m_Layer: 5
+  m_Name: TESTAddTaskProgressButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7332960961776778820
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3049358092666029569}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 715088798257131030}
+  m_Father: {fileID: 7807893844174565255}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.06, y: 0.59}
+  m_AnchorMax: {x: 0.29, y: 0.65}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4542447384827279482
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3049358092666029569}
+  m_CullTransparentMesh: 1
+--- !u!114 &2736060357754866243
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3049358092666029569}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4898360262927565657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3049358092666029569}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2736060357754866243}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 351654732571348405}
+        m_TargetAssemblyTypeName: DailyTaskManager, MainMenu
+        m_MethodName: TESTAddTaskProgress
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &3084190044325043130
 GameObject:
   m_ObjectHideFlags: 0
@@ -4642,6 +4775,143 @@ MonoBehaviour:
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4301751053394867501
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 715088798257131030}
+  - component: {fileID: 466742894373520335}
+  - component: {fileID: 7609110217500517590}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &715088798257131030
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4301751053394867501}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7332960961776778820}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.05, y: 0.05}
+  m_AnchorMax: {x: 0.95, y: 0.95}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &466742894373520335
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4301751053394867501}
+  m_CullTransparentMesh: 1
+--- !u!114 &7609110217500517590
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4301751053394867501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: TEST Add progress
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
+  m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 46.75
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
@@ -6701,6 +6971,7 @@ RectTransform:
   - {fileID: 4948425052580889643}
   - {fileID: 178853100958995881}
   - {fileID: 5078198386118618575}
+  - {fileID: 7332960961776778820}
   m_Father: {fileID: 7634772026811522219}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -8456,7 +8727,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6263373199715600180
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskView.prefab
@@ -4116,10 +4116,10 @@ RectTransform:
   - {fileID: 8455352816295630078}
   m_Father: {fileID: 1599829439781971887}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 486, y: -1071.4292}
+  m_SizeDelta: {x: 972, y: 388.57166}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3744314934325758347
 GameObject:
@@ -4852,10 +4852,10 @@ RectTransform:
   - {fileID: 6680580770969020039}
   m_Father: {fileID: 1599829439781971887}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 486, y: -194.28583}
+  m_SizeDelta: {x: 972, y: 388.57166}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4447274651562961892
 GameObject:
@@ -10265,10 +10265,10 @@ RectTransform:
   - {fileID: 1473214313960439479}
   m_Father: {fileID: 1599829439781971887}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 486, y: -632.8575}
+  m_SizeDelta: {x: 972, y: 388.57166}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8858500302479297864
 GameObject:

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyQuest.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyQuest.cs
@@ -28,9 +28,8 @@ public class DailyQuest : MonoBehaviour, IBeginDragHandler, IEndDragHandler
         if (!_clickEnabled)
             return;
 
-        PopupData data = new PopupData(_taskData, PopupData.GetType("own_task"));
-
-        StartCoroutine(dailyTaskManager.ShowPopupAndHandleResponse("Haluatko Hyväksyä! quest id: " + _taskData.Id.ToString(), 1, data));
+        PopupData data = new PopupData(_taskData);
+        StartCoroutine(dailyTaskManager.ShowPopupAndHandleResponse("Haluatko Hyväksyä! quest id: " + _taskData.Id, data));
     }
 
     public void PopulateData()

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyQuest.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyQuest.cs
@@ -28,8 +28,15 @@ public class DailyQuest : MonoBehaviour, IBeginDragHandler, IEndDragHandler
         if (!_clickEnabled)
             return;
 
+        string message;
+
+        if (dailyTaskManager.OwnTaskId == null)
+            message = "Haluatko hyväksyä tehtävän? \nquest id: ";
+        else
+            message = "Sinulla on jo valittu tehtävä.\n Haluatko hyväksyä tehtävän? \nquest id: ";
+
         PopupData data = new PopupData(_taskData);
-        StartCoroutine(dailyTaskManager.ShowPopupAndHandleResponse("Haluatko Hyväksyä! quest id: " + _taskData.Id, data));
+        StartCoroutine(dailyTaskManager.ShowPopupAndHandleResponse(message + _taskData.Id, data));
     }
 
     public void PopulateData()

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyQuest.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyQuest.cs
@@ -8,6 +8,7 @@ public class DailyQuest : MonoBehaviour, IBeginDragHandler, IEndDragHandler
 {
     //Variables
     private PlayerTasks.PlayerTask _taskData;
+    public PlayerTasks.PlayerTask TaskData {  get { return _taskData; } }
     private bool _clickEnabled = true;
     
     [Header("DailyQuest Texts")]

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyTaskManager.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyTaskManager.cs
@@ -34,6 +34,7 @@ public class DailyTaskManager : MonoBehaviour
     [SerializeField] private DailyTaskOwnTask _ownTaskPageHandler;
 
     private int? _ownTaskId;
+    public int? OwnTaskId { get { return _ownTaskId; } }
 
     [Header("ClanTaskPage")]
     [SerializeField] private GameObject _clanTaskView;
@@ -158,17 +159,22 @@ public class DailyTaskManager : MonoBehaviour
                 switch(data.Value.Type)
                 {
                     case PopupData.PopupDataType.OwnTask:
-                        PopupDataHandler(data.Value);
-                        SwitchTab(SelectedTab.OwnTask);
-                        _ownTaskTabButton.interactable = true;
-                        Debug.Log("Task accepted");
-                        break;
+                        {
+                            if (_ownTaskId != null)
+                                CancelTask();
+
+                            PopupDataHandler(data.Value);
+                            SwitchTab(SelectedTab.OwnTask);
+                            _ownTaskTabButton.interactable = true;
+                            break;
+                        }
                     case PopupData.PopupDataType.CancelTask:
-                        CancelTask();
-                        SwitchTab(SelectedTab.Tasks);
-                        _ownTaskTabButton.interactable = false;
-                        Debug.Log("Task canceled");
-                        break;
+                        {
+                            CancelTask();
+                            SwitchTab(SelectedTab.Tasks);
+                            _ownTaskTabButton.interactable = false;
+                            break;
+                        }
                 }
             }
             else
@@ -190,8 +196,10 @@ public class DailyTaskManager : MonoBehaviour
 
     private void HandleOwnTask(PopupData.OwnPageData data)
     {
+        //TODO: Add task accept code when server side has functionality.
         StartCoroutine(_ownTaskPageHandler.SetDailyTask(data.TaskDescription, data.TaskAmount, data.TaskPoints, data.TaskCoins));
         _ownTaskId = data.TaskId;
+        Debug.Log("Task id: " + _ownTaskId + ", has been accepted.");
     }
 
     // Calling popup for canceling task.
@@ -203,7 +211,9 @@ public class DailyTaskManager : MonoBehaviour
 
     private void CancelTask()
     {
+        //TODO: Add task cancellation code when server side has functionality.
         StartCoroutine(_ownTaskPageHandler.ClearCurrentTask());
+        Debug.Log("Task id: " + _ownTaskId + ", has been canceled.");
         _ownTaskId = null;
     }
 

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyTaskManager.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyTaskManager.cs
@@ -39,6 +39,9 @@ public class DailyTaskManager : MonoBehaviour
     [Header("ClanTaskPage")]
     [SerializeField] private GameObject _clanTaskView;
 
+    //Local Testing
+    private int _ownTaksProgress = 0;
+
     public enum SelectedTab
     {
         Tasks,
@@ -197,9 +200,37 @@ public class DailyTaskManager : MonoBehaviour
     private void HandleOwnTask(PopupData.OwnPageData data)
     {
         //TODO: Add task accept code when server side has functionality.
+        CalculateOwnTaskProgressBar(data.TaskAmount);
         StartCoroutine(_ownTaskPageHandler.SetDailyTask(data.TaskDescription, data.TaskAmount, data.TaskPoints, data.TaskCoins));
         _ownTaskId = data.TaskId;
         Debug.Log("Task id: " + _ownTaskId + ", has been accepted.");
+    }
+
+    public void TESTAddTaskProgress()
+    {
+        _ownTaksProgress++;
+
+        foreach (GameObject obj in _dailyTaskCardSlots)
+        {
+            DailyQuest quest = obj.GetComponent<DailyQuest>();
+
+            if (quest.TaskData.Id == _ownTaskId)
+            {
+                CalculateOwnTaskProgressBar(quest.TaskData.Amount);
+                return;
+            }
+        }
+    }
+
+    private void CalculateOwnTaskProgressBar(int taskAmount)
+    {
+        float progress = (float)_ownTaksProgress / (float)taskAmount;
+        StartCoroutine(_ownTaskPageHandler.SetTaskProgress(progress));
+        Debug.Log("Task id: " + _ownTaskId + ", current progress: " + progress);
+        if (progress >= 1f)
+        {
+            Debug.Log("Task id:" + _ownTaskId + ", is done");
+        }
     }
 
     // Calling popup for canceling task.
@@ -212,6 +243,7 @@ public class DailyTaskManager : MonoBehaviour
     private void CancelTask()
     {
         //TODO: Add task cancellation code when server side has functionality.
+        _ownTaksProgress = 0;
         StartCoroutine(_ownTaskPageHandler.ClearCurrentTask());
         Debug.Log("Task id: " + _ownTaskId + ", has been canceled.");
         _ownTaskId = null;

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyTaskOwnTask.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyTaskOwnTask.cs
@@ -73,6 +73,17 @@ public class DailyTaskOwnTask : MonoBehaviour
     }
     #endregion
 
+    public IEnumerator ClearCurrentTask()
+    {
+        _taskDescription.text = "";
+        _taskPointsReward.text = "";
+        _taskCoinsReward.text = "";
+
+        SetProgressBar(0);
+
+        yield return (true);
+    }
+
     public IEnumerator SetTaskProgress(float progress)
     {
         _taskProgressFillImage.fillAmount = progress;

--- a/Assets/MenuUi/Scripts/DailyQuest/PopupData.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/PopupData.cs
@@ -2,21 +2,10 @@ using Altzone.Scripts.Model.Poco.Game;
 
 public struct PopupData
 {
-    public PopupData(PlayerTasks.PlayerTask task, PopupDataType type)
-    {
-        _ownPage = new OwnPageData();
-        _type = type;
-
-        switch (type)
-        {
-            case PopupDataType.OwnTask: SetOwnPageData(task); break;
-            default: SetOwnPageData(task); break;
-        }
-    }
-
     public enum PopupDataType
     {
         OwnTask,
+        CancelTask,
     }
     private PopupDataType _type;
     public PopupDataType Type { get { return _type; } }
@@ -26,11 +15,11 @@ public struct PopupData
         switch (type)
         {
             case "own_task": return PopupDataType.OwnTask;
+            case "cancel_task": return PopupDataType.CancelTask;
             default: return PopupDataType.OwnTask;
         }
     }
 
-    #region OwnPage
     public struct OwnPageData
     {
         private int _taskId;
@@ -57,15 +46,28 @@ public struct PopupData
     private OwnPageData? _ownPage;
     public OwnPageData? OwnPage { get { return _ownPage; } }
 
+    public PopupData(PopupDataType type)
+    {
+        _ownPage = null;
+        _type = type;
+    }
+
+    public PopupData(PlayerTasks.PlayerTask task)
+    {
+        _ownPage = new OwnPageData();
+        _type = PopupDataType.OwnTask;
+
+        SetOwnPageData(task);
+    }
+
     public void SetOwnPageData(PlayerTasks.PlayerTask task)
     {
         if (_ownPage == null)
             _ownPage = new OwnPageData();
 
-        OwnPageData temp = _ownPage.Value;
-        temp.Set(task);
-        _ownPage = temp;
+        OwnPageData tempData = _ownPage.Value;
+        tempData.Set(task);
+        _ownPage = tempData;
         _type = PopupDataType.OwnTask;
     }
-    #endregion
 }


### PR DESCRIPTION
- Cancel button at OwnTask page now clears "_ownTaskId", clears OwnTask page current task stats and sets interactable to false on OwnTask tab button.
- When a new task is selected while there is already a selected task, the old task will be removed before setting the new task (no network functionality yet).
- DailyTask OwnTask page progress functionality and testing button.