### PR TITLE
Locking unowned characters in gallery and saving custom character to server, small fixes

### DIFF
--- a/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
@@ -37,7 +37,7 @@ namespace Altzone.Scripts.Model.Poco.Game
         public int Speed;
         public int SpeedSegmentCount;
         public int CharacterSize;
-        public int CharaacterSizeSegmentCount;
+        public int CharacterSizeSegmentCount;
         public int Attack;
         public int AttackSegmentCount;
         public int Defence;
@@ -74,7 +74,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             Speed = character.Speed;
             SpeedSegmentCount = 0;
             CharacterSize = character.CharacterSize;
-            CharaacterSizeSegmentCount = 0;
+            CharacterSizeSegmentCount = 0;
             Attack = character.Attack;
             AttackSegmentCount = 0;
             Defence = character.Defence;
@@ -112,7 +112,7 @@ namespace Altzone.Scripts.Model.Poco.Game
             Speed = character.speed;
             SpeedSegmentCount = 0;
             CharacterSize = character.size;
-            CharaacterSizeSegmentCount = 0;
+            CharacterSizeSegmentCount = 0;
             Attack = character.attack;
             AttackSegmentCount = 0;
             Defence = character.defence;
@@ -214,7 +214,7 @@ namespace Altzone.Scripts.Model.Poco.Game
                 case StatType.Defence:
                     return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Defence + 1) * (BaseCharacter.GetSegmentAmount(_characterBase, statType, Defence + 1) - DefenceSegmentCount);
                 case StatType.CharacterSize:
-                    return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, CharacterSize + 1) * (BaseCharacter.GetSegmentAmount(_characterBase, statType, CharacterSize + 1) - CharaacterSizeSegmentCount);
+                    return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, CharacterSize + 1) * (BaseCharacter.GetSegmentAmount(_characterBase, statType, CharacterSize + 1) - CharacterSizeSegmentCount);
                 case StatType.Hp:
                     return BaseCharacter.GetStatSegmentPrice(_characterBase, statType, Hp + 1) * (BaseCharacter.GetSegmentAmount(_characterBase, statType, Hp + 1) - HpSegmentCount);
                 case StatType.Speed:

--- a/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
@@ -43,6 +43,11 @@ namespace Altzone.Scripts.Model.Poco.Game
         public int Defence;
         public int DefenceSegmentCount;
 
+        public const int STATMAXCOMBINED = 50;
+        public const int STATMAXLEVEL = 24;
+        public const int STATMINLEVEL = 1;
+        public const int STATMAXPLAYERINCREASE = 10;
+
         public CustomCharacter(CharacterID id, int hp, int speed, int resistance, int attack, int defence)
         {
             //Assert.AreNotEqual(CharacterID.None, id);

--- a/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
@@ -129,6 +129,7 @@ namespace Altzone.Scripts.Model.Poco.Player
         {
             if (character == null) return;
 
+            bool characterInCharacterList = false;
             int i = 0;
             foreach (CustomCharacter item in _characterList)
             {
@@ -139,9 +140,11 @@ namespace Altzone.Scripts.Model.Poco.Player
                 }
 
                 _characterList[i] = character;
+                characterInCharacterList = true;
                 break;
             }
             Patch();
+            if (characterInCharacterList) ServerManager.Instance.StartUpdatingCustomCharacterToServer(character);
         }
 
 

--- a/Assets/Altzone/Scripts/ServerManager.cs
+++ b/Assets/Altzone/Scripts/ServerManager.cs
@@ -873,17 +873,6 @@ public class ServerManager : MonoBehaviour
     /// <param name="character">The CustomCharacter which to save to server.</param>
     public void StartUpdatingCustomCharacterToServer(CustomCharacter character)
     {
-        //DataStore store = Storefront.Get();
-
-        //ReadOnlyCollection<BaseCharacter> allItems = null;
-        //store.GetAllBaseCharacterYield(result => allItems = result);
-
-        //BaseCharacter baseCharacter = allItems.FirstOrDefault(c => c.Id == CharacterID.Artist);
-
-        //CustomCharacter gaya = new CustomCharacter(baseCharacter);
-
-        //gaya.ServerID = "67ac680ddcf5fa7ee819448d";
-
         StartCoroutine(UpdateCustomCharactersToServer(character, success =>
         {
             if (!success) Debug.LogError("Failed to save custom character to server!");

--- a/Assets/Altzone/Scripts/ServerManager.cs
+++ b/Assets/Altzone/Scripts/ServerManager.cs
@@ -867,6 +867,29 @@ public class ServerManager : MonoBehaviour
         }));
     }
 
+    /// <summary>
+    /// Starts a coroutine for updating custom character to server, since PlayerData where it's called isn't inherited from MonoBehaviour.
+    /// </summary>
+    /// <param name="character">The CustomCharacter which to save to server.</param>
+    public void StartUpdatingCustomCharacterToServer(CustomCharacter character)
+    {
+        //DataStore store = Storefront.Get();
+
+        //ReadOnlyCollection<BaseCharacter> allItems = null;
+        //store.GetAllBaseCharacterYield(result => allItems = result);
+
+        //BaseCharacter baseCharacter = allItems.FirstOrDefault(c => c.Id == CharacterID.Artist);
+
+        //CustomCharacter gaya = new CustomCharacter(baseCharacter);
+
+        //gaya.ServerID = "67ac680ddcf5fa7ee819448d";
+
+        StartCoroutine(UpdateCustomCharactersToServer(character, success =>
+        {
+            if (!success) Debug.LogError("Failed to save custom character to server!");
+        }));
+    }
+
     public IEnumerator UpdateCustomCharactersToServer(CustomCharacter character, Action<bool> callback)
     {
         if (character == null)
@@ -879,7 +902,7 @@ public class ServerManager : MonoBehaviour
 
         string body = JObject.FromObject(serverCharacter).ToString();
 
-        //Debug.Log(player);
+        Debug.LogWarning(body);
 
         yield return StartCoroutine(WebRequests.Put(DEVADDRESS + "customCharacter/", body, AccessToken, request =>
         {

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/GalleryCharacter.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/GalleryCharacter.prefab
@@ -38,6 +38,7 @@ RectTransform:
   - {fileID: 2640895224935226749}
   - {fileID: 9111877443963403600}
   - {fileID: 3813463039263476049}
+  - {fileID: 6652624679894425140}
   - {fileID: 3363226798787773503}
   - {fileID: 1497434569553465059}
   m_Father: {fileID: 0}
@@ -115,10 +116,10 @@ MonoBehaviour:
   _backgroundImage: {fileID: 1698316617930894126}
   _contentsImage: {fileID: 1436819896680901654}
   _contentsDetailsImage: {fileID: 5093630027183570878}
+  _lockImage: {fileID: 696824818084956741}
   _characterNameText: {fileID: 3511939312560207162}
   _aspectRatioFitter: {fileID: 365475382052161339}
   _piechartPreview: {fileID: 599868788555485942}
-  _removeButton: {fileID: 0}
 --- !u!114 &644753131678271565
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -457,6 +458,81 @@ MonoBehaviour:
   m_Sprite: {fileID: 21300000, guid: 06d0c68900f085c499074948130206c3, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6946680164202391572
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6652624679894425140}
+  - component: {fileID: 7577167431987420442}
+  - component: {fileID: 696824818084956741}
+  m_Layer: 5
+  m_Name: LockImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6652624679894425140
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6946680164202391572}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8755021714922067558}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.3, y: 0.1}
+  m_AnchorMax: {x: 0.7, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7577167431987420442
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6946680164202391572}
+  m_CullTransparentMesh: 1
+--- !u!114 &696824818084956741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6946680164202391572}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 71e4f36c084957447943ab9c40454a8d, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterStatsWindow/CharacterStatsPanel.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterStatsWindow/CharacterStatsPanel.prefab
@@ -525,81 +525,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &1636883977407704371
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5269626114538380871}
-  - component: {fileID: 4413017589872529724}
-  - component: {fileID: 2723795902907327401}
-  m_Layer: 5
-  m_Name: CenterImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &5269626114538380871
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1636883977407704371}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8098716958041391064}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.325, y: 0.325}
-  m_AnchorMax: {x: 0.675, y: 0.675}
-  m_AnchoredPosition: {x: 0, y: -5}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4413017589872529724
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1636883977407704371}
-  m_CullTransparentMesh: 1
---- !u!114 &2723795902907327401
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1636883977407704371}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.8078432, g: 0.23137257, b: 0.22352943, a: 1}
-  m_RaycastTarget: 0
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 811a546f9dc841e41bd0b7e1e8a4a15a, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1719116857912922061
 GameObject:
   m_ObjectHideFlags: 0
@@ -1271,6 +1196,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _controller: {fileID: 0}
   _characterImage: {fileID: 7974997585420314010}
+  _lockImage: {fileID: 4384712762890898633}
   _attackText: {fileID: 1045321615248787585}
   _hpText: {fileID: 4641588302065698436}
   _defenceText: {fileID: 3680906877321014546}
@@ -1555,6 +1481,81 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2926689153477280207
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8397465339346232296}
+  - component: {fileID: 271402833218587505}
+  - component: {fileID: 4384712762890898633}
+  m_Layer: 5
+  m_Name: LockImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8397465339346232296
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2926689153477280207}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8098716958041391064}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.3, y: 0.35}
+  m_AnchorMax: {x: 0.7, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -0.0000019073486}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &271402833218587505
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2926689153477280207}
+  m_CullTransparentMesh: 1
+--- !u!114 &4384712762890898633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2926689153477280207}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 71e4f36c084957447943ab9c40454a8d, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2943993027001619027
 GameObject:
   m_ObjectHideFlags: 0
@@ -2261,7 +2262,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1962866644636985388}
-  - {fileID: 5269626114538380871}
+  - {fileID: 8397465339346232296}
   m_Father: {fileID: 1338735798097026233}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.25, y: 0.3}
@@ -4547,6 +4548,11 @@ PrefabInstance:
     - target: {fileID: 8620236399698832103, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8620236399698832103, guid: 57890b7dbec8a984abb7d8148eefe9f6,
+        type: 3}
+      propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8620236399698832103, guid: 57890b7dbec8a984abb7d8148eefe9f6,

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/GalleryCharacter.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/GalleryCharacter.cs
@@ -6,12 +6,18 @@ using MenuUi.Scripts.DefenceScreen.CharacterGallery;
 
 namespace MenuUi.Scripts.CharacterGallery
 {
+    /// <summary>
+    /// Sets character gallery character's visual info to GalleryCharacter prefab.
+    /// GalleryCharacter prefabs are parented under CharacterInventorySlot prefabs.
+    /// Holds information about original inventory slot and has a method for returning this GalleryCharacter to its original slot
+    /// </summary>
     public class GalleryCharacter : MonoBehaviour, IGalleryCharacterData
     {
         [SerializeField] private Image _spriteImage;
         [SerializeField] private Image _backgroundImage;
         [SerializeField] private Image _contentsImage;
         [SerializeField] private Image _contentsDetailsImage;
+        [SerializeField] private Image _lockImage;
         [SerializeField] private TextMeshProUGUI _characterNameText;
         [SerializeField] private AspectRatioFitter _aspectRatioFitter;
         [SerializeField] private PieChartPreview _piechartPreview;
@@ -37,6 +43,15 @@ namespace MenuUi.Scripts.CharacterGallery
         }
 
 
+        /// <summary>
+        /// Initializes the visual and character slot info for this gallery character.
+        /// </summary>
+        /// <param name="sprite">The character sprite which to display.</param>
+        /// <param name="bgColor">The main color to display in the GalleryCharacter background.</param>
+        /// <param name="bgAltColor">The alternative color to display in the GalleryCharacter background.</param>
+        /// <param name="name">Character's name which to display.</param>
+        /// <param name="id">Character's ID.</param>
+        /// <param name="originalSlot">The original inventory slot for the GalleryCharacter prefab.</param>
         public void SetInfo(Sprite sprite, Color bgColor, Color bgAltColor, string name, CharacterID id, CharacterSlot originalSlot)
         {
             _spriteImage.sprite = sprite;
@@ -48,6 +63,9 @@ namespace MenuUi.Scripts.CharacterGallery
         }
 
 
+        /// <summary>
+        /// Set visual information and anchoring for when character is selected. (Placed to one of the top slots.)
+        /// </summary>
         public void SetSelectedVisuals()
         {
             _aspectRatioFitter.aspectRatio = 1;
@@ -61,9 +79,14 @@ namespace MenuUi.Scripts.CharacterGallery
 
             _contentsImage.gameObject.SetActive(false);
             _contentsDetailsImage.gameObject.SetActive(false);
+
+            _lockImage.gameObject.SetActive(false);
         }
 
 
+        /// <summary>
+        /// Set visual information and anchoring for when character is unselected. (Not in one of the top slots.)
+        /// </summary>
         public void SetUnselectedVisuals()
         {
             _aspectRatioFitter.aspectRatio = 0.6f;
@@ -76,6 +99,18 @@ namespace MenuUi.Scripts.CharacterGallery
 
             _contentsImage.gameObject.SetActive(true);
             _contentsDetailsImage.gameObject.SetActive(true);
+
+            _lockImage.gameObject.SetActive(false);
+        }
+
+
+        /// <summary>
+        /// Set visual information for when character is locked. (Not owned.)
+        /// </summary>
+        public void SetLockedVisuals()
+        {
+            SetUnselectedVisuals();
+            _lockImage.gameObject.SetActive(true);
         }
 
 
@@ -89,12 +124,18 @@ namespace MenuUi.Scripts.CharacterGallery
         }
 
 
+        /// <summary>
+        /// Enable being able to press the navi button which can open character stats edit window.
+        /// </summary>
         public void EnableNaviButton()
         {
-            _backgroundImage.raycastTarget = true;
+            _backgroundImage.raycastTarget = true; // the button depends on background image being raycast target.
         }
 
 
+        /// <summary>
+        /// Disable being able to press the navi button which can open character stats edit window.
+        /// </summary>
         public void DisableNaviButton()
         {
             _backgroundImage.raycastTarget = false;

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
@@ -11,7 +11,10 @@ using SignalBus = MenuUi.Scripts.Lobby.SignalBus;
 
 namespace MenuUi.Scripts.CharacterGallery
 {
-    public class ModelController : MonoBehaviour
+    /// <summary>
+    /// Controls the character gallery "model". Has methods for loading gallery characters and controlling the selected characters such as initiating the saving or selecting random characters.
+    /// </summary>
+    public class ModelController : AltMonoBehaviour
     {
         [SerializeField] private ModelView _view; //modelview script
 
@@ -57,27 +60,23 @@ namespace MenuUi.Scripts.CharacterGallery
 
         private IEnumerator Load()
         {
-            Debug.Log("Start");
             _view.Reset();
             yield return new WaitUntil(() => _view.IsReady);
-            var gameConfig = GameConfig.Get();
-            var playerSettings = gameConfig.PlayerSettings;
-            var playerGuid = playerSettings.PlayerGuid;
-            var store = Storefront.Get();
-            store.GetPlayerData(playerGuid, playerData =>
+
+            StartCoroutine(GetPlayerData(playerData =>
             {
                 _playerData = playerData;
-                var currentCharacterId = playerData.SelectedCharacterIds;
-                int[] characterId = new int[3];
-                for (int i = 0; i < currentCharacterId.Length; i++)
+                var selectedCharacterIds = playerData.SelectedCharacterIds;
+                int[] characterIds = new int[3];
+                for (int i = 0; i < selectedCharacterIds.Length; i++)
                 {
-                    characterId[i] = _playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == currentCharacterId[i])== null ? 0 : (int)_playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == currentCharacterId[i]).Id;
+                    characterIds[i] = _playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == selectedCharacterIds[i]) == null ? 0 : (int)_playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == selectedCharacterIds[i]).Id;
                 }
                 var characters = playerData.CustomCharacters.ToList();
                 characters.Sort((a, b) => a.Id.CompareTo(b.Id));
                 // Set characters in the ModelView
-                _view.SetCharacters(characters, characterId);
-            });
+                _view.SetCharacters(characters, characterIds);
+            }));
         }
 
 

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
@@ -108,7 +108,9 @@ namespace MenuUi.Scripts.CharacterGallery
             var characters = _playerData.CustomCharacters.ToList();
             characters.Sort((a, b) => a.Id.CompareTo(b.Id));
 
-            for (int i = 0; i < 3; i++)
+            if (characters.Count < _playerData.SelectedCharacterIds.Length) return;
+
+            for (int i = 0; i < _playerData.SelectedCharacterIds.Length; i++)
             {
                 if (string.IsNullOrEmpty(_playerData.SelectedCharacterIds[i]) || _playerData.SelectedCharacterIds[i] == "0")
                 {

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
@@ -88,15 +88,15 @@ namespace MenuUi.Scripts.CharacterGallery
             if (newServerId == null)
             {
                 _playerData.SelectedCharacterIds[slot] = "0";
-                return;
             }
 
             if (newServerId != _playerData.SelectedCharacterIds[slot])
             {
                 _playerData.SelectedCharacterIds[slot] = newServerId;
-                var store = Storefront.Get();
-                store.SavePlayerData(_playerData, null);
             }
+
+            var store = Storefront.Get();
+            store.SavePlayerData(_playerData, null);
         }
 
 

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/PieChartPreview.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/PieChartPreview.cs
@@ -91,7 +91,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterGallery
             };
 
             // Create slices
-            int maxCombinedStatLevel = 50; // TODO: replace this with reference to a constant which is defined somewhere
+            int maxCombinedStatLevel = CustomCharacter.STATMAXCOMBINED;
             float oneLevelFillAmount = 1.0f / maxCombinedStatLevel;
             float currentSliceFill = 1.0f;
             

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/SlotBase.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/SlotBase.cs
@@ -2,10 +2,15 @@ using UnityEngine;
 
 namespace MenuUi.Scripts.CharacterGallery
 {
+    /// <summary>
+    /// Base class for CharacterInventorySlot and SelectedCharacterInventorySlot. Has methods related to setting slot selectable.
+    /// </summary>
     public class SlotBase : MonoBehaviour
     {
         [SerializeField] private Animator _animator;
         [SerializeField] private GameObject _selectButton;
+
+        [HideInInspector] public bool IsLocked = false;
 
         public delegate void CharacterSelectedHandler(SlotBase slot);
         public CharacterSelectedHandler OnCharacterSelected;
@@ -18,10 +23,12 @@ namespace MenuUi.Scripts.CharacterGallery
         public void SetSelectable(bool selectable)
         {
             _selectButton.SetActive(selectable);
+
             GalleryCharacter galleryCharacter = GetComponentInChildren<GalleryCharacter>();
-            if (galleryCharacter != null && selectable) // play selectable animation if there is a gallery character child
+
+            if (galleryCharacter != null && selectable)
             {
-                PlaySelectableAnimation();
+                if (!IsLocked) PlaySelectableAnimation(); // only play selectable animation if slot isn't locked
                 galleryCharacter.DisableNaviButton();
             }
             else if (galleryCharacter != null && !selectable)

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/PieChart.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/PieChart.cs
@@ -10,8 +10,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
     {
         [SerializeField] private StatsWindowController _controller;
         [SerializeField] private PiechartReference _referenceSheet;
-        [SerializeField] private int _sliceAmount;
 
+        private int _sliceAmount;
 
         private Color _impactForceColor;
         private Color _impactForceAltColor;
@@ -57,6 +57,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
             _circleSprite = _referenceSheet.GetCircleSprite();
             _circlePatternedSprite = _referenceSheet.GetPatternedSprite();
+
+            _sliceAmount = CustomCharacter.STATMAXCOMBINED;
         }
 
 

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatUpdatePopUp.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatUpdatePopUp.cs
@@ -6,6 +6,9 @@ using UnityEngine.UI;
 
 namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 {
+    /// <summary>
+    /// Controls visual functionality of StatUpdatePopUp.
+    /// </summary>
     public class StatUpdatePopUp : MonoBehaviour
     {
         [SerializeField] private StatsWindowController _controller;
@@ -45,6 +48,13 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         public void OpenPopUp(int statType)
         {
             StatInfo statInfo = null;
+
+            if (_controller.IsCurrentCharacterLocked())
+            {
+                SignalBus.OnChangePopupInfoSignal("Et voi muokata lukittua hahmoa.");
+                ClosePopUp();
+                return;
+            }
 
             if (_controller.GetCurrentCharacterClass() == CharacterClassID.Obedient) // obedient characters can't be modified
             {

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsPanel.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsPanel.cs
@@ -5,10 +5,14 @@ using Altzone.Scripts.Model.Poco.Game;
 
 namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 {
+    /// <summary>
+    /// Controls visual functionality of CharacterStatsPanel.
+    /// </summary>
     public class StatsPanel : MonoBehaviour
     {
         [SerializeField] private StatsWindowController _controller;
         [SerializeField] private Image _characterImage;
+        [SerializeField] private Image _lockImage;
         [SerializeField] private TMP_Text _attackText;
         [SerializeField] private TMP_Text _hpText;
         [SerializeField] private TMP_Text _defenceText;
@@ -21,6 +25,15 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
             SetStatButtonTexts();
 
             _controller.OnStatUpdated += SetStatButtonTexts;
+
+            if(_controller.IsCurrentCharacterLocked())
+            {
+                _lockImage.gameObject.SetActive(true);
+            }
+            else
+            {
+                _lockImage.gameObject.SetActive(false);
+            }
         }
 
 

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Altzone.Scripts;
-using Altzone.Scripts.Config;
 using Altzone.Scripts.Model.Poco.Game;
 using Altzone.Scripts.Model.Poco.Player;
 using Altzone.Scripts.ModelV2;
@@ -11,13 +11,17 @@ using UnityEngine;
 
 namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 {
-    public class StatsWindowController : MonoBehaviour
+    /// <summary>
+    /// Holds methods which are used to access player data and custom character in stats window.
+    /// </summary>
+    public class StatsWindowController : AltMonoBehaviour
     {
         private PlayerData _playerData;
         private CharacterID _characterId;
-        private CustomCharacter _currentCharacter;
+        private CustomCharacter _customCharacter;
+        private BaseCharacter _baseCharacter;
 
-        // move these to CustomCharacter or where they should be later
+        // TODO: move these to CustomCharacter or where they should be later
         const int STATMAXCOMBINED = 50;
         const int STATMAXLEVEL = 14;
         const int STATMINLEVEL = 1;
@@ -32,7 +36,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
         private void OnEnable()
         {
-            _characterId = (CharacterID)SettingsCarrier.Instance.CharacterGalleryCharacterStatWindowToShow;
+            _characterId = SettingsCarrier.Instance.CharacterGalleryCharacterStatWindowToShow;
             SetPlayerData();
             SetCurrentCharacter();
         }
@@ -40,22 +44,40 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
         private void SetPlayerData() // Get player data from data store and set it to variable
         {
-            DataStore dataStore = Storefront.Get();
-            dataStore.GetPlayerData(GameConfig.Get().PlayerSettings.PlayerGuid, playerData =>
+            StartCoroutine(GetPlayerData(playerData =>
             {
-                if (playerData == null)
-                {
-                    Debug.Log("GetPlayerData is null");
-                    return;
-                }
                 _playerData = playerData;
-            });
+            }));
         }
 
 
         private void SetCurrentCharacter() // Get current custom character from player data and set it to variable
         {
-            _currentCharacter = _playerData.CustomCharacters.FirstOrDefault(c => c.Id == _characterId);
+            _customCharacter = _playerData.CustomCharacters.FirstOrDefault(c => c.Id == _characterId);
+
+            if (_customCharacter == null)
+            {
+                DataStore store = Storefront.Get();
+
+                ReadOnlyCollection<BaseCharacter> allItems = null;
+                store.GetAllBaseCharacterYield(result => allItems = result);
+
+                _baseCharacter = allItems.FirstOrDefault(c => c.Id == _characterId);
+            }
+            else
+            {
+                _baseCharacter = _customCharacter.CharacterBase;
+            }
+        }
+
+
+        /// <summary>
+        /// Check if current character is locked or no.
+        /// </summary>
+        /// <returns>True if current character is locked (player does not own it) and false if not (player owns this character).</returns>
+        public bool IsCurrentCharacterLocked()
+        {
+            return (_customCharacter == null);
         }
 
 
@@ -75,7 +97,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         /// <returns>Current character's name as string.</returns>
         public string GetCurrentCharacterName()
         {
-            var info = PlayerCharacterPrototypes.GetCharacter(((int)_currentCharacter.CharacterBase.Id).ToString());
+            var info = PlayerCharacterPrototypes.GetCharacter(((int)_characterId).ToString());
             if (info == null)
             {
                 return "";
@@ -93,7 +115,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         /// <returns>Current character's sprite.</returns>
         public Sprite GetCurrentCharacterSprite()
         {
-            var info = PlayerCharacterPrototypes.GetCharacter(((int)_currentCharacter.CharacterBase.Id).ToString());
+            var info = PlayerCharacterPrototypes.GetCharacter(((int)_characterId).ToString());
             if (info == null)
             {
                 return null;
@@ -233,7 +255,9 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         /// <returns>Stat diamond upgrade cost as int.</returns>
         public int GetDiamondCost(StatType statType)
         {
-            return _currentCharacter.GetPriceToNextLevel(statType);
+            if (_customCharacter == null) return 0;
+
+            return _customCharacter.GetPriceToNextLevel(statType);
         }
 
 
@@ -244,20 +268,22 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         /// <returns>Stat value as int.</returns>
         public int GetStat(StatType statType)
         {
+            if (_customCharacter == null) return GetBaseStat(statType);
+
             switch (statType)
             {
                 case StatType.None:
                     return -1;
                 case StatType.Speed:
-                    return _currentCharacter.Speed;
+                    return _customCharacter.Speed;
                 case StatType.Attack:
-                    return _currentCharacter.Attack;
+                    return _customCharacter.Attack;
                 case StatType.Hp:
-                    return _currentCharacter.Hp;
+                    return _customCharacter.Hp;
                 case StatType.CharacterSize:
-                    return _currentCharacter.CharacterSize;
+                    return _customCharacter.CharacterSize;
                 case StatType.Defence:
-                    return _currentCharacter.Defence;
+                    return _customCharacter.Defence;
             }
             return -1;
         }
@@ -275,15 +301,15 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                 case StatType.None:
                     return -1;
                 case StatType.Speed:
-                    return _currentCharacter.CharacterBase.DefaultSpeed;
+                    return _baseCharacter.DefaultSpeed;
                 case StatType.Attack:
-                    return _currentCharacter.CharacterBase.DefaultAttack;
+                    return _baseCharacter.DefaultAttack;
                 case StatType.Hp:
-                    return _currentCharacter.CharacterBase.DefaultHp;
+                    return _baseCharacter.DefaultHp;
                 case StatType.CharacterSize:
-                    return _currentCharacter.CharacterBase.DefaultCharacterSize;
+                    return _baseCharacter.DefaultCharacterSize;
                 case StatType.Defence:
-                    return _currentCharacter.CharacterBase.DefaultDefence;
+                    return _baseCharacter.DefaultDefence;
             }
             return -1;
         }
@@ -324,6 +350,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         /// <returns>If increasing the stat was successful as bool.</returns>
         public bool TryIncreaseStat(StatType statType)
         {
+            if (_customCharacter == null) return false;
+
             bool success = false;
 
             if (CanIncreaseStat(statType, true))
@@ -335,19 +363,19 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                     switch (statType)
                     {
                         case StatType.Speed:
-                            _currentCharacter.Speed++;
+                            _customCharacter.Speed++;
                             break;
                         case StatType.Attack:
-                            _currentCharacter.Attack++;
+                            _customCharacter.Attack++;
                             break;
                         case StatType.Hp:
-                            _currentCharacter.Hp++;
+                            _customCharacter.Hp++;
                             break;
                         case StatType.CharacterSize:
-                            _currentCharacter.CharacterSize++;
+                            _customCharacter.CharacterSize++;
                             break;
                         case StatType.Defence:
-                            _currentCharacter.Defence++;
+                            _customCharacter.Defence++;
                             break;
                     }
                     success = true;
@@ -356,7 +384,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
             if (success)
             {
-                _playerData.UpdateCustomCharacter(_currentCharacter);
+                _playerData.UpdateCustomCharacter(_customCharacter);
                 OnStatUpdated.Invoke(statType);
             }
 
@@ -388,6 +416,8 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         /// <returns>If decreasing the stat was successful as bool.</returns>
         public bool TryDecreaseStat(StatType statType)
         {
+            if (_customCharacter == null) return false;
+
             bool success = false;
 
             if (CanDecreaseStat(statType, true))
@@ -399,19 +429,19 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                     switch (statType)
                     {
                         case StatType.Speed:
-                            _currentCharacter.Speed--;
+                            _customCharacter.Speed--;
                             break;
                         case StatType.Attack:
-                            _currentCharacter.Attack--;
+                            _customCharacter.Attack--;
                             break;
                         case StatType.Hp:
-                            _currentCharacter.Hp--;
+                            _customCharacter.Hp--;
                             break;
                         case StatType.CharacterSize:
-                            _currentCharacter.CharacterSize--;
+                            _customCharacter.CharacterSize--;
                             break;
                         case StatType.Defence:
-                            _currentCharacter.Defence--;
+                            _customCharacter.Defence--;
                             break;
                     }
                     success = true;
@@ -420,7 +450,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
             if (success)
             {
-                _playerData.UpdateCustomCharacter(_currentCharacter);
+                _playerData.UpdateCustomCharacter(_customCharacter);
                 OnStatUpdated.Invoke(statType);
             }
 
@@ -431,14 +461,15 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         // Get all character stats combined
         private int GetStatsCombined()
         {
-            return _currentCharacter.Speed + _currentCharacter.CharacterSize + _currentCharacter.Attack + _currentCharacter.Defence + _currentCharacter.Hp;
+            if (_customCharacter == null) return GetBaseStatsCombined();
+            return _customCharacter.Speed + _customCharacter.CharacterSize + _customCharacter.Attack + _customCharacter.Defence + _customCharacter.Hp;
         }
 
 
         // Get all character base stats combined
         private int GetBaseStatsCombined()
         {
-            return _currentCharacter.CharacterBase.DefaultSpeed + _currentCharacter.CharacterBase.DefaultCharacterSize + _currentCharacter.CharacterBase.DefaultAttack + _currentCharacter.CharacterBase.DefaultDefence + _currentCharacter.CharacterBase.DefaultHp; 
+            return _baseCharacter.DefaultSpeed + _baseCharacter.DefaultCharacterSize + _baseCharacter.DefaultAttack + _baseCharacter.DefaultDefence + _baseCharacter.DefaultHp; 
         }
 
 

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
@@ -21,12 +21,6 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         private CustomCharacter _customCharacter;
         private BaseCharacter _baseCharacter;
 
-        // TODO: move these to CustomCharacter or where they should be later
-        const int STATMAXCOMBINED = 50;
-        const int STATMAXLEVEL = 14;
-        const int STATMINLEVEL = 1;
-        const int STATMAXPLAYERINCREASE = 10;
-
         public event Action OnEraserDecreased;
         public event Action OnDiamondDecreased;
 
@@ -327,15 +321,15 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
             {
                 if (!CheckCombinedLevelCap())
                 {
-                    SignalBus.OnChangePopupInfoSignal($"Et voi päivittää taitoa, taitojen summa on enintään {STATMAXCOMBINED}.");
+                    SignalBus.OnChangePopupInfoSignal($"Et voi päivittää taitoa, taitojen summa on enintään {CustomCharacter.STATMAXCOMBINED}.");
                 }
                 else if (!CheckStatLevelCap(statType))
                 {
-                    SignalBus.OnChangePopupInfoSignal($"Et voi päivittää taitoa, maksimitaso on {STATMAXLEVEL}.");
+                    SignalBus.OnChangePopupInfoSignal($"Et voi päivittää taitoa, maksimitaso on {CustomCharacter.STATMAXLEVEL}.");
                 }
                 else if (!CheckMaxPlayerIncreases())
                 {
-                    SignalBus.OnChangePopupInfoSignal($"Et voi päivittää taitoja enemmän kuin {STATMAXPLAYERINCREASE} kertaa."); // when every characters' combined base stats are 40 remove this
+                    SignalBus.OnChangePopupInfoSignal($"Et voi päivittää taitoja enemmän kuin {CustomCharacter.STATMAXPLAYERINCREASE} kertaa."); // when every characters' combined base stats are 40 remove this
                 }
             }
 
@@ -405,7 +399,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                 SignalBus.OnChangePopupInfoSignal($"Et voi vähentää pohjataitoa.");
             }
 
-            return GetStat(statType) > STATMINLEVEL && GetStat(statType) > GetBaseStat(statType);
+            return GetStat(statType) > CustomCharacter.STATMINLEVEL && GetStat(statType) > GetBaseStat(statType);
         }
 
 
@@ -476,7 +470,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         // Checks if stat levels combined are less than level cap
         private bool CheckCombinedLevelCap()
         {
-            if (GetStatsCombined() < STATMAXCOMBINED)
+            if (GetStatsCombined() < CustomCharacter.STATMAXCOMBINED)
             {
                 return true;
             }
@@ -491,7 +485,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
             int statValue = GetStat(statType);
 
-            if (statValue < STATMAXLEVEL)
+            if (statValue < CustomCharacter.STATMAXLEVEL)
             {
                 allowedToIncrease = true;
             }
@@ -503,7 +497,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         // Check if player has increased stats for max allowed player increases
         private bool CheckMaxPlayerIncreases()
         {
-            if (GetStatsCombined() - GetBaseStatsCombined() < STATMAXPLAYERINCREASE)
+            if (GetStatsCombined() - GetBaseStatsCombined() < CustomCharacter.STATMAXPLAYERINCREASE)
             {
                 return true;
             }

--- a/Assets/MenuUi/Scripts/Lobby/BattlePopupCharacterSlotController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/BattlePopupCharacterSlotController.cs
@@ -23,8 +23,8 @@ public class BattlePopupCharacterSlotController : AltMonoBehaviour
             var characters = playerData.CustomCharacters.ToList();
             for (int i = 0; i < _selectedCharacterSlots.Length; i++)
             {
-                PlayerCharacterPrototype charInfo = PlayerCharacterPrototypes.GetCharacter(playerData.SelectedCharacterIds[i].ToString());
-                CharacterID charID = playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == playerData.SelectedCharacterIds[i]) == null? CharacterID.None :playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == playerData.SelectedCharacterIds[i]).Id;
+                CharacterID charID = playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == playerData.SelectedCharacterIds[i]) == null ? CharacterID.None : playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == playerData.SelectedCharacterIds[i]).Id;
+                PlayerCharacterPrototype charInfo = PlayerCharacterPrototypes.GetCharacter(((int)charID).ToString());
                 if (charID is CharacterID.None) continue;
                 CharacterClassID charClassID = CustomCharacter.GetClassID(charID);
                 _selectedCharacterSlots[i].SetInfo(charInfo.GalleryImage, _classColorReference.GetColor(charClassID), _classColorReference.GetAlternativeColor(charClassID), charInfo.Name, charID, null);


### PR DESCRIPTION
Features:
- Unowned characters are locked in character gallery and stats window.
- Saving custom characters to server. Created helper method to ServerManager.cs for starting the coroutine, since PlayerData where it's called doesn't inherit MonoBehaviour.

Fixes:
- Saving removed characters to playerdata.
- Stat max value changed to 24 instead of 14.
- Added check for selecting random characters in ModelController.cs to prevent crashes if there are less than 3 custom characters.
- Fixed selected characters not showing in battle popup, related to the new server ids being in SelectedCharacterIds.

Refactoring:
- Moved stat constants to CustomCharacter.cs from StatsWindowController.cs.
- Documentation comments added to some modified code files (not every character gallery script is yet checked but more will be added in future pull requests when I have extra time)
- Fixed typo in CustomCharacter.cs where I mistakenly had named variable CharaacterSizeSegmentCount, changed to CharacterSizeSegmentCount.