### PR TITLE
DT Clan players, minor visual update & progress popup bugfix

### DIFF
--- a/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskClanPlayer.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskClanPlayer.prefab
@@ -107,8 +107,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3222750841936779648}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.875, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.775, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -140,7 +140,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 999999
+  m_text: 999999 p
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
   m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
@@ -168,7 +168,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 27.95
+  m_fontSize: 35.25
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -224,6 +224,7 @@ GameObject:
   - component: {fileID: -913691810175809863}
   - component: {fileID: 2734358534078775692}
   - component: {fileID: 7736634515023109615}
+  - component: {fileID: 709103919263401925}
   m_Layer: 5
   m_Name: DailyTaskClanPlayer
   m_TagString: Untagged
@@ -250,6 +251,7 @@ RectTransform:
   - {fileID: 8829192769345957314}
   - {fileID: 6645212508370373307}
   - {fileID: 4429246844142644320}
+  - {fileID: 4936883542008794308}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -278,7 +280,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_AspectMode: 1
-  m_AspectRatio: 20
+  m_AspectRatio: 10
 --- !u!114 &7736634515023109615
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -298,6 +300,36 @@ MonoBehaviour:
   _taskPointRewardIcon: {fileID: 3480069982962959994}
   _taskRewardValue: {fileID: 7091004078920147847}
   _playerTotalPoints: {fileID: 5999652212924004994}
+--- !u!114 &709103919263401925
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2087235962053905287}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 514f14b370df98e488588b1a5552f711, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3480069982962959994
 GameObject:
   m_ObjectHideFlags: 0
@@ -366,6 +398,81 @@ MonoBehaviour:
   m_Sprite: {fileID: 21300000, guid: 8d6947ea8a84ae242ba488ee5c990812, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4181053725210861194
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4936883542008794308}
+  - component: {fileID: 3482709757179591324}
+  - component: {fileID: 3643388228338933491}
+  m_Layer: 5
+  m_Name: DetailImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4936883542008794308
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4181053725210861194}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3222750841936779648}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3482709757179591324
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4181053725210861194}
+  m_CullTransparentMesh: 1
+--- !u!114 &3643388228338933491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4181053725210861194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 91d3de0d1b3a5d7469107876800c66d5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
@@ -664,7 +771,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &548237653487044551
 RectTransform:
   m_ObjectHideFlags: 0
@@ -801,7 +908,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6645212508370373307
 RectTransform:
   m_ObjectHideFlags: 0
@@ -953,8 +1060,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3222750841936779648}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.085, y: 0}
-  m_AnchorMax: {x: 0.35, y: 1}
+  m_AnchorMin: {x: 0.085, y: 0.25}
+  m_AnchorMax: {x: 0.35, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1073,7 +1180,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8829192769345957314
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1128,8 +1235,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3222750841936779648}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0.075, y: 1}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 0.075, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DailyTask/DailyTaskView.prefab
@@ -192,7 +192,7 @@ RectTransform:
   m_AnchorMin: {x: 0.335, y: 0.375}
   m_AnchorMax: {x: 0.665, y: 0.625}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 7.3999634}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1953571454872083799
 MonoBehaviour:
@@ -675,7 +675,7 @@ RectTransform:
   m_AnchorMin: {x: 0.335, y: 0.35}
   m_AnchorMax: {x: 0.665, y: 0.65}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -82.200005}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4733966939690220527
 MonoBehaviour:
@@ -3300,8 +3300,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 146263578284598194}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.2, y: 0.875}
-  m_AnchorMax: {x: 0.8, y: 0.925}
+  m_AnchorMin: {x: 0.1, y: 0.85}
+  m_AnchorMax: {x: 0.9, y: 0.925}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -3333,7 +3333,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "T\xE4ll\xE4 hetkell\xE4 t\xF6it\xE4 tekev\xE4t"
+  m_text: "Palkinnon ker\xE4\xE4miseen osallistuneet"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
   m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
@@ -3361,7 +3361,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 33.3
+  m_fontSize: 29.85
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -4152,7 +4152,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.4}
   m_AnchorMax: {x: 0.5, y: 0.6}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 259.84006, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8766672807748477069
 CanvasRenderer:
@@ -5194,7 +5194,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5744191507640438969
 RectTransform:
   m_ObjectHideFlags: 0
@@ -9757,7 +9757,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6263373199715600180
 RectTransform:
   m_ObjectHideFlags: 0
@@ -10307,6 +10307,7 @@ RectTransform:
   - {fileID: 791943112123744344}
   - {fileID: 5744191507640438969}
   - {fileID: 7658895658111496068}
+  - {fileID: 3308157100354077678}
   m_Father: {fileID: 7634772026811522219}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.05, y: 0.05}
@@ -10860,6 +10861,143 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &7667431194778079104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3308157100354077678}
+  - component: {fileID: 5767181253878100549}
+  - component: {fileID: 201133894763848818}
+  m_Layer: 5
+  m_Name: ReminderLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3308157100354077678
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7667431194778079104}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 146263578284598194}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.05, y: 0.05}
+  m_AnchorMax: {x: 0.95, y: 0.125}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5767181253878100549
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7667431194778079104}
+  m_CullTransparentMesh: 1
+--- !u!114 &201133894763848818
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7667431194778079104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "muistutamme ett\xE4 liika ty\xF6 on pahasta\nja liian v\xE4h\xE4n on laiskuutta"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
+  m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 31.8
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7756045567769054033
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyTaskClanPlayer.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyTaskClanPlayer.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
 using Altzone.Scripts.Model.Poco.Player;
@@ -15,30 +13,31 @@ public class DailyTaskClanPlayer : MonoBehaviour
     [SerializeField] private TextMeshProUGUI _taskRewardValue;
     [SerializeField] private TextMeshProUGUI _playerTotalPoints;
 
-    private PlayerData _playerData;
-    public PlayerData PlayerData {  get { return _playerData; } }
+    //private PlayerData _playerData;
+    //public PlayerData PlayerData {  get { return _playerData; } }
 
-    private PlayerTask _playerTask;
-    public PlayerTask PlayerTask { get { return _playerTask; } }
+    //private PlayerTask _playerTask;
+    //public PlayerTask PlayerTask { get { return _playerTask; } }
 
     private int _rank;
     public int Rank { get { return _rank; } }
 
-    public void Set(int rank, PlayerData player, PlayerTask task)
+    public void Set(int rank, string name, int points)
     {
         _rank = rank;
-        _playerData = player;
-        _playerTask = task;
+        //_playerData = player;
+        //_playerTask = task;
 
         _ranking.text = "" + rank;
-        _playerName.text = (player != null ? player.Name : "Player" + rank);
-        _taskName.text = (task != null ? task.Title : "No task");
+        _playerName.text = name;
+        //_playerName.text = (player != null ? player.Name : "Player" + rank);
+        //_taskName.text = (task != null ? task.Title : "No task");
 
-        _taskCoinRewardIcon.SetActive((task != null ? task.Coins > 0 : true));
-        _taskPointRewardIcon.SetActive((task != null ? task.Points > 0 : false));
+        //_taskCoinRewardIcon.SetActive((task != null ? task.Coins > 0 : true));
+        //_taskPointRewardIcon.SetActive((task != null ? task.Points > 0 : false));
 
-        _taskRewardValue.text = "" + (task != null ? (task.Coins > 0 ?  task.Coins : task.Points) : "9999");
-        _playerTotalPoints.text = "" + (player != null ? player.points : 1000000 - rank);
+        //_taskRewardValue.text = "" + (task != null ? (task.Coins > 0 ?  task.Coins : task.Points) : "9999");
+        //_playerTotalPoints.text = "" + (player != null ? player.points : 1000000 - rank);
+        _playerTotalPoints.text = $"{points} p";
     }
-
 }

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyTaskManager.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyTaskManager.cs
@@ -71,6 +71,7 @@ public class DailyTaskManager : AltMonoBehaviour
     void Start()
     {
         TaskGenerator();
+        StartCoroutine(PlayerDataTransferer("get", null, null, data => _currentPlayerData = data));
         StartCoroutine(GetSetExistingTask());
         StartCoroutine(PopulateClanPlayers());
         StartCoroutine(SetClanProgressBar());
@@ -293,118 +294,56 @@ public class DailyTaskManager : AltMonoBehaviour
 
     private IEnumerator PopulateClanPlayers()
     {
-        /*Commented code refering to getting PlayerData's from ClanData but
-         *there is missing or wrong format data. (Waiting for server side update)*/
+        bool? timeout = null;
+        StartCoroutine(WaitUntilTimeout(_timeoutSeconds, data => timeout = data));
+        yield return new WaitUntil(() => (_currentPlayerData != null || timeout != null));
 
-        #region
+        if (_currentPlayerData == null)
+        {
+            Debug.LogError("PlayerData is null!");
+            yield break;
+        }
 
-        //ClanData clan = null;
-        //string clanId = null;
-        //Storefront.Get().GetPlayerData(GameConfig.Get().PlayerSettings.PlayerGuid, p => clanId = p.ClanId);
+        timeout = null;
+        ClanData clanData = null;
 
-        //if (clanId == null)
-        //{
-        //    StartCoroutine(ServerManager.Instance.GetPlayerFromServer(content =>
-        //    {
-        //        if (content != null)
-        //            clanId = content.clan_id;
-        //        else
-        //        {
-        //            Debug.LogError("Could not connect to server and receive PlayerData");
-        //            return;
-        //        }
-        //    }));
-        //}
+        //Get clan data.
+        Storefront.Get().GetClanData(_currentPlayerData.ClanId, content => clanData = content);
 
-        //timeoutCoroutine = StartCoroutine(WaitUntilTimeout(_timeoutSeconds, data => timeout = data));
-        //yield return new WaitUntil(() => (playerData != null || timeout != null));
+        if (clanData == null)
+        {
+            StartCoroutine(ServerManager.Instance.GetClanFromServer(serverClan =>
+            {
+                if (serverClan != null)
+                    clanData = new(serverClan);
+                else
+                {
+                    Debug.LogError("Could not connect to server and receive quests");
+                    return;
+                }
+            }));
+        }
 
-        //if (playerData == null)
-        //{
-        //    StopCoroutine(playerCoroutine);
-        //    Debug.LogError($"Get player data timeout or null.");
-        //    yield break; //TODO: Add error handling.
-        //}
-        //else
-        //    StopCoroutine(timeoutCoroutine);
+        StartCoroutine(WaitUntilTimeout(_timeoutSeconds, data => timeout = data));
+        yield return new WaitUntil(() => (clanData != null || timeout != null));
 
-        //Storefront.Get().GetClanData(clanId, content => clan = content);
+        if (clanData == null)
+            yield break;
 
-        //if (clan == null)
-        //{
-        //    StartCoroutine(ServerManager.Instance.GetClanFromServer(content =>
-        //    {
-        //        if (content != null)
-        //            clan = content;
-        //        else
-        //        {
-        //            //offline testing random generator with id generator
-        //            Debug.LogError("Could not connect to server and receive quests");
-        //            return;
-        //        }
-        //    }));
-        //}
-
-        //timeoutCoroutine = StartCoroutine(WaitUntilTimeout(_timeoutSeconds, data => timeout = data));
-        //yield return new WaitUntil(() => (playerData != null || timeout != null));
-
-        //if (playerData == null)
-        //{
-        //    StopCoroutine(playerCoroutine);
-        //    Debug.LogError($"Get player data timeout or null.");
-        //    yield break; //TODO: Add error handling.
-        //}
-        //else
-        //    StopCoroutine(timeoutCoroutine);
-
-        //PlayerData clanPlayer = null;
-        //Storefront.Get().GetPlayerData(clan.Members[].PlayerDataId, cp => clanPlayer = cp);
-
-
-        //if (clan == null)
-        //{
-        //    StartCoroutine(ServerManager.Instance.GetPlayerLeaderboardFromServer(content =>
-        //    {
-        //        if (content != null)
-        //            clan = content;
-        //        else
-        //        {
-        //            //offline testing random generator with id generator
-        //            Debug.LogError("Could not connect to server and receive quests");
-        //            return;
-        //        }
-        //    }));
-        //}
-
-        //timeoutCoroutine = StartCoroutine(WaitUntilTimeout(_timeoutSeconds, data => timeout = data));
-        //yield return new WaitUntil(() => (playerData != null || timeout != null));
-
-        //if (playerData == null)
-        //{
-        //    StopCoroutine(playerCoroutine);
-        //    Debug.LogError($"Get player data timeout or null.");
-        //    yield break; //TODO: Add error handling.
-        //}
-        //else
-        //    StopCoroutine(timeoutCoroutine);
-
-        #endregion
-
-        //Testing code
-        for (int i = 0; i < 30; i++)
+        for (int i = 0; i < clanData.Members.Count; i++)
         {
             GameObject player = Instantiate(_clanPlayerPrefab, _clanPlayersList);
-            player.GetComponent<DailyTaskClanPlayer>().Set(i, null, null);
+            player.GetComponent<DailyTaskClanPlayer>().Set(i, clanData.Members[i].Name, 0);
 
             _clanPlayers.Add(player);
-            Debug.Log("Created clan player: " + i);
+            Debug.Log("Created clan player: " + clanData.Members[i].Name);
         }
 
         //Needed to update the instantiated DT cards spacing in HorizontalLayoutGroups.
         //LayoutRebuilder.ForceRebuildLayoutImmediate(_clanPlayersList);
 
         //Sets DT cards to left side.
-        _clanPlayersList.anchoredPosition = new Vector2(0f, -500f);
+        _clanPlayersList.anchoredPosition = new Vector2(0f, -5000f);
 
         yield return true;
     }

--- a/Assets/MenuUi/Scripts/DailyQuest/DailyTaskProgressPopup.cs
+++ b/Assets/MenuUi/Scripts/DailyQuest/DailyTaskProgressPopup.cs
@@ -35,13 +35,12 @@ public class DailyTaskProgressPopup : MonoBehaviour
     [SerializeField] private AnimationCurve _progressPopupContainerAnimationCurve;
 
     private bool _progressPopupCooldown = false;
+    Coroutine _coroutineMovePopup = null;
+    Coroutine _coroutineCooldownPopup = null;
 
     private void Start()
     {
-        _progressPopupDailyTaskContainer.position = _progressPopupDailyTaskHiddenLocation.position;
-        _progressPopupDailyTaskContainer.gameObject.SetActive(false);
-        _progressPopupProgressContainer.SetActive(true);
-        _progressPopupRewardContainer.SetActive(false);
+        Reset();
     }
 
     private void OnEnable()
@@ -52,11 +51,27 @@ public class DailyTaskProgressPopup : MonoBehaviour
     private void OnDisable()
     {
         DailyTaskProgressManager.OnTaskProgressed -= ShowProgressPopup;
+        Reset();
     }
 
     private void OnDestroy()
     {
         DailyTaskProgressManager.OnTaskProgressed -= ShowProgressPopup;
+    }
+
+    private void Reset()
+    {
+        _progressPopupCooldown = false;
+        _progressPopupDailyTaskContainer.position = _progressPopupDailyTaskHiddenLocation.position;
+        _progressPopupDailyTaskContainer.gameObject.SetActive(false);
+        _progressPopupProgressContainer.SetActive(true);
+        _progressPopupRewardContainer.SetActive(false);
+
+        if (_coroutineMovePopup != null)
+            StopCoroutine(_coroutineMovePopup);
+
+        if (_coroutineCooldownPopup != null)
+            StopCoroutine(_coroutineCooldownPopup);
     }
 
     private void ShowProgressPopup()
@@ -66,7 +81,7 @@ public class DailyTaskProgressPopup : MonoBehaviour
         if (!_progressPopupCooldown)
         {
             _progressPopupCooldown = true;
-            StartCoroutine(MoveProgressPopupContainer());
+            _coroutineMovePopup = StartCoroutine(MoveProgressPopupContainer());
         }
 
         if (task.TaskProgress >= task.Amount)
@@ -116,7 +131,7 @@ public class DailyTaskProgressPopup : MonoBehaviour
 
         _progressPopupDailyTaskContainer.gameObject.SetActive(false);
         _progressPopupRewardContainer.SetActive(false);
-        StartCoroutine(ProgressPopupCooldownTimer());
+        _coroutineCooldownPopup = StartCoroutine(ProgressPopupCooldownTimer());
     }
 
     private void SetProgressPopup(PlayerTask task)


### PR DESCRIPTION
- DailyTask clan page players are now fetched from ClanData members (Note: members name variable does not contain names yet).
- Made minor visual updates to DailyTask Clan page.
- Removed unused using statements.
- Fixed a bug where the DailyTaskProgressPopup wouldn't show the popup after user switched the whole view while the DTProgressPopup had a coroutine(s) still active.