### PR TITLE
Fixed bugs in updated character gallery layout and tab button sprite

### DIFF
--- a/Assets/MenuUi/Graphics/CommonGraphics/CommonTabButton.png.meta
+++ b/Assets/MenuUi/Graphics/CommonGraphics/CommonTabButton.png.meta
@@ -165,12 +165,12 @@ TextureImporter:
       name: CommonTabButton_0
       rect:
         serializedVersion: 2
-        x: 27
+        x: 6
         y: 81
-        width: 207
-        height: 84
+        width: 243
+        height: 102
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
@@ -278,14 +278,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.39215687}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: 21300000, guid: 7f8bbea03e8b57546b7659eee0a8d980, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -466,51 +466,16 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6762374876794546724}
     m_Modifications:
-    - target: {fileID: 1263005138304352113, guid: 00dd9bde2849f9c498dd00c084457690,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1775543799907187927, guid: 00dd9bde2849f9c498dd00c084457690,
         type: 3}
       propertyPath: m_Name
       value: GalleryCharacter
-      objectReference: {fileID: 0}
-    - target: {fileID: 1775543799907187927, guid: 00dd9bde2849f9c498dd00c084457690,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1813859720648059125, guid: 00dd9bde2849f9c498dd00c084457690,
-        type: 3}
-      propertyPath: image
-      value: 
-      objectReference: {fileID: 3146477122434043581}
-    - target: {fileID: 1813859720648059125, guid: 00dd9bde2849f9c498dd00c084457690,
-        type: 3}
-      propertyPath: _nameText
-      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 1813859720648059125, guid: 00dd9bde2849f9c498dd00c084457690,
         type: 3}
       propertyPath: initialSlot
       value: 
       objectReference: {fileID: 6762374876794546724}
-    - target: {fileID: 1813859720648059125, guid: 00dd9bde2849f9c498dd00c084457690,
-        type: 3}
-      propertyPath: _aspectRatioFitter
-      value: 
-      objectReference: {fileID: 4118898507377828520}
-    - target: {fileID: 1813859720648059125, guid: 00dd9bde2849f9c498dd00c084457690,
-        type: 3}
-      propertyPath: _backGroundspriteImage
-      value: 
-      objectReference: {fileID: 3146477122434043581}
-    - target: {fileID: 2934286175611341252, guid: 00dd9bde2849f9c498dd00c084457690,
-        type: 3}
-      propertyPath: _isCurrentPopOutWindow
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 8755021714922067558, guid: 00dd9bde2849f9c498dd00c084457690,
         type: 3}
       propertyPath: m_Pivot.x
@@ -611,13 +576,7 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8755021714922067558, guid: 00dd9bde2849f9c498dd00c084457690,
-        type: 3}
-      propertyPath: m_ConstrainProportionsScale
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 0}
+    m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -632,30 +591,6 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9132f07f6a08db94dbda72176dd12539, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &3146477122434043581 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1698316617930894126, guid: 00dd9bde2849f9c498dd00c084457690,
-    type: 3}
-  m_PrefabInstance: {fileID: 4340108514400331155}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &4118898507377828520 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 365475382052161339, guid: 00dd9bde2849f9c498dd00c084457690,
-    type: 3}
-  m_PrefabInstance: {fileID: 4340108514400331155}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!224 &5024676260890555381 stripped

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
@@ -603,7 +603,7 @@ RectTransform:
   - {fileID: 6035648118377856402}
   m_Father: {fileID: 7321252993112423886}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.05, y: 0}
   m_AnchorMax: {x: 0.8, y: 0.8}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -642,8 +642,8 @@ MonoBehaviour:
   m_ChildAlignment: 3
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 180, y: 180}
-  m_Spacing: {x: 10, y: 10}
+  m_CellSize: {x: 160, y: 160}
+  m_Spacing: {x: 25, y: 25}
   m_Constraint: 2
   m_ConstraintCount: 1
 --- !u!1 &1729104482803720081
@@ -853,7 +853,7 @@ MonoBehaviour:
   m_ChildAlignment: 4
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 180, y: 200}
+  m_CellSize: {x: 160, y: 160}
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 0
   m_ConstraintCount: 2
@@ -970,7 +970,7 @@ MonoBehaviour:
   m_ChildAlignment: 4
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 180, y: 200}
+  m_CellSize: {x: 160, y: 160}
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 0
   m_ConstraintCount: 2
@@ -1226,7 +1226,7 @@ MonoBehaviour:
   m_ChildAlignment: 4
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 180, y: 300}
+  m_CellSize: {x: 160, y: 280}
   m_Spacing: {x: 25, y: 25}
   m_Constraint: 1
   m_ConstraintCount: 4
@@ -2083,7 +2083,7 @@ MonoBehaviour:
   m_ChildAlignment: 4
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 180, y: 300}
+  m_CellSize: {x: 160, y: 160}
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 0
   m_ConstraintCount: 2
@@ -2524,8 +2524,8 @@ MonoBehaviour:
   m_ChildAlignment: 3
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 180, y: 180}
-  m_Spacing: {x: 10, y: 10}
+  m_CellSize: {x: 160, y: 160}
+  m_Spacing: {x: 25, y: 25}
   m_Constraint: 2
   m_ConstraintCount: 1
 --- !u!1 &8564527739144655954

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
@@ -141,6 +141,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7321252993112423886}
+  - {fileID: 1606256975741294150}
+  - {fileID: 1789303783340639584}
   - {fileID: 728300593614457015}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -832,8 +834,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 728300593614457015}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.9}
-  m_AnchorMax: {x: 1, y: 0.9}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
@@ -908,10 +910,10 @@ RectTransform:
   m_Children:
   - {fileID: 1466512668170666167}
   - {fileID: 5863237140747453045}
-  m_Father: {fileID: 728300593614457015}
+  m_Father: {fileID: 274154540934240047}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.9, y: 0.9}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.9, y: 0.675}
+  m_AnchorMax: {x: 1, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
@@ -1047,10 +1049,10 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 728300593614457015}
+  m_Father: {fileID: 274154540934240047}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.05, y: 0.9}
-  m_AnchorMax: {x: 0.9, y: 1}
+  m_AnchorMin: {x: 0.05, y: 0.675}
+  m_AnchorMax: {x: 0.9, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1579,7 +1581,7 @@ MonoBehaviour:
   m_fontSizeMax: 36
   m_fontStyle: 0
   m_HorizontalAlignment: 1
-  m_VerticalAlignment: 512
+  m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -1767,15 +1769,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1606256975741294150}
-  - {fileID: 1789303783340639584}
   - {fileID: 2992637691366964565}
   m_Father: {fileID: 274154540934240047}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: 0, y: -9}
-  m_SizeDelta: {x: 0, y: -9}
+  m_AnchorMax: {x: 1, y: 0.675}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1264843494194423629
 CanvasRenderer:

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
@@ -294,6 +294,358 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &806289540749044405
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6035648118377856402}
+  - component: {fileID: 5383386104936700610}
+  - component: {fileID: 2156979043524266241}
+  m_Layer: 5
+  m_Name: Slot3Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6035648118377856402
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 806289540749044405}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3928705158802509702}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5383386104936700610
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 806289540749044405}
+  m_CullTransparentMesh: 1
+--- !u!114 &2156979043524266241
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 806289540749044405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "Ved\xE4 t\xE4h\xE4n 3. suojasi"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
+  m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 28
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1142379372945856192
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1679905253382704294}
+  - component: {fileID: 2145000100227356582}
+  - component: {fileID: 7596711068456077473}
+  m_Layer: 5
+  m_Name: Slot1Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1679905253382704294
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1142379372945856192}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3928705158802509702}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2145000100227356582
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1142379372945856192}
+  m_CullTransparentMesh: 1
+--- !u!114 &7596711068456077473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1142379372945856192}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "Ved\xE4 t\xE4h\xE4n 1. suojasi"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
+  m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 28
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1689721816857784837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3928705158802509702}
+  - component: {fileID: 698001258324854869}
+  - component: {fileID: 7734631423109801524}
+  m_Layer: 5
+  m_Name: SlotTexts
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3928705158802509702
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689721816857784837}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1679905253382704294}
+  - {fileID: 6842026754787974055}
+  - {fileID: 6035648118377856402}
+  m_Father: {fileID: 7321252993112423886}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.8, y: 0.8}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &698001258324854869
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689721816857784837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
+--- !u!114 &7734631423109801524
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689721816857784837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 10
+    m_Right: 10
+    m_Top: 10
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 180, y: 180}
+  m_Spacing: {x: 10, y: 10}
+  m_Constraint: 2
+  m_ConstraintCount: 1
 --- !u!1 &1729104482803720081
 GameObject:
   m_ObjectHideFlags: 0
@@ -327,6 +679,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8458840792069638730}
+  - {fileID: 3928705158802509702}
   - {fileID: 368085340226034555}
   m_Father: {fileID: 274154540934240047}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1051,7 +1404,7 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 274154540934240047}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.05, y: 0.675}
+  m_AnchorMin: {x: 0, y: 0.675}
   m_AnchorMax: {x: 0.9, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -1512,7 +1865,7 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7321252993112423886}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.05, y: 0.8}
+  m_AnchorMin: {x: 0, y: 0.8}
   m_AnchorMax: {x: 0.8, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -1734,6 +2087,143 @@ MonoBehaviour:
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 0
   m_ConstraintCount: 2
+--- !u!1 &7300589515401798518
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6842026754787974055}
+  - component: {fileID: 6075999354314533975}
+  - component: {fileID: 4701824001799360936}
+  m_Layer: 5
+  m_Name: Slot2Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6842026754787974055
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7300589515401798518}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3928705158802509702}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6075999354314533975
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7300589515401798518}
+  m_CullTransparentMesh: 1
+--- !u!114 &4701824001799360936
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7300589515401798518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "Ved\xE4 t\xE4h\xE4n 2. suojasi"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
+  m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 28
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7388681695668014661
 GameObject:
   m_ObjectHideFlags: 0
@@ -1890,6 +2380,9 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 4ed3bf339af3aad4eb4117a5daf3f712, type: 3}
   - {fileID: 21300000, guid: 6ff4a90e01ec6b6488281153ce5efcd8, type: 3}
   - {fileID: 21300000, guid: cb1ba74ba2ebe8243a9d23024ab22cee, type: 3}
+  _selectedCharacterSlotText1: {fileID: 7596711068456077473}
+  _selectedCharacterSlotText2: {fileID: 4701824001799360936}
+  _selectedCharacterSlotText3: {fileID: 2156979043524266241}
 --- !u!114 &8564522138364767957
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
@@ -1880,8 +1880,8 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 872b37f840d89504982780c46a4c1ea5, type: 3}
   - {fileID: 21300000, guid: 50776d2c74951034d826e3080cf53828, type: 3}
   - {fileID: 21300000, guid: 542fee383fb78a64b8fad82a31c1f8c8, type: 3}
-  - {fileID: 21300000, guid: 9df3e17dc0d669e4eb95a35a1616b9d7, type: 3}
   - {fileID: 21300000, guid: f588dfdda7d94a745bcf226af89fdba5, type: 3}
+  - {fileID: 21300000, guid: 9df3e17dc0d669e4eb95a35a1616b9d7, type: 3}
   _selectedBackgroundSprites:
   - {fileID: 21300000, guid: 2de27fd1a232ae946888f7fbef9c1851, type: 3}
   - {fileID: 21300000, guid: 17116b55cd19642489acf2879ab4ca7a, type: 3}

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/DraggableCharacterGallery.prefab
@@ -2289,7 +2289,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.003921569}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/GalleryCharacter.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/GalleryCharacter.prefab
@@ -29,7 +29,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1775543799907187927}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -141,6 +141,7 @@ MonoBehaviour:
   _spriteImage: {fileID: 2980416419759435658}
   _backgroundSpriteImage: {fileID: 1698316617930894126}
   _characterNameText: {fileID: 3511939312560207162}
+  _aspectRatioFitter: {fileID: 365475382052161339}
   _piechartPreview: {fileID: 599868788555485942}
   parentBeforeDrag: {fileID: 0}
   allowedSlot: {fileID: 0}
@@ -415,17 +416,17 @@ PrefabInstance:
     - target: {fileID: 8468770450800277434, guid: 313c5a9a9e02aff4886892a2a3e86516,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.97
+      value: 0.98
       objectReference: {fileID: 0}
     - target: {fileID: 8468770450800277434, guid: 313c5a9a9e02aff4886892a2a3e86516,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.3
+      value: 0.4
       objectReference: {fileID: 0}
     - target: {fileID: 8468770450800277434, guid: 313c5a9a9e02aff4886892a2a3e86516,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.5
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 8468770450800277434, guid: 313c5a9a9e02aff4886892a2a3e86516,
         type: 3}

--- a/Assets/MenuUi/Prefabs/Windows/DefenceScreen/DefenceView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DefenceScreen/DefenceView.prefab
@@ -560,6 +560,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: GalleriaPanel
       objectReference: {fileID: 0}
+    - target: {fileID: 1945301030672382667, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3884548401295957108, guid: f8adbf41952228b4980d80ecace0ef68,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -586,6 +591,46 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3884548401295957108, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263414132599355883, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263414132599355883, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263414132599355883, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263414132599355883, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263414132599355883, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263414132599355883, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263414132599355883, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263414132599355883, guid: f8adbf41952228b4980d80ecace0ef68,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -751,6 +796,66 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7997585425236692616, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253210706428407530, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253210706428407530, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253210706428407530, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253210706428407530, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253210706428407530, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253210706428407530, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9203217445654628575, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9203217445654628575, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9203217445654628575, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9203217445654628575, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9203217445654628575, guid: f8adbf41952228b4980d80ecace0ef68,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9203217445654628575, guid: f8adbf41952228b4980d80ecace0ef68,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/CharacterSlot.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/CharacterSlot.cs
@@ -19,7 +19,7 @@ namespace MenuUi.Scripts.CharacterGallery
         public void SetInfo(Sprite sprite, Sprite backgroundSprite, Sprite selectedBackgroundSprite, string name, CharacterID id, ModelView view)
         {
             _spriteImage.sprite = sprite;
-            _backgroundSpriteImage.sprite = backgroundSprite;
+            //_backgroundSpriteImage.sprite = backgroundSprite;
             _nameText.text = name;
             _id = id;
             _character.SetInfo(sprite, backgroundSprite, selectedBackgroundSprite, name, id, view);

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/DraggableCharacter.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/DraggableCharacter.cs
@@ -47,10 +47,20 @@ namespace MenuUi.Scripts.CharacterGallery
         private Sprite _unselectedBackgroundSprite;
 
 
+        private void Awake()
+        {
+            _piechartPreview.gameObject.SetActive(false);
+        }
+
+
         private void OnEnable()
         {
-            _piechartPreview.UpdateChart(Id);
+            if (_piechartPreview.gameObject.activeInHierarchy)
+            {
+                _piechartPreview.UpdateChart(Id);
+            }
         }
+
 
 
         private void Start()
@@ -232,8 +242,12 @@ namespace MenuUi.Scripts.CharacterGallery
             _backgroundSpriteImage.sprite = _selectedBackgroundSprite;
             _aspectRatioFitter.aspectRatio = 1;
             _characterNameText.gameObject.SetActive(false);
+
             _spriteImage.rectTransform.anchorMax = new Vector2(0.9f, 0.9f);
             _spriteImage.rectTransform.anchorMin = new Vector2(0.1f, 0.1f);
+
+            _piechartPreview.gameObject.SetActive(true);
+            _piechartPreview.UpdateChart(Id);
         }
 
 
@@ -242,8 +256,11 @@ namespace MenuUi.Scripts.CharacterGallery
             _backgroundSpriteImage.sprite = _unselectedBackgroundSprite;
             _aspectRatioFitter.aspectRatio = 0.6f;
             _characterNameText.gameObject.SetActive(true);
+
             _spriteImage.rectTransform.anchorMax = new Vector2(0.9f, 0.75f);
             _spriteImage.rectTransform.anchorMin = new Vector2(0.1f, 0.1f);
+
+            _piechartPreview.gameObject.SetActive(false);
         }
     }
 }

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelView.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelView.cs
@@ -6,6 +6,7 @@ using Altzone.Scripts.Model.Poco.Game;
 using UnityEngine;
 using UnityEngine.UI;
 using Altzone.Scripts.ModelV2;
+using TMPro;
 
 namespace MenuUi.Scripts.CharacterGallery
 {
@@ -18,6 +19,10 @@ namespace MenuUi.Scripts.CharacterGallery
 
         [SerializeField] private Sprite[] _backgroundSprites;
         [SerializeField] private Sprite[] _selectedBackgroundSprites;
+
+        [SerializeField] private TextMeshProUGUI _selectedCharacterSlotText1;
+        [SerializeField] private TextMeshProUGUI _selectedCharacterSlotText2;
+        [SerializeField] private TextMeshProUGUI _selectedCharacterSlotText3;
 
         private bool _isReady;
 
@@ -101,6 +106,7 @@ namespace MenuUi.Scripts.CharacterGallery
             _characterButtons.Clear();
             _characterSlots.Clear();
             LoadAndCachePrefabs();
+            CheckSelectedCharacterSlotTexts();
         }
 
 
@@ -207,6 +213,7 @@ namespace MenuUi.Scripts.CharacterGallery
                             }
                             i++;
                         }
+                        CheckSelectedCharacterSlotTexts();
                     };
 
                     // subscribing to removed from top slot event
@@ -233,6 +240,37 @@ namespace MenuUi.Scripts.CharacterGallery
                         }
                     }
                 }
+            }
+
+            CheckSelectedCharacterSlotTexts();
+        }
+
+
+        public void CheckSelectedCharacterSlotTexts()
+        {
+            if (_CurSelectedCharacterSlots[2].transform.childCount > 0)
+            {
+                _selectedCharacterSlotText3.enabled = false;
+            }
+            else
+            {
+                _selectedCharacterSlotText3.enabled = true;
+            }
+            if (_CurSelectedCharacterSlots[1].transform.childCount > 0)
+            {
+                _selectedCharacterSlotText2.enabled = false;
+            }
+            else
+            {
+                _selectedCharacterSlotText2.enabled = true;
+            }
+            if (_CurSelectedCharacterSlots[0].transform.childCount > 0)
+            {
+                _selectedCharacterSlotText1.enabled = false;
+            }
+            else
+            {
+                _selectedCharacterSlotText1.enabled = true;
             }
         }
 
@@ -269,6 +307,8 @@ namespace MenuUi.Scripts.CharacterGallery
                     CurrentCharacterId = CharacterID.None;
                 }
             }
+
+            CheckSelectedCharacterSlotTexts();
         }
     }
 }


### PR DESCRIPTION
- Updated CommonTabButton in sprite editor to not be cut weirdly. (not necessarily a gallery fix but fix for every tab button in the game)
- Piechart shows now only for selected characters.
- Character inventory slot background changed.
- Fixed overlap issue when scrolling in character gallery.
- Fixed bug with 600 and 700 background sprites being switched in the array where they are defined.
- Added back selected character slot texts.
- Scrolling up and down in gallery is easier now. (but swiping to other main menu windows is more difficult)
- Lowered grid size in gallery so there is less chance of clipping.