### PR TITLE
ClanValue selector logic and handling fixes

### DIFF
--- a/Assets/Altzone/Scripts/Model/Poco/Clan/ServerClan.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Clan/ServerClan.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Altzone.Scripts.Voting;
 
@@ -26,5 +27,18 @@ namespace Altzone.Scripts.Model.Poco.Clan
         public int? furnitureCount { get; set; }
         public int? raidRoomCount { get; set; }
         public List<PollData> polls { get; set; }
+        public ClanLogo clanLogo { get; set; }
+    }
+
+    public enum ClanLogoType
+    {
+        None,
+        Heart
+    }
+    [Serializable]
+    public class ClanLogo
+    {
+        public ClanLogoType logoType { get; set; }
+        public List<string> pieceColors { get; set; }
     }
 }

--- a/Assets/MenuUi/Prefabs/Clan/ClanSettings.prefab
+++ b/Assets/MenuUi/Prefabs/Clan/ClanSettings.prefab
@@ -64,7 +64,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _valueSelectorObject: {fileID: 202944389429737228}
   _activateButton: {fileID: 2637716073653634247}
-  _scrollBar: {fileID: 6404656583179441688}
+  _scrollRectComponent: {fileID: 6405720582892755878}
   _labelTogglePrefab: {fileID: 9142154561159488018, guid: 4b98591facea2684886cb562c2ba5460,
     type: 3}
   _labelImagePrefab: {fileID: 3140534817053600678, guid: 116db0f2cdec84749957449664b3fe38,

--- a/Assets/MenuUi/Prefabs/Clan/ClanSettings.prefab
+++ b/Assets/MenuUi/Prefabs/Clan/ClanSettings.prefab
@@ -62,6 +62,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 768c872e3eeb19b4ba23ab5861c2ce6f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _valueSelectorObject: {fileID: 202944389429737228}
+  _activateButton: {fileID: 2637716073653634247}
+  _scrollBar: {fileID: 6404656583179441688}
   _labelTogglePrefab: {fileID: 9142154561159488018, guid: 4b98591facea2684886cb562c2ba5460,
     type: 3}
   _labelImagePrefab: {fileID: 3140534817053600678, guid: 116db0f2cdec84749957449664b3fe38,
@@ -378,7 +381,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 48.65
+  m_fontSize: 39.9
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -458,7 +461,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.04, y: 0.1424409}
   m_AnchorMax: {x: 0.96, y: 0.87146306}
-  m_AnchoredPosition: {x: 0, y: -9.999939}
+  m_AnchoredPosition: {x: 0, y: -9.9999695}
   m_SizeDelta: {x: 0, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9203601558325987527
@@ -593,7 +596,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 45.5
+  m_fontSize: 36.55
   m_fontSizeBase: 25
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -795,7 +798,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 58.2
+  m_fontSize: 47.7
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1972,7 +1975,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 25.7
+  m_fontSize: 21.1
   m_fontSizeBase: 5
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -2690,7 +2693,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 49.25
+  m_fontSize: 40.35
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -3122,7 +3125,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 40.05
+  m_fontSize: 32.85
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -3259,7 +3262,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 27.5
+  m_fontSize: 22.55
   m_fontSizeBase: 5
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -4090,7 +4093,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24.8
+  m_fontSize: 20.35
   m_fontSizeBase: 5
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -4317,7 +4320,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 40.05
+  m_fontSize: 32.85
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -6128,7 +6131,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 55.45
+  m_fontSize: 45.5
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -6267,7 +6270,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 41.3
+  m_fontSize: 33.85
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -8557,7 +8560,7 @@ PrefabInstance:
     - target: {fileID: 4279458544638658286, guid: 6f690bb33c1bdce469a64adeaf8614db,
         type: 3}
       propertyPath: m_fontSize
-      value: 72
+      value: 62.45
       objectReference: {fileID: 0}
     - target: {fileID: 6563582005748136573, guid: 6f690bb33c1bdce469a64adeaf8614db,
         type: 3}
@@ -8798,7 +8801,7 @@ PrefabInstance:
     - target: {fileID: 5029625442628242303, guid: 1973ba674bd1e39488f5ad71181caf28,
         type: 3}
       propertyPath: m_fontSize
-      value: 43.5
+      value: 35.7
       objectReference: {fileID: 0}
     - target: {fileID: 5051431190338678266, guid: 1973ba674bd1e39488f5ad71181caf28,
         type: 3}
@@ -10173,7 +10176,7 @@ PrefabInstance:
     - target: {fileID: 2199488499600492946, guid: c5bddb70cfcd71d4683c5c6819209308,
         type: 3}
       propertyPath: m_fontSize
-      value: 52.25
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 4463451107186381493, guid: c5bddb70cfcd71d4683c5c6819209308,
         type: 3}
@@ -10460,7 +10463,7 @@ PrefabInstance:
     - target: {fileID: 2199488499600492946, guid: c5bddb70cfcd71d4683c5c6819209308,
         type: 3}
       propertyPath: m_fontSize
-      value: 52.25
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 4463451107186381493, guid: c5bddb70cfcd71d4683c5c6819209308,
         type: 3}
@@ -10629,7 +10632,7 @@ PrefabInstance:
     - target: {fileID: 2199488499600492946, guid: c5bddb70cfcd71d4683c5c6819209308,
         type: 3}
       propertyPath: m_fontSize
-      value: 51.5
+      value: 39.35
       objectReference: {fileID: 0}
     - target: {fileID: 6865229239137791869, guid: c5bddb70cfcd71d4683c5c6819209308,
         type: 3}

--- a/Assets/MenuUi/Prefabs/Clan/CreateClan.prefab
+++ b/Assets/MenuUi/Prefabs/Clan/CreateClan.prefab
@@ -887,6 +887,7 @@ MonoBehaviour:
   _closeLanguageSelect: {fileID: 3719403107676370444}
   _createClanOK: {fileID: 5014486994110506936}
   _naviTarget: {fileID: 11400000, guid: af7bed882640abb4c883d988f7d81a34, type: 2}
+  _scrollbarValues: {fileID: 1499496441936510908}
 --- !u!1 &1522905625465808281
 GameObject:
   m_ObjectHideFlags: 0
@@ -4246,6 +4247,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 768c872e3eeb19b4ba23ab5861c2ce6f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _valueSelectorObject: {fileID: 1522905625465808281}
+  _activateButton: {fileID: 6192158681132152622}
   _labelTogglePrefab: {fileID: 9142154561159488018, guid: 4b98591facea2684886cb562c2ba5460,
     type: 3}
   _labelImagePrefab: {fileID: 3140534817053600678, guid: 116db0f2cdec84749957449664b3fe38,
@@ -4292,7 +4295,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 0}
+  m_TargetGraphic: {fileID: 5670095091268334515}
   m_OnClick:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/MenuUi/Prefabs/Clan/CreateClan.prefab
+++ b/Assets/MenuUi/Prefabs/Clan/CreateClan.prefab
@@ -882,6 +882,7 @@ MonoBehaviour:
   _passwordWarningOutline: {fileID: 5734001436455827807}
   _goalWarningOutline: {fileID: 8256111806386788650}
   _languageWarningOutline: {fileID: 263451008036746917}
+  _valuesWarningOutline: {fileID: 4027301245409479176}
   _warningPopup: {fileID: 788613460611345365}
   _closeLanguageSelect: {fileID: 3719403107676370444}
   _createClanOK: {fileID: 5014486994110506936}
@@ -1088,7 +1089,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 26.15
+  m_fontSize: 36.95
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1345,7 +1346,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 31.45
+  m_fontSize: 44.45
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1692,7 +1693,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36.3
+  m_fontSize: 51.3
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -2202,7 +2203,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 30.85
+  m_fontSize: 43.65
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -2554,6 +2555,81 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &4027301245409479176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3204238480847701991}
+  - component: {fileID: 4869307507472047505}
+  - component: {fileID: 867755741749699302}
+  m_Layer: 5
+  m_Name: WarningOutline_Values
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &3204238480847701991
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4027301245409479176}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2815421089376695608}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.698}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4869307507472047505
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4027301245409479176}
+  m_CullTransparentMesh: 1
+--- !u!114 &867755741749699302
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4027301245409479176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4275928203425297319
 GameObject:
   m_ObjectHideFlags: 0
@@ -2647,7 +2723,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 47.25
+  m_fontSize: 66.8
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -2961,7 +3037,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 111.232254}
+  m_SizeDelta: {x: 0, y: 158.44693}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &8882311531581677731
 MonoBehaviour:
@@ -3169,7 +3245,7 @@ RectTransform:
   m_Father: {fileID: 900001433349162789}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: -0.00018310547}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -4140,6 +4216,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
+  - {fileID: 3204238480847701991}
   - {fileID: 9107964299544642369}
   - {fileID: 4635508610906215713}
   m_Father: {fileID: 3999813593351278550}
@@ -5392,7 +5469,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 49.15
+  m_fontSize: 54.6
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -6024,7 +6101,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 32.3
+  m_fontSize: 45.7
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -6603,7 +6680,7 @@ PrefabInstance:
     - target: {fileID: 5029625442628242303, guid: 1973ba674bd1e39488f5ad71181caf28,
         type: 3}
       propertyPath: m_fontSize
-      value: 29.85
+      value: 42.2
       objectReference: {fileID: 0}
     - target: {fileID: 5377643931811425935, guid: 1973ba674bd1e39488f5ad71181caf28,
         type: 3}
@@ -6768,7 +6845,7 @@ PrefabInstance:
     - target: {fileID: 5029625442628242303, guid: 1973ba674bd1e39488f5ad71181caf28,
         type: 3}
       propertyPath: m_fontSize
-      value: 30.7
+      value: 43.4
       objectReference: {fileID: 0}
     - target: {fileID: 5051431190338678266, guid: 1973ba674bd1e39488f5ad71181caf28,
         type: 3}
@@ -6873,12 +6950,12 @@ PrefabInstance:
     - target: {fileID: 3154999418737615134, guid: f85120bf637965c4ea95b247302bd2b8,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 723.00964
+      value: 1029.905
       objectReference: {fileID: 0}
     - target: {fileID: 3154999418737615134, guid: f85120bf637965c4ea95b247302bd2b8,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 111.232254
+      value: 158.44693
       objectReference: {fileID: 0}
     - target: {fileID: 3154999418737615134, guid: f85120bf637965c4ea95b247302bd2b8,
         type: 3}
@@ -6918,12 +6995,12 @@ PrefabInstance:
     - target: {fileID: 3154999418737615134, guid: f85120bf637965c4ea95b247302bd2b8,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 361.50482
+      value: 514.9525
       objectReference: {fileID: 0}
     - target: {fileID: 3154999418737615134, guid: f85120bf637965c4ea95b247302bd2b8,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -55.616127
+      value: -79.223465
       objectReference: {fileID: 0}
     - target: {fileID: 3154999418737615134, guid: f85120bf637965c4ea95b247302bd2b8,
         type: 3}
@@ -6953,7 +7030,7 @@ PrefabInstance:
     - target: {fileID: 7916248436925301640, guid: f85120bf637965c4ea95b247302bd2b8,
         type: 3}
       propertyPath: m_fontSize
-      value: 37.9
+      value: 54
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/MenuUi/Prefabs/Clan/CreateClan.prefab
+++ b/Assets/MenuUi/Prefabs/Clan/CreateClan.prefab
@@ -887,7 +887,6 @@ MonoBehaviour:
   _closeLanguageSelect: {fileID: 3719403107676370444}
   _createClanOK: {fileID: 5014486994110506936}
   _naviTarget: {fileID: 11400000, guid: af7bed882640abb4c883d988f7d81a34, type: 2}
-  _scrollbarValues: {fileID: 1499496441936510908}
 --- !u!1 &1522905625465808281
 GameObject:
   m_ObjectHideFlags: 0
@@ -1738,6 +1737,61 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2557675851324654603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5783232744867995032}
+  - component: {fileID: 5904445888979301236}
+  m_Layer: 0
+  m_Name: ClanValuesViewManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5783232744867995032
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2557675851324654603}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -187.91757}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3999813593351278550}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5904445888979301236
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2557675851324654603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b82083231629564e95b7359c0b37393, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _objectsToActivate:
+  - {fileID: 1522905625465808281}
+  - {fileID: 8281527775391587679}
+  _objectsToHide:
+  - {fileID: 3079550343720922087}
+  - {fileID: 8547530150921208277}
+  _scrollRectComponent: {fileID: 4761222938785934135}
 --- !u!1 &2596751005373582912
 GameObject:
   m_ObjectHideFlags: 0
@@ -4299,46 +4353,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1522905625465808281}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 3079550343720922087}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 8547530150921208277}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 8281527775391587679}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 5904445888979301236}
+        m_TargetAssemblyTypeName: ClanValuesViewManager, MainMenu
+        m_MethodName: ShowValuesView
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -5360,6 +5378,7 @@ RectTransform:
   - {fileID: 4436667224235885394}
   - {fileID: 7853993449864566034}
   - {fileID: 7811281355865699830}
+  - {fileID: 5783232744867995032}
   - {fileID: 2963449519479721587}
   - {fileID: 2815421089376695608}
   - {fileID: 5019712739824181944}
@@ -5963,46 +5982,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1522905625465808281}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 3079550343720922087}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8547530150921208277}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 8281527775391587679}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 5904445888979301236}
+        m_TargetAssemblyTypeName: ClanValuesViewManager, MainMenu
+        m_MethodName: HideValuesView
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
+++ b/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
@@ -129,6 +129,13 @@ public class ClanCreateNew : MonoBehaviour
             return;
         }
 
+        List<string> serverValues = new ();
+
+        foreach( var value in values)
+        {
+            serverValues.Add(value.ToString().ToLower());
+        }
+
         ServerClan serverClan = new ServerClan
         {
             name = clanName,
@@ -138,7 +145,7 @@ public class ClanCreateNew : MonoBehaviour
             language = language,
             goal = goal,
             ageRange = age,
-            labels = new()
+            labels = serverValues
         };
 
         StartCoroutine(ServerManager.Instance.PostClanToServer(serverClan, clan =>

--- a/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
+++ b/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
@@ -73,6 +73,7 @@ public class ClanCreateNew : MonoBehaviour
         _goalWarningOutline.SetActive(false);
         _passwordWarningOutline.SetActive(false);
         _languageWarningOutline.SetActive(false);
+        _valuesWarningOutline.SetActive(false);
 
         _ageSelection.Initialize(ClanAge.All);
         _clanGoalSelection.Initialize(Goals.Fiilistely);

--- a/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
+++ b/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
@@ -33,6 +33,7 @@ public class ClanCreateNew : MonoBehaviour
     [SerializeField] private GameObject _passwordWarningOutline;
     [SerializeField] private GameObject _goalWarningOutline;
     [SerializeField] private GameObject _languageWarningOutline;
+    [SerializeField] private GameObject _valuesWarningOutline;
     [SerializeField] private PopupController _warningPopup;
 
     [Header("Buttons")]
@@ -122,7 +123,7 @@ public class ClanCreateNew : MonoBehaviour
         List<HeartPieceData> clanHeartPieces = new();
         for (int i = 0; i < 50; i++) clanHeartPieces.Add(new HeartPieceData(i, _selectedHeartColor));
 
-        if (!CheckClanValuesValidity(clanName, isOpen, password, language, goal))
+        if (!CheckClanInputsValidity(clanName, isOpen, password, language, goal, values))
         {
             return;
         }
@@ -171,7 +172,7 @@ public class ClanCreateNew : MonoBehaviour
         }));
     }
 
-    private bool CheckClanValuesValidity(string clanName, bool isOpen, string password, Language language, Goals goal)
+    private bool CheckClanInputsValidity(string clanName, bool isOpen, string password, Language language, Goals goal, ClanValues[] values)
     {
         bool validInputs = true;
 
@@ -206,6 +207,17 @@ public class ClanCreateNew : MonoBehaviour
             validInputs = false;
         }
         else _goalWarningOutline.SetActive(false);
+
+        if (values.Length < 3)
+        {
+            _valuesWarningOutline.SetActive(true);
+            _warningPopup.ActivatePopUp("Klaanille tulee olla valittuna vähintää 3 arvoa");
+            validInputs = false;
+        }
+        else
+        {
+            _valuesWarningOutline.SetActive(false);
+        }
 
         return validInputs;
     }

--- a/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
+++ b/Assets/MenuUi/Scripts/Clan/ClanCreateNew.cs
@@ -131,9 +131,18 @@ public class ClanCreateNew : MonoBehaviour
 
         List<string> serverValues = new ();
 
-        foreach( var value in values)
+        foreach(var value in values)
         {
             serverValues.Add(value.ToString().ToLower());
+        }
+
+        ClanLogo logo = new ClanLogo();
+        logo.logoType = ClanLogoType.Heart;
+        logo.pieceColors = new();
+
+        foreach(var piece in clanHeartPieces)
+        {
+            logo.pieceColors.Add(ColorUtility.ToHtmlStringRGB(piece.pieceColor));
         }
 
         ServerClan serverClan = new ServerClan
@@ -145,7 +154,8 @@ public class ClanCreateNew : MonoBehaviour
             language = language,
             goal = goal,
             ageRange = age,
-            labels = serverValues
+            labels = serverValues,
+            clanLogo = logo
         };
 
         StartCoroutine(ServerManager.Instance.PostClanToServer(serverClan, clan =>

--- a/Assets/MenuUi/Scripts/Clan/ClanValuesViewManager.cs
+++ b/Assets/MenuUi/Scripts/Clan/ClanValuesViewManager.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ClanValuesViewManager : MonoBehaviour
+{
+    [SerializeField] private GameObject[] _objectsToActivate;
+
+    [SerializeField] private GameObject[] _objectsToHide;
+
+    [SerializeField] private ScrollRect _scrollRectComponent;
+
+    public void ShowValuesView()
+    {
+        foreach (GameObject toActivate in _objectsToActivate)
+        {
+            toActivate.SetActive(true);
+        }
+
+        foreach(GameObject toHide in _objectsToHide)
+        {
+            toHide.SetActive(false);
+        }
+
+        StartCoroutine(ResetScrollPosition()); 
+    }
+
+    public void HideValuesView()
+    {
+        foreach (GameObject toActivate in _objectsToActivate)
+        {
+            toActivate.SetActive(false);
+        }
+
+        foreach (GameObject toHide in _objectsToHide)
+        {
+            toHide.SetActive(true);
+        }
+    }
+
+    private IEnumerator ResetScrollPosition()
+    {
+        yield return null; 
+        _scrollRectComponent.verticalNormalizedPosition = 1f;
+    }
+}

--- a/Assets/MenuUi/Scripts/Clan/ClanValuesViewManager.cs.meta
+++ b/Assets/MenuUi/Scripts/Clan/ClanValuesViewManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b82083231629564e95b7359c0b37393
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Scripts/Clan/ValueLabels/ClanValuePanel.cs
+++ b/Assets/MenuUi/Scripts/Clan/ValueLabels/ClanValuePanel.cs
@@ -19,7 +19,7 @@ public class ClanValuePanel : MonoBehaviour
         {
             GameObject labelPanel = Instantiate(_valuePrefab, _grid.transform);
             ValueLabelHandler labelHandler = labelPanel.GetComponent<ValueLabelHandler>();
-            labelHandler.SetLabelInfo(value);
+            labelHandler.SetLabelInfo(value, true);
         }
     }
 }

--- a/Assets/MenuUi/Scripts/Clan/ValueLabels/ValueLabelHandler.cs
+++ b/Assets/MenuUi/Scripts/Clan/ValueLabels/ValueLabelHandler.cs
@@ -18,11 +18,20 @@ public class ValueLabelHandler : MonoBehaviour
         CheckLabelSize();
     }
 
-    public void SetLabelInfo(ClanValues value)
+    public void SetLabelInfo(ClanValues value, bool showName)
     {
         labelInfo = _reference.GetLabelInfo(value);
-        _textLabel.text = labelInfo.Name;
         _labelImage.sprite = labelInfo.Image;
+
+        if (showName)
+        {
+            _textLabel.enabled = true;
+            _textLabel.text = labelInfo.Name;   
+        }
+        else
+        {
+            _textLabel.enabled = false;
+        } 
     }
 
     public void CheckLabelSize()

--- a/Assets/MenuUi/Scripts/Clan/ValueLabels/ValueSelectionController.cs
+++ b/Assets/MenuUi/Scripts/Clan/ValueLabels/ValueSelectionController.cs
@@ -56,10 +56,12 @@ public class ValueSelectionController : MonoBehaviour
         {
             if (SelectedValues.Count >= 5)
             {
-                ClanValues removedValue = SelectedValues[0];
-                ValueLabelHandler handlerOfRemoved = _labelHandlers.Find(labelHandler => labelHandler.labelInfo.values == removedValue);
-                handlerOfRemoved.Unselect();
-                SelectedValues.RemoveAt(0);
+                //ClanValues removedValue = SelectedValues[0];
+                //ValueLabelHandler handlerOfRemoved = _labelHandlers.Find(labelHandler => labelHandler.labelInfo.values == removedValue);
+                //handlerOfRemoved.Unselect();
+                //SelectedValues.RemoveAt(0);
+
+                return;
             }
 
             SelectedValues.Add(toggledHandler.labelInfo.values);

--- a/Assets/MenuUi/Scripts/Clan/ValueLabels/ValueSelectionController.cs
+++ b/Assets/MenuUi/Scripts/Clan/ValueLabels/ValueSelectionController.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using UnityEngine;
 using Altzone.Scripts.Model.Poco.Clan;
 using UnityEngine.UI;
+using System.Collections;
 
 public class ValueSelectionController : MonoBehaviour
 {
     [Header("Objects")]
     [SerializeField] private GameObject _valueSelectorObject;
     [SerializeField] private GameObject _activateButton;
+
+    [SerializeField] private ScrollRect _scrollRectComponent;
 
     [Header("Prefabs")]
     [SerializeField] private GameObject _labelTogglePrefab;
@@ -21,13 +24,23 @@ public class ValueSelectionController : MonoBehaviour
     private List<ValueLabelHandler> _labelHandlers = new();
     public List<ClanValues> SelectedValues { get; private set; } = new();
 
-    void Start() => CreateLabels();
+    private void Start()
+    {
+        CreateLabels();
+        StartCoroutine(ResetScrollPosition());
+    }
 
     public void SetSelected(List<ClanValues> selected)
     {
         SelectedValues = new(selected);
         CreateLabels();
         UpdateSelectedDisplay();
+    }
+
+    private IEnumerator ResetScrollPosition()
+    {
+        yield return null;
+        _scrollRectComponent.verticalNormalizedPosition = 1f;
     }
 
     private void CreateLabels()

--- a/Assets/MenuUi/Scripts/Clan/ValueLabels/ValueSelectionController.cs
+++ b/Assets/MenuUi/Scripts/Clan/ValueLabels/ValueSelectionController.cs
@@ -2,9 +2,14 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Altzone.Scripts.Model.Poco.Clan;
+using UnityEngine.UI;
 
 public class ValueSelectionController : MonoBehaviour
 {
+    [Header("Objects")]
+    [SerializeField] private GameObject _valueSelectorObject;
+    [SerializeField] private GameObject _activateButton;
+
     [Header("Prefabs")]
     [SerializeField] private GameObject _labelTogglePrefab;
     [SerializeField] private GameObject _labelImagePrefab;
@@ -35,7 +40,7 @@ public class ValueSelectionController : MonoBehaviour
         {
             GameObject labelPanel = Instantiate(_labelTogglePrefab, _valueListParent);
             ValueLabelHandler labelHandler = labelPanel.GetComponent<ValueLabelHandler>();
-            labelHandler.SetLabelInfo(value);
+            labelHandler.SetLabelInfo(value, true);
             _labelHandlers.Add(labelHandler);
 
             if (SelectedValues.Contains(value)) labelHandler.Select();
@@ -54,34 +59,46 @@ public class ValueSelectionController : MonoBehaviour
         }
         else
         {
-            if (SelectedValues.Count >= 5)
+            if (SelectedValues.Count < 5)
             {
-                //ClanValues removedValue = SelectedValues[0];
-                //ValueLabelHandler handlerOfRemoved = _labelHandlers.Find(labelHandler => labelHandler.labelInfo.values == removedValue);
-                //handlerOfRemoved.Unselect();
-                //SelectedValues.RemoveAt(0);
-
-                return;
+                SelectedValues.Add(toggledHandler.labelInfo.values);
+                ValueLabelHandler handlerOfSelected = _labelHandlers.Find(handler => handler.labelInfo.values == toggledHandler.labelInfo.values);
+                handlerOfSelected.Select();
             }
-
-            SelectedValues.Add(toggledHandler.labelInfo.values);
-            ValueLabelHandler handlerOfSelected = _labelHandlers.Find(handler => handler.labelInfo.values == toggledHandler.labelInfo.values);
-            handlerOfSelected.Select();
         }
 
         UpdateSelectedDisplay();
+    }
+
+    public void RemoveSelectedValue(ValueLabelHandler removedHandler)
+    {
+        if (_valueSelectorObject.activeSelf)
+        {
+            ValueLabelHandler handlerOfRemoved = _labelHandlers.Find(handler => handler.labelInfo.values == removedHandler.labelInfo.values);
+            handlerOfRemoved.Unselect();
+            SelectedValues.Remove(removedHandler.labelInfo.values);
+
+            UpdateSelectedDisplay();
+        }
+        else
+        {
+            _activateButton.GetComponent<Button>().onClick.Invoke();
+        }
+
     }
 
     private void UpdateSelectedDisplay()
     {
         foreach (Transform child in _selectedValuesParent) Destroy(child.gameObject);
 
-        foreach (ClanValues selectedValue in SelectedValues)
+        foreach (ClanValues value in SelectedValues)
         {
-            Debug.Log(selectedValue);
-            GameObject label = Instantiate(_labelImagePrefab, _selectedValuesParent);
-            ValueImageHandle imageHandler = label.GetComponent<ValueImageHandle>();
-            imageHandler.SetLabelInfo(selectedValue);
+            GameObject selectedPanel = Instantiate(_labelTogglePrefab, _selectedValuesParent);
+            ValueLabelHandler labelHandlerSelected = selectedPanel.GetComponent<ValueLabelHandler>();
+            labelHandlerSelected.SetLabelInfo(value, false);
+            _labelHandlers.Add(labelHandlerSelected);
+
+            labelHandlerSelected._selectButton.onClick.AddListener(() => RemoveSelectedValue(labelHandlerSelected));
         }
     }
 }


### PR DESCRIPTION
- Clan value selector no longer deletes selected values when trying to select more than 5.
- Created a check for minimum values selected. At least 3 clan values must be selected when trying to create a clan.
- Selected clan values can now be unselected by clicking on them in the selected values field. This is only possible when the clan value selection panel is open to avoid false positives.  
- Fixed scrollbar to start at the top instead of at the middle.