### PR TITLE
Renamed character stat Resistance to CharacterSize

### DIFF
--- a/Assets/Altzone/Scripts/Config/ScriptableObjects/GameSettings.cs
+++ b/Assets/Altzone/Scripts/Config/ScriptableObjects/GameSettings.cs
@@ -116,7 +116,7 @@ namespace Altzone.Scripts.Config.ScriptableObjects
         public PlayerActorBase _battlePrefab;
         [Range(0, 10)] public int _hp;
         [Range(0, 10)] public int _speed;
-        [Range(0, 10)] public int _resistance;
+        [Range(0, 10)] public int _characterSize;
         [Range(0, 10)] public int _attack;
         [Range(0, 10)] public int _defence;
 
@@ -126,7 +126,7 @@ namespace Altzone.Scripts.Config.ScriptableObjects
             _character = character;
             _hp = hp;
             _speed=Speed;
-            _resistance = Resistance;
+            _characterSize = Resistance;
             _attack = Attack;
             _defence = Defence;
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/BattleCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/BattleCharacter.cs
@@ -14,7 +14,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         public readonly string Name;
         public readonly float Hp;
         public readonly float Speed;
-        public readonly float Resistance;
+        public readonly float CharacterSize;
         public readonly float Attack;
         public readonly float Defence;
 
@@ -29,7 +29,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             Name = name;
             Hp = hp;
             Speed = speed;
-            Resistance = resistance;
+            CharacterSize = resistance;
             Attack = attack;
             Defence = defence;
         }
@@ -42,7 +42,7 @@ namespace Altzone.Scripts.Model.Poco.Game
                 customCharacter.Name,
                 customCharacter.Hp + characterClass.Hp,
                 customCharacter.Speed + characterClass.Speed,
-                customCharacter.Resistance + characterClass.Resistance,
+                customCharacter.CharacterSize + characterClass.CharacterSize,
                 customCharacter.Attack + characterClass.Attack,
                 customCharacter.Defence + characterClass.Defence);
         }
@@ -63,7 +63,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         public override string ToString()
         {
             return $"CustomCharacter: {CharacterID} : {Name}" +
-                   $", Hp: {Hp}, Speed: {Speed}, Resistance: {Resistance}, Attack: {Attack}, Defence: {Defence}";
+                   $", Hp: {Hp}, Speed: {Speed}, Resistance: {CharacterSize}, Attack: {Attack}, Defence: {Defence}";
         }
     }
 }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/CharacterClass.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/CharacterClass.cs
@@ -16,7 +16,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         [Unique] public string Name;
         public int Hp;
         public int Speed;
-        public int Resistance;
+        public int CharacterSize;
         public int Attack;
         public int Defence;
 
@@ -32,7 +32,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             Name = GetClassName(id);
             Hp = hp;
             Speed = speed;
-            Resistance = resistance;
+            CharacterSize = resistance;
             Attack = attack;
             Defence = defence;
         }
@@ -45,7 +45,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         public override string ToString()
         {
             return $"{nameof(Id)}: {Id}, {nameof(Name)}: {Name}" +
-                   $", {nameof(Speed)}: {Speed}, {nameof(Resistance)}: {Resistance}, {nameof(Attack)}: {Attack}, {nameof(Defence)}: {Defence}";
+                   $", {nameof(Speed)}: {Speed}, {nameof(CharacterSize)}: {CharacterSize}, {nameof(Attack)}: {Attack}, {nameof(Defence)}: {Defence}";
         }
 
         public static string GetClassName(CharacterClassID id)

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/BaseCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/BaseCharacter.cs
@@ -8,7 +8,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         None,
         Attack,
         Defence,
-        Resistance,
+        CharacterSize,
         Hp,
         Speed
     }
@@ -34,9 +34,9 @@ namespace Altzone.Scripts.Model.Poco.Game
         protected int _speed;
         protected int _defaultSpeed;
         protected ValueStrength _speedStrength = ValueStrength.None;
-        protected int _resistance;
-        protected int _defaultResistance;
-        protected ValueStrength _resistanceStrength = ValueStrength.None;
+        protected int _characterSize;
+        protected int _defaultCharacterSize;
+        protected ValueStrength _characterSizeStrength = ValueStrength.None;
         protected int _attack;
         protected int _defaultAttack;
         protected ValueStrength _attackStrength = ValueStrength.None;
@@ -52,8 +52,8 @@ namespace Altzone.Scripts.Model.Poco.Game
         public int DefaultHp { get => _defaultHp; }
         public int Speed { get => _speed;}
         public int DefaultSpeed { get => _defaultSpeed; }
-        public int Resistance { get => _resistance;}
-        public int DefaultResistance { get => _defaultResistance; }
+        public int CharacterSize { get => _characterSize;}
+        public int DefaultCharacterSize { get => _defaultCharacterSize; }
         public int Attack { get => _attack;}
         public int DefaultAttack { get => _defaultAttack; }
         public int Defence { get => _defence;}
@@ -70,7 +70,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _hp = _defaultHp;
             _attack = _defaultAttack;
             _defence = _defaultDefence;
-            _resistance = _defaultResistance;
+            _characterSize = _defaultCharacterSize;
             _speed = _defaultSpeed;
         }
 
@@ -86,7 +86,7 @@ namespace Altzone.Scripts.Model.Poco.Game
                 StatType.None       => (FP)(-1),
                 StatType.Attack     => GetAttackValue(level),
                 StatType.Defence    => GetDefenceValue(level),
-                StatType.Resistance => GetResistanceValue(level),
+                StatType.CharacterSize => GetCharacterSizeValue(level),
                 StatType.Hp         => GetHpValue(level),
                 StatType.Speed      => GetSpeedValue(level),
 
@@ -160,7 +160,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             };
         }
 
-        private static FP GetResistanceValue(int level)
+        private static FP GetCharacterSizeValue(int level)
         {
             return level switch
             {
@@ -269,8 +269,8 @@ namespace Altzone.Scripts.Model.Poco.Game
                     return GetSegmentAmount(nextLevel - character._defaultAttack) * GetStatSegmentPrice(character, type, nextLevel - character._defaultAttack);
                 case StatType.Defence:
                     return GetSegmentAmount(nextLevel - character._defaultDefence) * GetStatSegmentPrice(character, type, nextLevel - character._defaultDefence);
-                case StatType.Resistance:
-                    return GetSegmentAmount(nextLevel - character._defaultResistance) * GetStatSegmentPrice(character, type, nextLevel - character._defaultResistance);
+                case StatType.CharacterSize:
+                    return GetSegmentAmount(nextLevel - character._defaultCharacterSize) * GetStatSegmentPrice(character, type, nextLevel - character._defaultCharacterSize);
                 case StatType.Hp:
                     return GetSegmentAmount(nextLevel - character._defaultHp) * GetStatSegmentPrice(character, type, nextLevel - character._defaultHp);
                 case StatType.Speed:
@@ -288,8 +288,8 @@ namespace Altzone.Scripts.Model.Poco.Game
                     return GetStrengthMulti(character._attackStrength) * GetSegmentPrice(nextLevel - character._defaultAttack);
                 case StatType.Defence:
                     return GetStrengthMulti(character._defenceStrength) * GetSegmentPrice(nextLevel - character._defaultDefence);
-                case StatType.Resistance:
-                    return GetStrengthMulti(character._resistanceStrength) * GetSegmentPrice(nextLevel - character._defaultResistance);
+                case StatType.CharacterSize:
+                    return GetStrengthMulti(character._characterSizeStrength) * GetSegmentPrice(nextLevel - character._defaultCharacterSize);
                 case StatType.Hp:
                     return GetStrengthMulti(character._hpStrength) * GetSegmentPrice(nextLevel - character._defaultHp);
                 case StatType.Speed:
@@ -362,8 +362,8 @@ namespace Altzone.Scripts.Model.Poco.Game
                 case StatType.Defence:
                     nextLevel = nextLevel - character._defaultDefence;
                     break;
-                case StatType.Resistance:
-                    nextLevel = nextLevel - character._defaultResistance;
+                case StatType.CharacterSize:
+                    nextLevel = nextLevel - character._defaultCharacterSize;
                     break;
                 case StatType.Hp:
                     nextLevel = nextLevel - character._defaultHp;

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Confluent/ConfluentClassCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Confluent/ConfluentClassCharacter.cs
@@ -14,7 +14,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         protected ConfluentClassCharacter()
         {
             _attackStrength = ValueStrength.VeryWeak;
-            _resistanceStrength = ValueStrength.Strong;
+            _characterSizeStrength = ValueStrength.Strong;
             _hpStrength = ValueStrength.SemiWeak;
             _defenceStrength = ValueStrength.Strong;
             _speedStrength = ValueStrength.Medium;

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Confluent/SoulSistersCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Confluent/SoulSistersCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 2;
             _defaultDefence = 11;
             _defaultHp = 2;
-            _defaultResistance = 12;
+            _defaultCharacterSize = 12;
             _defaultSpeed = 2;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Desentisitizer/BodybuilderCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Desentisitizer/BodybuilderCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 6;
             _defaultDefence = 12;
             _defaultHp = 1;
-            _defaultResistance = 8;
+            _defaultCharacterSize = 8;
             _defaultSpeed = 3;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Desentisitizer/DesentisitizerClassCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Desentisitizer/DesentisitizerClassCharacter.cs
@@ -14,7 +14,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         protected DesentisitizerClassCharacter()
         {
             _attackStrength = ValueStrength.Strong;
-            _resistanceStrength = ValueStrength.Medium;
+            _characterSizeStrength = ValueStrength.Medium;
             _hpStrength = ValueStrength.VeryWeak;
             _defenceStrength = ValueStrength.VeryStrong;
             _speedStrength = ValueStrength.Weak;

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Desentisitizer/RacistCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Desentisitizer/RacistCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 6;
             _defaultDefence = 12;
             _defaultHp = 1;
-            _defaultResistance = 8;
+            _defaultCharacterSize = 8;
             _defaultSpeed = 3;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Intellectualizer/IntellectualizerClassCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Intellectualizer/IntellectualizerClassCharacter.cs
@@ -14,7 +14,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         protected IntellectualizerClassCharacter()
         {
             _attackStrength = ValueStrength.Medium;
-            _resistanceStrength = ValueStrength.Weak;
+            _characterSizeStrength = ValueStrength.Weak;
             _hpStrength = ValueStrength.Medium;
             _defenceStrength = ValueStrength.SemiWeak;
             _speedStrength = ValueStrength.SemiWeak;

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Intellectualizer/ResearcherCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Intellectualizer/ResearcherCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 10;
             _defaultDefence = 3;
             _defaultHp = 8;
-            _defaultResistance = 8;
+            _defaultCharacterSize = 8;
             _defaultSpeed = 6;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Obedient/ObedientClassCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Obedient/ObedientClassCharacter.cs
@@ -14,7 +14,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         protected ObedientClassCharacter()
         {
             _attackStrength = ValueStrength.None;
-            _resistanceStrength = ValueStrength.None;
+            _characterSizeStrength = ValueStrength.None;
             _hpStrength = ValueStrength.None;
             _defenceStrength = ValueStrength.None;
             _speedStrength = ValueStrength.None;

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Obedient/PreacherCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Obedient/PreacherCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 10;
             _defaultDefence = 10;
             _defaultHp = 10;
-            _defaultResistance = 10;
+            _defaultCharacterSize = 10;
             _defaultSpeed = 10;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Projector/GrafitiartistCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Projector/GrafitiartistCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 7;
             _defaultDefence = 10;
             _defaultHp = 3;
-            _defaultResistance = 8;
+            _defaultCharacterSize = 8;
             _defaultSpeed = 4;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Projector/ProjectorClassCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Projector/ProjectorClassCharacter.cs
@@ -14,7 +14,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         protected ProjectorClassCharacter()
         {
             _attackStrength = ValueStrength.SemiStrong;
-            _resistanceStrength = ValueStrength.Weak;
+            _characterSizeStrength = ValueStrength.Weak;
             _hpStrength = ValueStrength.SemiWeak;
             _defenceStrength = ValueStrength.Medium;
             _speedStrength = ValueStrength.Medium;

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Retroflector/AlcoholicCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Retroflector/AlcoholicCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 9;
             _defaultDefence = 8;
             _defaultHp = 1;
-            _defaultResistance = 10;
+            _defaultCharacterSize = 10;
             _defaultSpeed = 5;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Retroflector/OvereaterCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Retroflector/OvereaterCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 6;
             _defaultDefence = 8;
             _defaultHp = 4;
-            _defaultResistance = 12;
+            _defaultCharacterSize = 12;
             _defaultSpeed = 3;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Retroflector/RetroflectorClassCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Retroflector/RetroflectorClassCharacter.cs
@@ -14,7 +14,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         protected RetroflectorClassCharacter()
         {
             _attackStrength = ValueStrength.SemiWeak;
-            _resistanceStrength = ValueStrength.VeryStrong;
+            _characterSizeStrength = ValueStrength.VeryStrong;
             _hpStrength = ValueStrength.SemiStrong;
             _defenceStrength = ValueStrength.Strong;
             _speedStrength = ValueStrength.Weak;

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Trickster/ComedianCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Trickster/ComedianCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 8;
             _defaultDefence = 4;
             _defaultHp = 2;
-            _defaultResistance = 4;
+            _defaultCharacterSize = 4;
             _defaultSpeed = 11;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Trickster/ConmanCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Trickster/ConmanCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             _defaultAttack = 7;
             _defaultDefence = 5;
             _defaultHp = 2;
-            _defaultResistance = 6;
+            _defaultCharacterSize = 6;
             _defaultSpeed = 10;
             InitializeValues();
         }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Trickster/TricksterClassCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/Characters/Trickster/TricksterClassCharacter.cs
@@ -12,7 +12,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         protected TricksterClassCharacter()
         {
             _attackStrength = ValueStrength.SemiWeak;
-            _resistanceStrength = ValueStrength.Weak;
+            _characterSizeStrength = ValueStrength.Weak;
             _hpStrength = ValueStrength.Medium;
             _defenceStrength = ValueStrength.VeryWeak;
             _speedStrength = ValueStrength.Strong;

--- a/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
@@ -36,8 +36,8 @@ namespace Altzone.Scripts.Model.Poco.Game
         public int HpSegmentCount;
         public int Speed;
         public int SpeedSegmentCount;
-        public int Resistance;
-        public int ResistanceSegmentCount;
+        public int CharacterSize;
+        public int CharaacterSizeSegmentCount;
         public int Attack;
         public int AttackSegmentCount;
         public int Defence;
@@ -53,7 +53,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             Hp = hp;
             HpSegmentCount = 0;
             Speed = speed;
-            Resistance = resistance;
+            CharacterSize = resistance;
             Attack = attack;
             Defence = defence;
         }
@@ -68,8 +68,8 @@ namespace Altzone.Scripts.Model.Poco.Game
             HpSegmentCount = 0;
             Speed = character.Speed;
             SpeedSegmentCount = 0;
-            Resistance = character.Resistance;
-            ResistanceSegmentCount = 0;
+            CharacterSize = character.CharacterSize;
+            CharaacterSizeSegmentCount = 0;
             Attack = character.Attack;
             AttackSegmentCount = 0;
             Defence = character.Defence;
@@ -106,8 +106,8 @@ namespace Altzone.Scripts.Model.Poco.Game
             HpSegmentCount = 0;
             Speed = character.speed;
             SpeedSegmentCount = 0;
-            Resistance = character.resistance;
-            ResistanceSegmentCount = 0;
+            CharacterSize = character.size;
+            CharaacterSizeSegmentCount = 0;
             Attack = character.attack;
             AttackSegmentCount = 0;
             Defence = character.defence;
@@ -131,7 +131,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             return $"{nameof(Id)}: {Id}" +
                    $", {nameof(Name)}: {Name}" +
                    $", {nameof(CharacterBase)}: {CharacterBase}" +
-                   $", {nameof(Hp)}: {Hp}, {nameof(Speed)}: {Speed}, {nameof(Resistance)}: {Resistance}, {nameof(Attack)}: {Attack}, {nameof(Defence)}: {Defence}";
+                   $", {nameof(Hp)}: {Hp}, {nameof(Speed)}: {Speed}, {nameof(CharacterSize)}: {CharacterSize}, {nameof(Attack)}: {Attack}, {nameof(Defence)}: {Defence}";
         }
 
         public static string GetCharacterName(CharacterID id)
@@ -186,7 +186,7 @@ namespace Altzone.Scripts.Model.Poco.Game
                     break;
                 case StatType.Defence:
                     break;
-                case StatType.Resistance:
+                case StatType.CharacterSize:
                     break;
                 case StatType.Hp:
                     break;
@@ -208,8 +208,8 @@ namespace Altzone.Scripts.Model.Poco.Game
                     return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Attack + 1) * (BaseCharacter.GetSegmentAmount(_characterBase, statType, Attack + 1)- AttackSegmentCount);
                 case StatType.Defence:
                     return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Defence + 1) * (BaseCharacter.GetSegmentAmount(_characterBase, statType, Defence + 1) - DefenceSegmentCount);
-                case StatType.Resistance:
-                    return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Resistance + 1) * (BaseCharacter.GetSegmentAmount(_characterBase, statType, Resistance + 1) - ResistanceSegmentCount);
+                case StatType.CharacterSize:
+                    return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, CharacterSize + 1) * (BaseCharacter.GetSegmentAmount(_characterBase, statType, CharacterSize + 1) - CharaacterSizeSegmentCount);
                 case StatType.Hp:
                     return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Hp + 1) * (BaseCharacter.GetSegmentAmount(_characterBase, statType, Hp + 1) - HpSegmentCount);
                 case StatType.Speed:
@@ -228,8 +228,8 @@ namespace Altzone.Scripts.Model.Poco.Game
                     return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Attack+1);
                 case StatType.Defence:
                     return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Defence+1);
-                case StatType.Resistance:
-                    return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Resistance+1);
+                case StatType.CharacterSize:
+                    return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, CharacterSize+1);
                 case StatType.Hp:
                     return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Hp+1);
                 case StatType.Speed:

--- a/Assets/Altzone/Scripts/Model/Poco/Game/DiamondType.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/DiamondType.cs
@@ -3,7 +3,7 @@ namespace Altzone.Scripts.Model.Poco.Game
     public enum DiamondType
     {
         DiamondSpeed,
-        DiamondResistance,
+        DiamondCharacterSize,
         DiamondAttack,
         DiamondHP
     }

--- a/Assets/Altzone/Scripts/Model/Poco/Game/ServerCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/ServerCharacter.cs
@@ -12,7 +12,7 @@ public class ServerCharacter
     public string characterId { get; set; }
     public string name { get; set; }
     public int speed { get; set; }
-    public int resistance { get; set; }
+    public int size { get; set; }
     public int attack { get; set; }
     public int defence { get; set; }
     public int hp { get; set; }
@@ -26,7 +26,7 @@ public class ServerCharacter
         characterId = ((int)character.Id).ToString();
         name = character.Name;
         speed = character.Speed;
-        resistance = character.Resistance;
+        size = character.CharacterSize;
         attack = character.Attack;
         defence = character.Defence;
         hp = character.Hp;
@@ -47,7 +47,7 @@ public class ServerCharacter
 
         name = CustomCharacter.GetCharacterName(id);
         speed = character.Speed;
-        resistance = character.Resistance;
+        size = character.CharacterSize;
         attack = character.Attack;
         defence = character.Defence;
         hp = character.Hp;

--- a/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
@@ -42,7 +42,7 @@ namespace Altzone.Scripts.Model.Poco.Player
         private List<CustomCharacter> _characterList;
 
         public int DiamondSpeed = 1000;
-        public int DiamondResistance = 1000;
+        public int DiamondCharacterSize = 1000;
         public int DiamondAttack = 1000;
         public int DiamondDefence = 1000;
         public int DiamondHP = 1000;

--- a/Assets/Altzone/Scripts/ModelV2/Internal/CharacterSpec.cs
+++ b/Assets/Altzone/Scripts/ModelV2/Internal/CharacterSpec.cs
@@ -61,7 +61,7 @@ namespace Altzone.Scripts.ModelV2.Internal
 
         [Header("Special Attributes")] public NumAttribute Hp;
         public NumAttribute Speed;
-        public NumAttribute Resistance;
+        public NumAttribute CharacterSize;
         public NumAttribute Attack;
         public NumAttribute Defence;
 

--- a/Assets/Altzone/Scripts/ModelV2/PlayerCharacterPrototype.cs
+++ b/Assets/Altzone/Scripts/ModelV2/PlayerCharacterPrototype.cs
@@ -30,7 +30,7 @@ namespace Altzone.Scripts.ModelV2
 
         public readonly SpecialAttribute Hp;
         public readonly SpecialAttribute Speed;
-        public readonly SpecialAttribute Resistance;
+        public readonly SpecialAttribute CharacterSize;
         public readonly SpecialAttribute Attack;
         public readonly SpecialAttribute Defence;
 
@@ -45,10 +45,10 @@ namespace Altzone.Scripts.ModelV2
                 _characterSpec.Hp.Level, _characterSpec.Hp.Coefficient);
             Speed = new SpecialAttribute((int)BaseCharacter.GetStatValue(StatType.Speed, _characterSpec.Speed.Level),
                 _characterSpec.Speed.Level, _characterSpec.Speed.Coefficient);
-            Resistance =
+            CharacterSize =
                 new SpecialAttribute(
-                    (int)BaseCharacter.GetStatValue(StatType.Resistance, _characterSpec.Resistance.Level),
-                    _characterSpec.Resistance.Level, _characterSpec.Resistance.Coefficient);
+                    (int)BaseCharacter.GetStatValue(StatType.CharacterSize, _characterSpec.CharacterSize.Level),
+                    _characterSpec.CharacterSize.Level, _characterSpec.CharacterSize.Coefficient);
             Attack = new SpecialAttribute(
                 (int)BaseCharacter.GetStatValue(StatType.Attack, _characterSpec.Attack.Level),
                 _characterSpec.Attack.Level, _characterSpec.Attack.Coefficient);

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -495,7 +495,7 @@ namespace Altzone.Scripts.Lobby
                     Hp         = BaseCharacter.GetStatValueFP(StatType.Hp, character.Hp),
                     Attack     = BaseCharacter.GetStatValueFP(StatType.Attack, character.Attack),
                     Defence    = BaseCharacter.GetStatValueFP(StatType.Defence, character.Defence),
-                    Resistance = BaseCharacter.GetStatValueFP(StatType.Resistance, character.Resistance),
+                    CharacterSize = BaseCharacter.GetStatValueFP(StatType.CharacterSize, character.CharacterSize),
                     Speed      = BaseCharacter.GetStatValueFP(StatType.Speed, character.Speed)
                 };
             }

--- a/Assets/Battle1/Scripts/Battle/Game/BattleUIController.cs
+++ b/Assets/Battle1/Scripts/Battle/Game/BattleUIController.cs
@@ -44,7 +44,7 @@ namespace Battle1.Scripts.Battle.Game
             return diamondType switch
             {
                 DiamondType.DiamondSpeed      => teamDiamonds[0],
-                DiamondType.DiamondResistance => teamDiamonds[1],
+                DiamondType.DiamondCharacterSize => teamDiamonds[1],
                 DiamondType.DiamondAttack     => teamDiamonds[2],
                 DiamondType.DiamondHP         => teamDiamonds[3],
                 _ => null,

--- a/Assets/Battle1/Scripts/Battle/Game/DiamondController.cs
+++ b/Assets/Battle1/Scripts/Battle/Game/DiamondController.cs
@@ -92,7 +92,7 @@ namespace Battle1.Scripts.Battle.Game
             return diamondType switch
             {
                 DiamondType.DiamondSpeed      => _diamondDataArray[0],
-                DiamondType.DiamondResistance => _diamondDataArray[1],
+                DiamondType.DiamondCharacterSize => _diamondDataArray[1],
                 DiamondType.DiamondAttack     => _diamondDataArray[2],
                 DiamondType.DiamondHP         => _diamondDataArray[3],
                 _ => null,

--- a/Assets/Battle1/Scripts/Battle/PhotonBattle.cs
+++ b/Assets/Battle1/Scripts/Battle/PhotonBattle.cs
@@ -81,7 +81,7 @@ namespace Battle1.Scripts.Battle
                 "placeholder",
                 BaseCharacter.GetStatValue(StatType.Hp, characterStats[0]),
                 BaseCharacter.GetStatValue(StatType.Speed, characterStats[1]),
-                BaseCharacter.GetStatValue(StatType.Resistance, characterStats[2]),
+                BaseCharacter.GetStatValue(StatType.CharacterSize, characterStats[2]),
                 BaseCharacter.GetStatValue(StatType.Attack, characterStats[3]),
                 BaseCharacter.GetStatValue(StatType.Defence, characterStats[4])
             );

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/PieChartPreview.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/PieChartPreview.cs
@@ -29,7 +29,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterGallery
             _impactForceColor = _referenceSheet.GetColor(StatType.Attack);
             _healthPointsColor = _referenceSheet.GetColor(StatType.Hp);
             _defenceColor = _referenceSheet.GetColor(StatType.Defence);
-            _characterSizeColor = _referenceSheet.GetColor(StatType.Resistance);
+            _characterSizeColor = _referenceSheet.GetColor(StatType.CharacterSize);
             _speedColor = _referenceSheet.GetColor(StatType.Speed);
             _defaultColor = _referenceSheet.GetColor(StatType.None);
             _circleSprite = _referenceSheet.GetCircleSprite();
@@ -77,7 +77,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterGallery
             int impactForce = customCharacter.Attack;
             int healthPoints = customCharacter.Hp;
             int defence = customCharacter.Defence;
-            int characterSize = customCharacter.Resistance;
+            int characterSize = customCharacter.CharacterSize;
             int speed = customCharacter.Speed;
 
             // Arrange stats

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/PieChart.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/PieChart.cs
@@ -46,8 +46,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
             _defenceColor = _referenceSheet.GetColor(StatType.Defence);
             _defenceAltColor = _referenceSheet.GetAlternativeColor(StatType.Defence);
 
-            _characterSizeColor = _referenceSheet.GetColor(StatType.Resistance);
-            _characterSizeAltColor = _referenceSheet.GetAlternativeColor(StatType.Resistance);
+            _characterSizeColor = _referenceSheet.GetColor(StatType.CharacterSize);
+            _characterSizeAltColor = _referenceSheet.GetAlternativeColor(StatType.CharacterSize);
 
             _speedColor = _referenceSheet.GetColor(StatType.Speed);
             _speedAltColor = _referenceSheet.GetAlternativeColor(StatType.Speed);
@@ -85,14 +85,14 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
             int impactForce = _controller.GetStat(StatType.Attack);
             int healthPoints = _controller.GetStat(StatType.Hp);
             int defence = _controller.GetStat(StatType.Defence);
-            int characterSize = _controller.GetStat(StatType.Resistance);
+            int characterSize = _controller.GetStat(StatType.CharacterSize);
             int speed = _controller.GetStat(StatType.Speed);
 
             // Get base stats
             int impactForceBase = _controller.GetBaseStat(StatType.Attack);
             int healthPointsBase = _controller.GetBaseStat(StatType.Hp);
             int defenceBase = _controller.GetBaseStat(StatType.Defence);
-            int characterSizeBase = _controller.GetBaseStat(StatType.Resistance);
+            int characterSizeBase = _controller.GetBaseStat(StatType.CharacterSize);
             int speedBase = _controller.GetBaseStat(StatType.Speed);
 
             // Arrange stats

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatUpdatePopUp.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatUpdatePopUp.cs
@@ -65,8 +65,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                 case StatType.Defence:
                     statInfo = _statsReference.GetStatInfo(StatType.Defence);
                     break;
-                case StatType.Resistance:
-                    statInfo = _statsReference.GetStatInfo(StatType.Resistance);
+                case StatType.CharacterSize:
+                    statInfo = _statsReference.GetStatInfo(StatType.CharacterSize);
                     break;
                 case StatType.Hp:
                     statInfo = _statsReference.GetStatInfo(StatType.Hp);

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsPanel.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsPanel.cs
@@ -48,7 +48,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                 _attackText.text = _controller.GetStat(StatType.Attack).ToString();
                 _hpText.text = _controller.GetStat(StatType.Hp).ToString();
                 _defenceText.text = _controller.GetStat(StatType.Defence).ToString();
-                _charSizeText.text = _controller.GetStat(StatType.Resistance).ToString();
+                _charSizeText.text = _controller.GetStat(StatType.CharacterSize).ToString();
                 _speedText.text = _controller.GetStat(StatType.Speed).ToString();
             }
             else
@@ -64,8 +64,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                     case StatType.Defence:
                         _defenceText.text = _controller.GetStat(StatType.Defence).ToString();
                         break;
-                    case StatType.Resistance:
-                        _charSizeText.text = _controller.GetStat(StatType.Resistance).ToString();
+                    case StatType.CharacterSize:
+                        _charSizeText.text = _controller.GetStat(StatType.CharacterSize).ToString();
                         break;
                     case StatType.Speed:
                         _speedText.text = _controller.GetStat(StatType.Speed).ToString();

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
@@ -254,8 +254,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                     return _currentCharacter.Attack;
                 case StatType.Hp:
                     return _currentCharacter.Hp;
-                case StatType.Resistance:
-                    return _currentCharacter.Resistance;
+                case StatType.CharacterSize:
+                    return _currentCharacter.CharacterSize;
                 case StatType.Defence:
                     return _currentCharacter.Defence;
             }
@@ -280,8 +280,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                     return _currentCharacter.CharacterBase.DefaultAttack;
                 case StatType.Hp:
                     return _currentCharacter.CharacterBase.DefaultHp;
-                case StatType.Resistance:
-                    return _currentCharacter.CharacterBase.DefaultResistance;
+                case StatType.CharacterSize:
+                    return _currentCharacter.CharacterBase.DefaultCharacterSize;
                 case StatType.Defence:
                     return _currentCharacter.CharacterBase.DefaultDefence;
             }
@@ -343,8 +343,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                         case StatType.Hp:
                             _currentCharacter.Hp++;
                             break;
-                        case StatType.Resistance:
-                            _currentCharacter.Resistance++;
+                        case StatType.CharacterSize:
+                            _currentCharacter.CharacterSize++;
                             break;
                         case StatType.Defence:
                             _currentCharacter.Defence++;
@@ -407,8 +407,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                         case StatType.Hp:
                             _currentCharacter.Hp--;
                             break;
-                        case StatType.Resistance:
-                            _currentCharacter.Resistance--;
+                        case StatType.CharacterSize:
+                            _currentCharacter.CharacterSize--;
                             break;
                         case StatType.Defence:
                             _currentCharacter.Defence--;
@@ -431,14 +431,14 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         // Get all character stats combined
         private int GetStatsCombined()
         {
-            return _currentCharacter.Speed + _currentCharacter.Resistance + _currentCharacter.Attack + _currentCharacter.Defence + _currentCharacter.Hp;
+            return _currentCharacter.Speed + _currentCharacter.CharacterSize + _currentCharacter.Attack + _currentCharacter.Defence + _currentCharacter.Hp;
         }
 
 
         // Get all character base stats combined
         private int GetBaseStatsCombined()
         {
-            return _currentCharacter.CharacterBase.DefaultSpeed + _currentCharacter.CharacterBase.DefaultResistance + _currentCharacter.CharacterBase.DefaultAttack + _currentCharacter.CharacterBase.DefaultDefence + _currentCharacter.CharacterBase.DefaultHp; 
+            return _currentCharacter.CharacterBase.DefaultSpeed + _currentCharacter.CharacterBase.DefaultCharacterSize + _currentCharacter.CharacterBase.DefaultAttack + _currentCharacter.CharacterBase.DefaultDefence + _currentCharacter.CharacterBase.DefaultHp; 
         }
 
 

--- a/Assets/MenuUi/Scripts/Lobby/InRoom/RoomSetupManager.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InRoom/RoomSetupManager.cs
@@ -137,7 +137,7 @@ namespace MenuUI.Scripts.Lobby.InRoom
                     characterIds[i] = (int)battleCharacter[i].Id;
                     characterStats[i * 5] = battleCharacter[i].Hp;
                     characterStats[i * 5 + 1] = battleCharacter[i].Speed;
-                    characterStats[i * 5 + 2] = battleCharacter[i].Resistance;
+                    characterStats[i * 5 + 2] = battleCharacter[i].CharacterSize;
                     characterStats[i * 5 + 3] = battleCharacter[i].Attack;
                     characterStats[i * 5 + 4] = battleCharacter[i].Defence;
                     selectedCharacters.Add(battleCharacter[i]);

--- a/Assets/MenuUi/Scripts/ReferenceSheets/PiechartReference.cs
+++ b/Assets/MenuUi/Scripts/ReferenceSheets/PiechartReference.cs
@@ -45,7 +45,7 @@ namespace MenuUi.Scripts.DefenceScreen
                     return _defenceColor;
                 case StatType.Hp:
                     return _healthPointsColor;
-                case StatType.Resistance:
+                case StatType.CharacterSize:
                     return _characterSizeColor;
                 case StatType.Speed:
                     return _speedColor;
@@ -71,7 +71,7 @@ namespace MenuUi.Scripts.DefenceScreen
                     return _defenceAlternativeColor;
                 case StatType.Hp:
                     return _healthPointsAlternativeColor;
-                case StatType.Resistance:
+                case StatType.CharacterSize:
                     return _characterSizeAlternativeColor;
                 case StatType.Speed:
                     return _speedAlternativeColor;

--- a/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
+++ b/Assets/QuantumUser/Simulation/BattleCharacterBase.cs
@@ -11,7 +11,7 @@ namespace Quantum
 
         public FP Hp;
         public FP Speed;
-        public FP Resistance;
+        public FP CharacterSize;
         public FP Attack;
         public FP Defence;
     }


### PR DESCRIPTION
- Renamed character stat Resistance to CharacterSize everywhere in code.
- In ServerCharacter.cs renaming resistance to size fixes the bug where character size was not correctly fetched from the server for custom characters.