### PR TITLE
Updated character gallery character slots visuals

### DIFF
--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
@@ -75,6 +75,81 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1290541703553438362
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5955726358595140849}
+  - component: {fileID: 3001272696208726961}
+  - component: {fileID: 5059424912043922917}
+  m_Layer: 5
+  m_Name: ContentsOverlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5955726358595140849
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1290541703553438362}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6762374876794546724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3001272696208726961
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1290541703553438362}
+  m_CullTransparentMesh: 1
+--- !u!114 &5059424912043922917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1290541703553438362}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a9301cb73591e5d45a4c5fc5391370f8, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3508052492520471368
 GameObject:
   m_ObjectHideFlags: 0
@@ -247,6 +322,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
+  - {fileID: 5955726358595140849}
+  - {fileID: 5384627972271665875}
   - {fileID: 978708161471739503}
   - {fileID: 1505972532492136700}
   - {fileID: 8467504842734029194}
@@ -311,9 +388,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _animator: {fileID: 6663672098119100784}
   _selectButton: {fileID: 7018444139741886887}
+  IsLocked: 0
   Character: {fileID: 8169646972705860285}
   _spriteImage: {fileID: 4373653401983087985}
   _backgroundSpriteImage: {fileID: 2053534294522563814}
+  _contentsSpriteImage: {fileID: 5059424912043922917}
   _nameText: {fileID: 1401336240080573343}
 --- !u!114 &8170631812076819300
 MonoBehaviour:
@@ -474,6 +553,81 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 71d674438388ba84aa04ee4e1cc04f81, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6257021046990187013
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5384627972271665875}
+  - component: {fileID: 7165509571628740756}
+  - component: {fileID: 3594894570574985621}
+  m_Layer: 5
+  m_Name: ContentsDetailOverlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5384627972271665875
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6257021046990187013}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6762374876794546724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7165509571628740756
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6257021046990187013}
+  m_CullTransparentMesh: 1
+--- !u!114 &3594894570574985621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6257021046990187013}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 06d0c68900f085c499074948130206c3, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
@@ -545,7 +545,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/GalleryCharacter.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/GalleryCharacter.prefab
@@ -115,7 +115,6 @@ MonoBehaviour:
   _backgroundImage: {fileID: 1698316617930894126}
   _contentsImage: {fileID: 1436819896680901654}
   _contentsDetailsImage: {fileID: 5093630027183570878}
-  _lockImage: {fileID: 0}
   _characterNameText: {fileID: 3511939312560207162}
   _aspectRatioFitter: {fileID: 365475382052161339}
   _piechartPreview: {fileID: 599868788555485942}
@@ -373,7 +372,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/CharacterSlot.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/CharacterSlot.cs
@@ -12,6 +12,7 @@ namespace MenuUi.Scripts.CharacterGallery
         private CharacterID _id;
         [SerializeField] private Image _spriteImage;
         [SerializeField] private Image _backgroundSpriteImage;
+        [SerializeField] private Image _contentsSpriteImage;
         [SerializeField] private TextMeshProUGUI _nameText;
 
         public CharacterID Id { get => _id; }
@@ -22,6 +23,7 @@ namespace MenuUi.Scripts.CharacterGallery
             _nameText.text = name;
             _id = id;
             _backgroundSpriteImage.color = new Color(bgColor.r - 0.4f, bgColor.g - 0.4f, bgColor.b - 0.4f);
+            _contentsSpriteImage.color = new Color(bgAltColor.r - 0.4f, bgAltColor.g - 0.4f, bgAltColor.b - 0.4f);
             Character.SetInfo(sprite, bgColor, bgAltColor, name, id, this);
         }
     }


### PR DESCRIPTION
- Added contents sprite image to character inventory slot prefab, so that the box outline for character name and sprite will be in selected character slots too.
- Made details image invisible for character inventory slot and gallery character. (Didn't delete yet if it will be used later after all)