### PR TITLE
Texture change script for TabLineBase

### DIFF
--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterStatsWindow/TabLineStatsWindow.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterStatsWindow/TabLineStatsWindow.prefab
@@ -634,6 +634,50 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 595070455881823951, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: _getActiveButtonFromSwipe
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 595070455881823951, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: _tabLineButtons.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 595070455881823951, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: _tabLineButtons.Array.data[0]._activeTabSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f9502a761bdb9d443a2586af83639324,
+        type: 3}
+    - target: {fileID: 595070455881823951, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: _tabLineButtons.Array.data[1]._activeTabSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: c433a4178a90cc34c821393bcf41915e,
+        type: 3}
+    - target: {fileID: 595070455881823951, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: _tabLineButtons.Array.data[0]._inactiveTabSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 273e4f551a0f43d43832d9468d603dd4,
+        type: 3}
+    - target: {fileID: 595070455881823951, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: _tabLineButtons.Array.data[1]._inactiveTabSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 12715fe80ae8cdd44babb8b66bbca49e,
+        type: 3}
+    - target: {fileID: 595070455881823951, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: _tabLineButtons.Array.data[0]._detailImageComponent
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 595070455881823951, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: _tabLineButtons.Array.data[1]._detailImageComponent
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1404414662961198789, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_Color.b
@@ -657,12 +701,22 @@ PrefabInstance:
     - target: {fileID: 3083645397524688902, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.98
+      value: 0.956
       objectReference: {fileID: 0}
     - target: {fileID: 3083645397524688902, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.78
+      value: 0.756
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083645397524688902, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3083645397524688902, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4789815415191667178, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
@@ -751,43 +805,64 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4972399519487402402, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f9502a761bdb9d443a2586af83639324,
+        type: 3}
+    - target: {fileID: 4972399519487402402, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4972399519487402402, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
       propertyPath: m_Color.b
-      value: 0.67058825
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4972399519487402402, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_Color.g
-      value: 0.227451
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4972399519487402402, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_Color.r
-      value: 0.627451
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5455678281516419644, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_Color.b
-      value: 0.79215693
+      value: 0.22352943
       objectReference: {fileID: 0}
     - target: {fileID: 5455678281516419644, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_Color.g
-      value: 0.32941177
+      value: 0.22352943
       objectReference: {fileID: 0}
     - target: {fileID: 5455678281516419644, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_Color.r
-      value: 0.6117647
+      value: 0.8078432
       objectReference: {fileID: 0}
     - target: {fileID: 5481847502602699424, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.76
+      value: 0.756
       objectReference: {fileID: 0}
     - target: {fileID: 5481847502602699424, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.56
+      value: 0.556
+      objectReference: {fileID: 0}
+    - target: {fileID: 5481847502602699424, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5481847502602699424, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6633164837591512556, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
@@ -821,17 +896,33 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6682411111857242805, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: c433a4178a90cc34c821393bcf41915e,
+        type: 3}
+    - target: {fileID: 6682411111857242805, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
       propertyPath: m_Color.b
-      value: 0.67058825
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6682411111857242805, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_Color.g
-      value: 0.33333334
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6682411111857242805, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155573576286643043, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155573576286643043, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_Color.a
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7374777170036250210, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
@@ -894,9 +985,23 @@ PrefabInstance:
       propertyPath: m_fontColor32.rgba
       value: 4294375930
       objectReference: {fileID: 0}
+    - target: {fileID: 8342995491120871134, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8342995491120871134, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 8769779974361688627, guid: e22bdd3e0c370fc4b80581ecb7a9da83, type: 3}
+    - {fileID: 5926450162771414224, guid: e22bdd3e0c370fc4b80581ecb7a9da83, type: 3}
+    - {fileID: 8814453850970363211, guid: e22bdd3e0c370fc4b80581ecb7a9da83, type: 3}
+    - {fileID: 5797458262843075130, guid: e22bdd3e0c370fc4b80581ecb7a9da83, type: 3}
+    - {fileID: 5647717842749581979, guid: e22bdd3e0c370fc4b80581ecb7a9da83, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 190456095295517285, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}

--- a/Assets/MenuUi/Prefabs/UI Components/TabLineBase.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/TabLineBase.prefab
@@ -150,8 +150,8 @@ MonoBehaviour:
     _activeDetailSprite: {fileID: 0}
     _inactiveTabSprite: {fileID: 0}
     _inactiveDetailSprite: {fileID: 0}
-    ButtonComponent: {fileID: 4920232304727102816}
-    _tabImageComponent: {fileID: 6682411111857242805}
+    ButtonComponent: {fileID: 472687744616341565}
+    _tabImageComponent: {fileID: 4972399519487402402}
     _detailImageComponent: {fileID: 7155573576286643043}
   - _activeTabSprite: {fileID: 0}
     _activeDetailSprite: {fileID: 0}

--- a/Assets/MenuUi/Prefabs/UI Components/TabLineBase.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/TabLineBase.prefab
@@ -85,6 +85,7 @@ GameObject:
   m_Component:
   - component: {fileID: 190456095295517285}
   - component: {fileID: 400857129563694600}
+  - component: {fileID: 595070455881823951}
   - component: {fileID: 3713396448592114125}
   m_Layer: 5
   m_Name: TabLineBase
@@ -124,6 +125,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2082420161837013928}
   m_CullTransparentMesh: 1
+--- !u!114 &595070455881823951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082420161837013928}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb907510ee6a3054589606cf24e7d2ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _getActiveButtonFromSwipe: 0
+  _tabLineButtons:
+  - _activeTabSprite: {fileID: 0}
+    _activeDetailSprite: {fileID: 0}
+    _inactiveTabSprite: {fileID: 0}
+    _inactiveDetailSprite: {fileID: 0}
+    ButtonComponent: {fileID: 4920232304727102816}
+    _tabImageComponent: {fileID: 6682411111857242805}
+    _detailImageComponent: {fileID: 8342995491120871134}
+  - _activeTabSprite: {fileID: 0}
+    _activeDetailSprite: {fileID: 0}
+    _inactiveTabSprite: {fileID: 0}
+    _inactiveDetailSprite: {fileID: 0}
+    ButtonComponent: {fileID: 4920232304727102816}
+    _tabImageComponent: {fileID: 6682411111857242805}
+    _detailImageComponent: {fileID: 7155573576286643043}
+  - _activeTabSprite: {fileID: 0}
+    _activeDetailSprite: {fileID: 0}
+    _inactiveTabSprite: {fileID: 0}
+    _inactiveDetailSprite: {fileID: 0}
+    ButtonComponent: {fileID: 4789815415191667178}
+    _tabImageComponent: {fileID: 1404414662961198789}
+    _detailImageComponent: {fileID: 8593413527962958490}
 --- !u!114 &3713396448592114125
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Scripts/SwipeNavigation/SwipeUI.cs
+++ b/Assets/MenuUi/Scripts/SwipeNavigation/SwipeUI.cs
@@ -374,7 +374,7 @@ namespace MenuUi.Scripts.SwipeNavigation
         /// </summary>
         private void UpdateButtonContent()
         {
-            if (buttonImages == null || buttonImages.Length == 0) return;
+            if (buttonImages == null || buttonImages.Length == 0 || !_isInMainMenu) return;
 
             for (int i = 0; i < buttonImages.Length; i++)
             {

--- a/Assets/MenuUi/Scripts/TabLine.meta
+++ b/Assets/MenuUi/Scripts/TabLine.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7720b979822c69549aa214560a741125
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Scripts/TabLine/TabLine.cs
+++ b/Assets/MenuUi/Scripts/TabLine/TabLine.cs
@@ -28,7 +28,10 @@ namespace MenuUi.Scripts.TabLine
 
         private void OnDestroy()
         {
-            _swipe.OnCurrentPageChanged -= OnSwipeCurrentPageChanged;
+            if (_getActiveButtonFromSwipe)
+            {
+                _swipe.OnCurrentPageChanged -= OnSwipeCurrentPageChanged;
+            }
         }
 
 

--- a/Assets/MenuUi/Scripts/TabLine/TabLine.cs
+++ b/Assets/MenuUi/Scripts/TabLine/TabLine.cs
@@ -22,6 +22,11 @@ namespace MenuUi.Scripts.TabLine
             {
                 _swipe = FindObjectOfType<SwipeUI>();
                 _swipe.OnCurrentPageChanged += OnSwipeCurrentPageChanged;
+                ActivateTabButton(_swipe.CurrentPage);
+            }
+            else
+            {
+                ActivateTabButton(0);
             }
         }
 

--- a/Assets/MenuUi/Scripts/TabLine/TabLine.cs
+++ b/Assets/MenuUi/Scripts/TabLine/TabLine.cs
@@ -1,0 +1,107 @@
+using System;
+using MenuUi.Scripts.SwipeNavigation;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace MenuUi.Scripts.TabLine
+{
+    /// <summary>
+    /// Is used to set active and inactive tab button visuals.
+    /// </summary>
+    public class TabLine : MonoBehaviour
+    {
+        [SerializeField] private bool _getActiveButtonFromSwipe = false;
+        [SerializeField] private TabLineButton[] _tabLineButtons;
+
+        private SwipeUI _swipe;
+
+
+        private void Awake()
+        {
+            if (_getActiveButtonFromSwipe)
+            {
+                _swipe = FindObjectOfType<SwipeUI>();
+                _swipe.OnCurrentPageChanged += OnSwipeCurrentPageChanged;
+            }
+        }
+
+
+        private void OnDestroy()
+        {
+            _swipe.OnCurrentPageChanged -= OnSwipeCurrentPageChanged;
+        }
+
+
+        private void OnSwipeCurrentPageChanged()
+        {
+            ActivateTabButton(_swipe.CurrentPage);
+        }
+
+
+        /// <summary>
+        /// Sets the tab button at the index active and others inactive.
+        /// </summary>
+        /// <param name="index">The index in tab line buttons array.</param>
+        public void ActivateTabButton(int index)
+        {
+            // Check if enough tab button entries in array.
+            if (_tabLineButtons.Length - 1 < index)
+            {
+                return;
+            }
+
+            _tabLineButtons[index].SetActiveVisuals();
+
+            for (int i = 0; i < _tabLineButtons.Length; i++)
+            {
+                if (i == index) continue;
+
+                _tabLineButtons[i].SetInactiveVisuals();
+            }
+        }
+
+
+        [Serializable]
+        private class TabLineButton
+        {
+            [Header("Sprite assets (detail sprites are optional)")]
+            [SerializeField] private Sprite _activeTabSprite;
+            [SerializeField] private Sprite _activeDetailSprite;
+            [SerializeField] private Sprite _inactiveTabSprite;
+            [SerializeField] private Sprite _inactiveDetailSprite;
+
+            [Header("References to components")]
+            [SerializeField] public Button ButtonComponent;
+            [SerializeField] private Image _tabImageComponent;
+            [SerializeField] private Image _detailImageComponent;
+
+
+            public void SetActiveVisuals()
+            {
+                if (_tabImageComponent != null && _activeTabSprite != null)
+                {
+                    _tabImageComponent.sprite = _activeTabSprite;
+                }
+
+                if (_detailImageComponent != null && _activeDetailSprite != null)
+                {
+                    _detailImageComponent.sprite = _activeDetailSprite;
+                }
+            }
+
+
+            public void SetInactiveVisuals()
+            {
+                if (_tabImageComponent != null && _inactiveTabSprite != null)
+                {
+                    _tabImageComponent.sprite = _inactiveTabSprite;
+                }
+
+                if (_detailImageComponent != null && _inactiveDetailSprite != null)
+                {
+                    _detailImageComponent.sprite = _inactiveDetailSprite;
+                }
+            }
+        }
+    }
+}

--- a/Assets/MenuUi/Scripts/TabLine/TabLine.cs.meta
+++ b/Assets/MenuUi/Scripts/TabLine/TabLine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb907510ee6a3054589606cf24e7d2ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- TabLine.cs script created.
-It has array of private serializable TabLineButton objects which hold the sprite and component references. 
-It's possible to get the active button index from swipe, if the _getActiveButtonFromSwipe boolean is true, or you can manually call public ActivateTabButton method which takes int index as a paramter. It can possibly be linked in the tab buttons OnClick method in editor, or then through script.
- Doesn't break any existing tab button configurations
- Updated the tabline buttons for CharacterStatsWindowView.