### PR TITLE
DT save & load from PlayerData

### DIFF
--- a/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
@@ -50,7 +50,8 @@ namespace Altzone.Scripts.Model.Poco.Player
 
         public int BackpackCapacity;
 
-        public int dailyTaskId = 0;
+        public PlayerTasks.PlayerTask Task = null;
+        public int TaskProgress = 0;
 
         public int points = 0;
 

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyTaskOwnTask.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyTaskOwnTask.cs
@@ -31,15 +31,13 @@ public class DailyTaskOwnTask : MonoBehaviour
     [SerializeField] private TextMeshProUGUI _randomText;
 
     #region SetTask
-    public IEnumerator SetDailyTask(string taskDescription, int amount, int points, int coins)
+    public void SetDailyTask(string taskDescription, int amount, int points, int coins)
     {
         _taskDescription.text = taskDescription;
         _taskPointsReward.text = "" + points;
         _taskCoinsReward.text = "" + coins;
 
         SetProgressBar(amount);
-
-        yield return (true);
     }
 
     private void SetProgressBar(int amount)
@@ -84,11 +82,9 @@ public class DailyTaskOwnTask : MonoBehaviour
         yield return (true);
     }
 
-    public IEnumerator SetTaskProgress(float progress)
+    public void SetTaskProgress(float progress)
     {
         _taskProgressFillImage.fillAmount = progress;
-
-        yield return new WaitUntil(() => true);
     }
 
     public IEnumerator SetStipend(int points, int coins, int rank)

--- a/Assets/MenuUi/Scripts/DailyQuest/PopupData.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/PopupData.cs
@@ -43,8 +43,11 @@ public struct PopupData
             _taskCoins = task.Coins;
         }
     }
-    private OwnPageData? _ownPage;
-    public OwnPageData? OwnPage { get { return _ownPage; } }
+    //private OwnPageData? _ownPage;
+    //public OwnPageData? OwnPage { get { return _ownPage; } }
+
+    private PlayerTasks.PlayerTask _ownPage;
+    public PlayerTasks.PlayerTask OwnPage { get { return _ownPage; } }
 
     public PopupData(PopupDataType type)
     {
@@ -54,20 +57,22 @@ public struct PopupData
 
     public PopupData(PlayerTasks.PlayerTask task)
     {
-        _ownPage = new OwnPageData();
+        //_ownPage = new OwnPageData();
+        _ownPage = task;
         _type = PopupDataType.OwnTask;
 
-        SetOwnPageData(task);
+        //SetOwnPageData(task);
     }
 
     public void SetOwnPageData(PlayerTasks.PlayerTask task)
     {
-        if (_ownPage == null)
-            _ownPage = new OwnPageData();
+        //if (_ownPage == null)
+        //_ownPage = new OwnPageData();
 
-        OwnPageData tempData = _ownPage.Value;
-        tempData.Set(task);
-        _ownPage = tempData;
+        //OwnPageData tempData = _ownPage.Value;
+        //tempData.Set(task);
+        //_ownPage = tempData;
+        _ownPage = task;
         _type = PopupDataType.OwnTask;
     }
 }


### PR DESCRIPTION
- If existing task is found on startup (not possible -> no server or local storage test saving functionality at the moment) the task data will be set to OwnPage and it is selected as the active tab.
- Changed multiple lines in DailyTaskManager.cs & PopupData.cs to get and save data regarding the PlayerTask class data that is now stored in PlayerData.cs.