### PR TITLE
AvatarEditor save & load, bug fix & code readability

### DIFF
--- a/Assets/Altzone/Scripts/AltMonoBehaviour.cs
+++ b/Assets/Altzone/Scripts/AltMonoBehaviour.cs
@@ -103,8 +103,29 @@ public class AltMonoBehaviour : MonoBehaviour
 
         yield return new WaitUntil(() => callback != null);
     }
+    protected IEnumerator SavePlayerData(PlayerData playerData, System.Action<PlayerData> callback)
+    {
 
-    protected IEnumerator GetClanData(System.Action<ClanData> callback, string clanId = null)
+        Storefront.Get().SavePlayerData(playerData, callback);
+
+        /*if (callback == null)
+        {
+            StartCoroutine(ServerManager.Instance.GetClanFromServer(content =>
+            {
+                if (content != null)
+                    callback(new(content));
+                else
+                {
+                    Debug.LogError("Could not connect to server and receive player");
+                    return;
+                }
+            }));
+        }*/
+
+        yield return new WaitUntil(() => callback != null);
+    }
+
+    protected IEnumerator GetClanData(string clanId, System.Action<ClanData> callback)
     {
         if(clanId == null)
         {
@@ -129,5 +150,66 @@ public class AltMonoBehaviour : MonoBehaviour
         }
 
         yield return new WaitUntil(() => callback != null);
+    }
+    protected IEnumerator GetClanData(System.Action<ClanData> callback, string clanId = null)
+    {
+        yield return StartCoroutine(GetClanData(clanId, callback));
+    }
+
+    protected IEnumerator SaveClanData(System.Action<ClanData> callback, ClanData clanData)
+    {
+
+        Storefront.Get().SaveClanData(clanData, callback);
+
+        /*if (callback == null)
+        {
+            StartCoroutine(ServerManager.Instance.GetClanFromServer(content =>
+            {
+                if (content != null)
+                    callback(new(content));
+                else
+                {
+                    Debug.LogError("Could not connect to server and receive player");
+                    return;
+                }
+            }));
+        }*/
+
+        yield return new WaitUntil(() => callback != null);
+    }
+
+    protected IEnumerator PlayerDataTransferer(string operationType, PlayerData unsavedData, float timeoutTime, System.Action<bool> timeoutCallback, System.Action<PlayerData> dataCallback)
+    {
+        PlayerData receivedData = null;
+        bool? timeout = null;
+        Coroutine playerCoroutine;
+
+        switch (operationType.ToLower())
+        {
+            case "get":
+                {
+                    //Get player data.
+                    playerCoroutine = StartCoroutine(CoroutineWithTimeout(GetPlayerData, receivedData, timeoutTime, timeoutCallBack => timeout = timeoutCallBack, data => receivedData = data));
+                    break;
+                }
+            case "save":
+                {
+                    //Save player data.
+                    playerCoroutine = StartCoroutine(CoroutineWithTimeout(SavePlayerData, unsavedData, receivedData, timeoutTime, timeoutCallback: timeoutCallBack => timeout = timeoutCallBack, data => receivedData = data));
+                    break;
+                }
+            default: Debug.LogError($"Received: {operationType}, when expecting \"get\" or \"save\"."); yield break;
+        }
+
+        yield return new WaitUntil(() => (receivedData != null || timeout != null));
+
+        if (receivedData == null)
+        {
+            timeoutCallback(true);
+            Debug.LogError($"Player data operation: \"{operationType}\" timeout or null.");
+            yield break;
+        }
+
+        dataCallback(receivedData);
     }
 }

--- a/Assets/Altzone/Scripts/AltMonoBehaviour.cs
+++ b/Assets/Altzone/Scripts/AltMonoBehaviour.cs
@@ -178,6 +178,14 @@ public class AltMonoBehaviour : MonoBehaviour
         yield return new WaitUntil(() => callback != null);
     }
 
+    /// <summary>
+    /// Used to get and save player data to/from server.
+    /// </summary>
+    /// <param name="operationType">"get" or "save"</param>
+    /// <param name="unsavedData">If saving: insert unsaved data.<br/> If getting: insert <c>null</c>.</param>
+    /// <param name="timeoutTime">Time until coroutine force stops if no responce is received.</param>
+    /// <param name="timeoutCallback">Returns value if timeout with server.</param>
+    /// <param name="dataCallback">Returns <c>PlayerData</c>.</param>
     protected IEnumerator PlayerDataTransferer(string operationType, PlayerData unsavedData, float timeoutTime, System.Action<bool> timeoutCallback, System.Action<PlayerData> dataCallback)
     {
         PlayerData receivedData = null;

--- a/Assets/Altzone/Scripts/Model/Poco/Player/AvatarData.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Player/AvatarData.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Assets.Altzone.Scripts.Model.Poco.Player
+{
+    public class AvatarData
+    {
+        public AvatarData(string name, List<int> features, List<int> colors, Vector2 scale)
+        {
+            Name = name;
+            Features = features;
+            Colors = colors;
+            Scale = scale;
+        }
+
+        public string Name;
+        public List<int> Features;
+        public List<int> Colors;
+        public Vector2 Scale;
+    }
+}

--- a/Assets/Altzone/Scripts/Model/Poco/Player/AvatarData.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Player/AvatarData.cs
@@ -5,7 +5,7 @@ namespace Assets.Altzone.Scripts.Model.Poco.Player
 {
     public class AvatarData
     {
-        public AvatarData(string name, List<int> features, List<int> colors, Vector2 scale)
+        public AvatarData(string name, List<int> features, List<string> colors, Vector2 scale)
         {
             Name = name;
             Features = features;
@@ -15,7 +15,7 @@ namespace Assets.Altzone.Scripts.Model.Poco.Player
 
         public string Name;
         public List<int> Features;
-        public List<int> Colors;
+        public List<string> Colors;
         public Vector2 Scale;
     }
 }

--- a/Assets/Altzone/Scripts/Model/Poco/Player/AvatarData.cs.meta
+++ b/Assets/Altzone/Scripts/Model/Poco/Player/AvatarData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: afdc65aae7f78374590c97553abf9e91
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
@@ -7,6 +7,7 @@ using Altzone.Scripts.Model.Poco.Attributes;
 using Altzone.Scripts.Model.Poco.Clan;
 using Altzone.Scripts.Model.Poco.Game;
 using Altzone.Scripts.Voting;
+using Assets.Altzone.Scripts.Model.Poco.Player;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -51,6 +52,7 @@ namespace Altzone.Scripts.Model.Poco.Player
         public int BackpackCapacity;
 
         public PlayerTask Task = null;
+        public AvatarData AvatarData;
 
         public int points = 0;
 

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Clothes/Avatar301Clothes.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Clothes/Avatar301Clothes.png.meta
@@ -3,7 +3,7 @@ guid: a950927c8986a4d41b8e342fcfbc8577
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 207
-        y: 3
+        y: 90
         width: 113
         height: 139
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Clothes/Avatar401Clothes.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Clothes/Avatar401Clothes.png.meta
@@ -3,7 +3,7 @@ guid: 9d9ee2b0c51a3c44abe1f015d73296e4
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,7 +166,7 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 183
-        y: 10
+        y: 100
         width: 146
         height: 147
       alignment: 0
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar301Eyes.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar301Eyes.png.meta
@@ -3,7 +3,7 @@ guid: 2596350cfaab3a44ea5bbcc6d88e53e0
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 176
-        y: 197
+        y: 255
         width: 175
-        height: 48
+        height: 65
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar401Eyes.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar401Eyes.png.meta
@@ -3,7 +3,7 @@ guid: c24563afc89dc904ba488ceecf0e93c8
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 162
-        y: 196
+        y: 255
         width: 204
-        height: 57
+        height: 60
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar501Eyes.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar501Eyes.png.meta
@@ -3,7 +3,7 @@ guid: d11919efe7a69314e806eb2a40733f22
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 169
-        y: 192
+        y: 250
         width: 197
-        height: 62
+        height: 70
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar601-1Eyes.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar601-1Eyes.png.meta
@@ -3,7 +3,7 @@ guid: 8924ce594a5ff2f4ba4004580b59f9e4
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 133
-        y: 187
+        y: 240
         width: 255
         height: 66
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar601-2Eyes.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar601-2Eyes.png.meta
@@ -3,7 +3,7 @@ guid: b8915a22e9caefb4fb38a885f045b40f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 137
-        y: 191
+        y: 242
         width: 260
         height: 66
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar701Eyes.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Eyes/Avatar701Eyes.png.meta
@@ -3,7 +3,7 @@ guid: d79139055f8ec134ab21cb4652afb88f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,9 +166,9 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 147
-        y: 178
+        y: 240
         width: 231
-        height: 80
+        height: 105
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar301Hair.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar301Hair.png.meta
@@ -3,7 +3,7 @@ guid: fd8ba004fcf667d46b109d1717cfa6c6
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 83
-        y: 232
+        y: 260
         width: 328
         height: 219
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar401Hair.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar401Hair.png.meta
@@ -3,7 +3,7 @@ guid: 83834478f6d6be44d9e634b24f047175
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 69
-        y: 79
+        y: 185
         width: 423
-        height: 311
+        height: 315
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar501Hair.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar501Hair.png.meta
@@ -3,7 +3,7 @@ guid: 54ac73de859e4374db347d55dbb1b304
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 99
-        y: 228
+        y: 260
         width: 295
-        height: 186
+        height: 185
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar601-1Hair.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar601-1Hair.png.meta
@@ -3,7 +3,7 @@ guid: eb717d27d62edaf4da18a970c67e4856
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 61
-        y: 1
+        y: 80
         width: 364
-        height: 426
+        height: 380
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar601-2Hair.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/HairHat/Avatar601-2Hair.png.meta
@@ -3,7 +3,7 @@ guid: b841929f2a12f78418d324b6ce593c75
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 61
-        y: 1
+        y: 80
         width: 364
-        height: 426
+        height: 380
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar301Mouth.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar301Mouth.png.meta
@@ -3,7 +3,7 @@ guid: d0ee66730ec0b074f9a0d11784ccd663
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 249
-        y: 148
+        y: 220
         width: 43
         height: 19
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar401Mouth.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar401Mouth.png.meta
@@ -3,7 +3,7 @@ guid: 540ddf9d5960692409e3d8d202f7d19b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 242
-        y: 143
+        y: 215
         width: 53
         height: 29
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar501Mouth.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar501Mouth.png.meta
@@ -3,7 +3,7 @@ guid: bdf78138e8e36454fa7710a26833ef09
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 243
-        y: 158
+        y: 220
         width: 53
-        height: 13
+        height: 25
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar601Mouth.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar601Mouth.png.meta
@@ -3,7 +3,7 @@ guid: 1a8436d123f124941986b25b55ad91e5
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -165,12 +165,12 @@ TextureImporter:
       name: image8_0
       rect:
         serializedVersion: 2
-        x: 252
-        y: 179
-        width: 37
-        height: 20
+        x: 245
+        y: 215
+        width: 60
+        height: 30
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar701Mouth.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Mouth/Avatar701Mouth.png.meta
@@ -3,7 +3,7 @@ guid: 8787befeee8897947b444c208972ddea
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 202
-        y: 149
+        y: 215
         width: 136
         height: 43
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Nose/Avatar301Nose.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Nose/Avatar301Nose.png.meta
@@ -3,7 +3,7 @@ guid: 92435f9a7f3ff0043b1efac4e67527ff
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 259
-        y: 181
+        y: 220
         width: 31
         height: 63
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Nose/Avatar401Nose.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Nose/Avatar401Nose.png.meta
@@ -3,7 +3,7 @@ guid: 5d81820abd0b1cb46b088b027920b8e3
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -166,11 +166,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 261
-        y: 180
+        y: 240
         width: 27
         height: 39
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Nose/Avatar501Nose.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Nose/Avatar501Nose.png.meta
@@ -3,7 +3,7 @@ guid: 98fcfb4d4905c054db75384f0517c102
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -165,12 +165,12 @@ TextureImporter:
       name: image19_0
       rect:
         serializedVersion: 2
-        x: 244
-        y: 181
+        x: 250
+        y: 240
         width: 48
         height: 27
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Nose/Avatar601Nose.png.meta
+++ b/Assets/MenuUi/Graphics/AvatarGraphics/AvatarFeatures/Nose/Avatar601Nose.png.meta
@@ -3,7 +3,7 @@ guid: 63ddbbcae2ca78f41b38b3a1860dd2e9
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -165,12 +165,12 @@ TextureImporter:
       name: image3_0
       rect:
         serializedVersion: 2
-        x: 256
-        y: 179
-        width: 29
+        x: 250
+        y: 240
+        width: 50
         height: 21
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -191,7 +191,7 @@ TextureImporter:
         width: 512
         height: 512
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []

--- a/Assets/MenuUi/Prefabs/Windows/Avatar/AvatarEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/Avatar/AvatarEditor.prefab
@@ -3205,6 +3205,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73978bc6ca34bdf4e838acacac9147ac, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _timeoutSeconds: 10
   _characterLoader: {fileID: 3572067151878312193}
   _modeList:
   - {fileID: 1583219091284170855}

--- a/Assets/MenuUi/Prefabs/Windows/Avatar/AvatarEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/Avatar/AvatarEditor.prefab
@@ -1768,7 +1768,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8944099634186064353}
   - component: {fileID: 5227175995781872566}
-  - component: {fileID: 2682408130751760177}
   m_Layer: 0
   m_Name: EditorMenu
   m_TagString: Untagged
@@ -1809,32 +1808,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3069741852416127881}
   m_CullTransparentMesh: 1
---- !u!114 &2682408130751760177
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3069741852416127881}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73978bc6ca34bdf4e838acacac9147ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _characterLoader: {fileID: 3572067151878312193}
-  _modeList:
-  - {fileID: 1583219091284170855}
-  - {fileID: 1665418200380759846}
-  - {fileID: 3990782255532189438}
-  _switchModeButtons:
-  - {fileID: 6399676103353379342}
-  - {fileID: 1960484600104632230}
-  - {fileID: 1219249222629886835}
-  _saveButton: {fileID: 1891825094661328202}
-  _defaultMode: 0
-  _visualDataScriptableObject: {fileID: 11400000, guid: 5924f2967fcfeb0469785ea0b5f3d2b2,
-    type: 2}
-  _avatarVisualsParent: {fileID: 5099103689188165273}
 --- !u!1 &3631476720980781489
 GameObject:
   m_ObjectHideFlags: 0
@@ -3196,6 +3169,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4231379166148945069}
+  - component: {fileID: 2999011772624794886}
   m_Layer: 0
   m_Name: AvatarEditor
   m_TagString: Untagged
@@ -3219,6 +3193,32 @@ Transform:
   - {fileID: 2303743429245796772}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2999011772624794886
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7298176311922543583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73978bc6ca34bdf4e838acacac9147ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _characterLoader: {fileID: 3572067151878312193}
+  _modeList:
+  - {fileID: 1583219091284170855}
+  - {fileID: 1665418200380759846}
+  - {fileID: 3990782255532189438}
+  _switchModeButtons:
+  - {fileID: 6399676103353379342}
+  - {fileID: 1960484600104632230}
+  - {fileID: 1219249222629886835}
+  _saveButton: {fileID: 1891825094661328202}
+  _defaultMode: 0
+  _visualDataScriptableObject: {fileID: 11400000, guid: 5924f2967fcfeb0469785ea0b5f3d2b2,
+    type: 2}
+  _avatarVisualsParent: {fileID: 5099103689188165273}
 --- !u!1 &7323484196095293164
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Scripts/AvatarEditor/AvatarEditorController.cs
+++ b/Assets/MenuUi/Scripts/AvatarEditor/AvatarEditorController.cs
@@ -100,7 +100,7 @@ namespace MenuUi.Scripts.AvatarEditor
             PlayerData playerData = null;
 
             // _nameInput.text = _playerAvatar.Name;
-            StartCoroutine(PlayerDataTransferer("get", null, data => timeout = data, data => playerData = data));
+            StartCoroutine(PlayerDataTransferer("get", null, _timeoutSeconds, data => timeout = data, data => playerData = data));
 
             yield return new WaitUntil(() => ((timeout != null) || (playerData != null)));
 
@@ -112,9 +112,7 @@ namespace MenuUi.Scripts.AvatarEditor
             if (_currentPlayerData.AvatarData == null)
             {
                 Debug.Log("AvatarData is null. Using default data.");
-                //_featurePicker.GetDefaultAvatar();
                 _playerAvatar = new(new List<FeatureID>() { 0,0,0,0,0,0,0,0,0 } );
-                //yield break;
             }
             else
                 _playerAvatar = new(_currentPlayerData.AvatarData);
@@ -127,30 +125,6 @@ namespace MenuUi.Scripts.AvatarEditor
 
             _avatarScaler.SetLoadedScale(_playerAvatar.Scale);
         }
-
-        //private List<FeatureID> LoadFeaturesFromPrefs()
-        //{
-        //    List<FeatureID> features = new();
-        //    for(int i = 0; i < Enum.GetNames(typeof(FeatureSlot)).Length-1; i++){
-        //        features.Add((FeatureID)PlayerPrefs.GetInt(((FeatureSlot)i).ToString()+"Feature"));
-        //        Debug.Log("Loaded Feature: " + features[i].ToString() + " from a key of: " + ((FeatureSlot)i).ToString());
-        //    }
-        //    return features;
-        //}
-
-        //private List<FeatureColor> LoadColorsFromPrefs()
-        //{
-        //    List<FeatureColor> colors = new();
-        //    for (int i = 0; i < Enum.GetNames(typeof(FeatureSlot)).Length-1; i++){
-        //        colors.Add((FeatureColor)PlayerPrefs.GetInt(((FeatureSlot)i).ToString()+"Color"));
-        //    }
-        //    return colors;
-        //}
-
-        //private Vector2 LoadScaleFromPrefs()
-        //{
-        //    return new Vector2(PlayerPrefs.GetFloat("ScaleX"), PlayerPrefs.GetFloat("ScaleY"));
-        //}
 
         #endregion
 
@@ -171,10 +145,10 @@ namespace MenuUi.Scripts.AvatarEditor
 
             savePlayerData.AvatarData = new(_playerAvatar.Name,
                 _playerAvatar.ToFeaturesListInt(_featurePicker.GetCurrentlySelectedFeatures()),
-                _playerAvatar.ToFeatureColorListInt(_colorPicker.GetCurrentColors()),
+                _colorPicker.GetCurrentColors(),
                 _avatarScaler.GetCurrentScale());
 
-            StartCoroutine(PlayerDataTransferer("save", savePlayerData, data => timeout = data, data => playerData = data));
+            StartCoroutine(PlayerDataTransferer("save", savePlayerData, _timeoutSeconds, data => timeout = data, data => playerData = data));
 
             yield return new WaitUntil(() => ((timeout != null) || (playerData != null)));
 
@@ -184,119 +158,6 @@ namespace MenuUi.Scripts.AvatarEditor
             _currentPlayerData = playerData;
         }
 
-        // private void SaveName()
-        // {
-        //     string characterName = _nameInput.text;
-        //     // Debug.Log("Character name saved: " + characterName);
-
-        //     _playerAvatar.Name = characterName;
-        //     PlayerPrefs.SetString("CharacterName", characterName);
-        // }
-
-        //private void SaveFeaturesToPrefs()
-        //{
-        //    List<FeatureID> features = _featurePicker.GetCurrentlySelectedFeatures();
-        //    for(int i = 0; i < features.Count; i++){
-        //        // Debug.Log("Saving feature: " +_selectedFeatures[i] + " to a string key named: " + ((FeatureSlot)i).ToString());
-        //        PlayerPrefs.SetInt(((FeatureSlot)i).ToString()+"Feature", (int)features[i]);
-        //    }
-        //}
-
-        //private void SaveColorsToPrefs()
-        //{
-        //    List<FeatureColor> colors = _colorPicker.GetCurrentColors();
-        //    for(int i = 0; i < _playerAvatar.Colors.Count; i++){
-        //        Debug.Log("Saving color: " +colors[i] + " to a string key named: " + ((FeatureSlot)i).ToString());
-        //        PlayerPrefs.SetInt(((FeatureSlot)i).ToString()+"Color", (int)colors[i]);
-        //    }
-        //}
-
-        //private void SaveScaleToPrefs()
-        //{
-        //    PlayerPrefs.SetFloat("ScaleX", _selectedScale.x);
-        //    PlayerPrefs.SetFloat("ScaleY", _selectedScale.y);
-        //}
-
-        //private void SaveDataToScriptableObject()
-        //{
-        //    _visualDataScriptableObject.sprites.Clear();
-        //    _visualDataScriptableObject.colors.Clear();
-        //    foreach(Image image in _avatarVisualsParent.GetComponentsInChildren<Image>())
-        //    {
-        //        _visualDataScriptableObject.sprites.Add(image.sprite);
-        //        _visualDataScriptableObject.colors.Add(image.color);
-        //    }
-        //}
-
-        private IEnumerator SavePlayerData(PlayerData playerData, System.Action<PlayerData> callback) //TODO: Remove when available in AltMonoBehaviour.
-        {
-            //Cant' save to server because server manager doesn't have functionality!
-            //Storefront.Get().SavePlayerData(playerData, callback);
-
-            //if (callback == null)
-            //{
-            //    StartCoroutine(ServerManager.Instance.UpdatePlayerToServer( playerData., content =>
-            //    {
-            //        if (content != null)
-            //            callback(new(content));
-            //        else
-            //        {
-            //            Debug.LogError("Could not connect to server and save player");
-            //            return;
-            //        }
-            //    }));
-            //}
-
-            //yield return new WaitUntil(() => callback != null);
-
-            //Testing code
-            callback(playerData);
-
-            yield return true;
-        }
-
         #endregion
-
-        /// <summary>
-        /// Used to get and save player data to/from server.
-        /// </summary>
-        /// <param name="operationType">"get" or "save"</param>
-        /// <param name="unsavedData">If saving: insert unsaved data.<br/> If getting: insert <c>null</c>.</param>
-        /// <param name="timeoutCallback">Returns value if timeout with server.</param>
-        /// <param name="dataCallback">Returns <c>PlayerData</c>.</param>
-        private IEnumerator PlayerDataTransferer(string operationType, PlayerData unsavedData, System.Action<bool> timeoutCallback, System.Action<PlayerData> dataCallback)
-        {
-            PlayerData receivedData = null;
-            bool? timeout = null;
-            Coroutine playerCoroutine;
-
-            switch (operationType.ToLower())
-            {
-                case "get":
-                    {
-                        //Get player data.
-                        playerCoroutine = StartCoroutine(CoroutineWithTimeout(GetPlayerData, receivedData, _timeoutSeconds, timeoutCallBack => timeout = timeoutCallBack, data => receivedData = data));
-                        break;
-                    }
-                case "save":
-                    {
-                        //Save player data.
-                        playerCoroutine = StartCoroutine(CoroutineWithTimeout(SavePlayerData, unsavedData, receivedData, _timeoutSeconds, timeoutCallBack => timeout = timeoutCallBack, data => receivedData = data));
-                        break;
-                    }
-                default: Debug.LogError($"Received: {operationType}, when expecting \"get\" or \"save\"."); yield break;
-            }
-
-            yield return new WaitUntil(() => (receivedData != null || timeout != null));
-
-            if (receivedData == null)
-            {
-                timeoutCallback(true);
-                Debug.LogError($"Player data operation: \"{operationType}\" timeout or null.");
-                yield break;
-            }
-
-            dataCallback(receivedData);
-        }
     }
 }

--- a/Assets/MenuUi/Scripts/AvatarEditor/AvatarEditorController.cs
+++ b/Assets/MenuUi/Scripts/AvatarEditor/AvatarEditorController.cs
@@ -1,54 +1,72 @@
-
-using System;
+using System.Collections;
 using System.Collections.Generic;
+using Altzone.Scripts.Model.Poco.Player;
 using UnityEngine;
 using UnityEngine.UI;
 
 namespace MenuUi.Scripts.AvatarEditor
 {
-    public class AvatarEditorController : MonoBehaviour
+    public class AvatarEditorController : AltMonoBehaviour
     {
-        [SerializeField]private CharacterLoader _characterLoader;
-        private AvatarEditorMode _currentMode = 0;
-        [SerializeField]private List<GameObject> _modeList;
-        [SerializeField]private List<Button> _switchModeButtons;
-        [SerializeField]private Button _saveButton;
-        [SerializeField]private AvatarEditorMode _defaultMode = AvatarEditorMode.FeaturePicker;
-        [SerializeField]private AvatarVisualDataScriptableObject _visualDataScriptableObject;
-        [SerializeField]private GameObject _avatarVisualsParent;
+        private PlayerData _currentPlayerData;
+
+        [SerializeField] private float _timeoutSeconds = 10f;
+
+        private enum AvatarEditorMode
+        {
+            FeaturePicker,
+            ColorPicker,
+            AvatarScaler,
+        }
+        private AvatarEditorMode _currentMode = AvatarEditorMode.FeaturePicker;
+
+        [SerializeField] private CharacterLoader _characterLoader;
+        [SerializeField] private List<GameObject> _modeList;
+        [SerializeField] private List<Button> _switchModeButtons;
+        [SerializeField] private Button _saveButton;
+        [SerializeField] private AvatarEditorMode _defaultMode = AvatarEditorMode.FeaturePicker;
+        [SerializeField] private AvatarVisualDataScriptableObject _visualDataScriptableObject;
+        [SerializeField] private GameObject _avatarVisualsParent;
         private FeatureSlot _currentlySelectedCategory;
         
-        
-        private Vector2 _selectedScale;
+        //private Vector2 _selectedScale;
         private PlayerAvatar _playerAvatar;
         private FeaturePicker _featurePicker;
         private ColorPicker _colorPicker;
         private AvatarScaler _avatarScaler;
-        void Awake(){
+
+        void Awake()
+        {
             _featurePicker = _modeList[0].GetComponent<FeaturePicker>();
             _colorPicker = _modeList[1].GetComponent<ColorPicker>(); 
             _avatarScaler = _modeList[2].GetComponent<AvatarScaler>();
         }
-        void Start(){
-            _saveButton.onClick.AddListener(SaveAvatarData);
+
+        void Start()
+        {
+            _saveButton.onClick.AddListener(() => StartCoroutine(SaveAvatarData()));
             _switchModeButtons[0].onClick.AddListener(delegate{GoIntoMode(AvatarEditorMode.FeaturePicker);});
             _switchModeButtons[1].onClick.AddListener(delegate{GoIntoMode(AvatarEditorMode.ColorPicker);});
             _switchModeButtons[2].onClick.AddListener(delegate{GoIntoMode(AvatarEditorMode.AvatarScaler);});
         }
-        void OnEnable(){
+
+        void OnEnable()
+        {
             _characterLoader.RefreshPlayerCurrentCharacter(CharacterLoaded);
             foreach(GameObject mode in _modeList){
                 mode.SetActive(false);
             }
             _currentMode = _defaultMode;
-
         }
+
         private void CharacterLoaded()
         {
-            LoadAvatarData();
+            StartCoroutine(LoadAvatarData());
             GoIntoMode(_defaultMode);
         }
+
         #region Mode selection
+
         private void GoIntoMode(AvatarEditorMode mode)
         {
             SetSaveableData();
@@ -67,18 +85,39 @@ namespace MenuUi.Scripts.AvatarEditor
             
             _modeList[(int)_currentMode].SetActive(true);
         }
-        private void RestoreDefaultColorToFeature(){
+
+        private void RestoreDefaultColorToFeature()
+        {
             _colorPicker.RestoreDefaultColor(_featurePicker.GetCurrentlySelectedCategory());
         }
+
         #endregion
         #region Loading Data
 
-
-
-        private void LoadAvatarData()
+        private IEnumerator LoadAvatarData()
         {
-            _playerAvatar = new PlayerAvatar(PlayerPrefs.GetString("CharacterName"), LoadFeaturesFromPrefs(), LoadColorsFromPrefs(), LoadScaleFromPrefs());
+            bool? timeout = null;
+            PlayerData playerData = null;
+
             // _nameInput.text = _playerAvatar.Name;
+            StartCoroutine(PlayerDataTransferer("get", null, data => timeout = data, data => playerData = data));
+
+            yield return new WaitUntil(() => ((timeout != null) || (playerData != null)));
+
+            if (playerData == null)
+                yield break;
+
+            _currentPlayerData = playerData;
+
+            if (_currentPlayerData.AvatarData == null)
+            {
+                Debug.Log("AvatarData is null. Using default data.");
+                //_featurePicker.GetDefaultAvatar();
+                _playerAvatar = new(new List<FeatureID>() { 0,0,0,0,0,0,0,0,0 } );
+                //yield break;
+            }
+            else
+                _playerAvatar = new(_currentPlayerData.AvatarData);
 
             _featurePicker.SetCharacterClassID(_characterLoader.GetCharacterClassID());
             _featurePicker.SetLoadedFeatures(_playerAvatar.Features);
@@ -87,49 +126,63 @@ namespace MenuUi.Scripts.AvatarEditor
             _colorPicker.SetLoadedColors(_playerAvatar.Colors, _playerAvatar.Features);
 
             _avatarScaler.SetLoadedScale(_playerAvatar.Scale);
+        }
 
-            
-        }
-        private List<FeatureID> LoadFeaturesFromPrefs()
-        {
-            List<FeatureID> features = new();
-            for(int i = 0; i < Enum.GetNames(typeof(FeatureSlot)).Length-1; i++){
-                features.Add((FeatureID)PlayerPrefs.GetInt(((FeatureSlot)i).ToString()+"Feature"));
-                Debug.Log("Loaded Feature: " + features[i].ToString() + " from a key of: " + ((FeatureSlot)i).ToString());
-            }
-            return features;
-        }
-        private List<FeatureColor> LoadColorsFromPrefs()
-        {
-            List<FeatureColor> colors = new();
-            for (int i = 0; i < Enum.GetNames(typeof(FeatureSlot)).Length-1; i++){
-                colors.Add((FeatureColor)PlayerPrefs.GetInt(((FeatureSlot)i).ToString()+"Color"));
-            }
-            return colors;
-        }
-        private Vector2 LoadScaleFromPrefs()
-        {
-            return new Vector2(PlayerPrefs.GetFloat("ScaleX"), PlayerPrefs.GetFloat("ScaleY"));
-        }
+        //private List<FeatureID> LoadFeaturesFromPrefs()
+        //{
+        //    List<FeatureID> features = new();
+        //    for(int i = 0; i < Enum.GetNames(typeof(FeatureSlot)).Length-1; i++){
+        //        features.Add((FeatureID)PlayerPrefs.GetInt(((FeatureSlot)i).ToString()+"Feature"));
+        //        Debug.Log("Loaded Feature: " + features[i].ToString() + " from a key of: " + ((FeatureSlot)i).ToString());
+        //    }
+        //    return features;
+        //}
+
+        //private List<FeatureColor> LoadColorsFromPrefs()
+        //{
+        //    List<FeatureColor> colors = new();
+        //    for (int i = 0; i < Enum.GetNames(typeof(FeatureSlot)).Length-1; i++){
+        //        colors.Add((FeatureColor)PlayerPrefs.GetInt(((FeatureSlot)i).ToString()+"Color"));
+        //    }
+        //    return colors;
+        //}
+
+        //private Vector2 LoadScaleFromPrefs()
+        //{
+        //    return new Vector2(PlayerPrefs.GetFloat("ScaleX"), PlayerPrefs.GetFloat("ScaleY"));
+        //}
+
         #endregion
+
         #region Saving Data
-        private void SetSaveableData(){
-            _currentlySelectedCategory = _featurePicker.GetCurrentlySelectedCategory();
-            _selectedScale = _avatarScaler.GetCurrentScale();
-        }
 
-        private void SaveAvatarData()
+        private void SetSaveableData()
         {
-            SetSaveableData();
-            SaveFeaturesToPrefs();
-            SaveColorsToPrefs();
-            SaveScaleToPrefs();
-            PlayerPrefs.Save();
-
-            SaveDataToScriptableObject();
+            _currentlySelectedCategory = _featurePicker.GetCurrentlySelectedCategory();
+            //_playerAvatar.
+            //_selectedScale = _avatarScaler.GetCurrentScale();
         }
 
-        
+        private IEnumerator SaveAvatarData()
+        {
+            bool? timeout = null;
+            PlayerData playerData = null;
+            PlayerData savePlayerData = _currentPlayerData;
+
+            savePlayerData.AvatarData = new(_playerAvatar.Name,
+                _playerAvatar.ToFeaturesListInt(_featurePicker.GetCurrentlySelectedFeatures()),
+                _playerAvatar.ToFeatureColorListInt(_colorPicker.GetCurrentColors()),
+                _avatarScaler.GetCurrentScale());
+
+            StartCoroutine(PlayerDataTransferer("save", savePlayerData, data => timeout = data, data => playerData = data));
+
+            yield return new WaitUntil(() => ((timeout != null) || (playerData != null)));
+
+            if (playerData == null)
+                yield break;
+
+            _currentPlayerData = playerData;
+        }
 
         // private void SaveName()
         // {
@@ -139,46 +192,111 @@ namespace MenuUi.Scripts.AvatarEditor
         //     _playerAvatar.Name = characterName;
         //     PlayerPrefs.SetString("CharacterName", characterName);
         // }
-        private void SaveFeaturesToPrefs()
-        {
-            List<FeatureID> features = _featurePicker.GetCurrentlySelectedFeatures();
-            for(int i = 0; i < features.Count; i++){
-                // Debug.Log("Saving feature: " +_selectedFeatures[i] + " to a string key named: " + ((FeatureSlot)i).ToString());
-                PlayerPrefs.SetInt(((FeatureSlot)i).ToString()+"Feature", (int)features[i]);
-            }
-        }
-        private void SaveColorsToPrefs()
-        {
-            List<FeatureColor> colors = _colorPicker.GetCurrentColors();
-            for(int i = 0; i < _playerAvatar.Colors.Count; i++){
-                Debug.Log("Saving color: " +colors[i] + " to a string key named: " + ((FeatureSlot)i).ToString());
-                PlayerPrefs.SetInt(((FeatureSlot)i).ToString()+"Color", (int)colors[i]);
-            }
-        }
-        private void SaveScaleToPrefs()
-        {
-            PlayerPrefs.SetFloat("ScaleX", _selectedScale.x);
-            PlayerPrefs.SetFloat("ScaleY", _selectedScale.y);
-        }
 
-        private void SaveDataToScriptableObject()
+        //private void SaveFeaturesToPrefs()
+        //{
+        //    List<FeatureID> features = _featurePicker.GetCurrentlySelectedFeatures();
+        //    for(int i = 0; i < features.Count; i++){
+        //        // Debug.Log("Saving feature: " +_selectedFeatures[i] + " to a string key named: " + ((FeatureSlot)i).ToString());
+        //        PlayerPrefs.SetInt(((FeatureSlot)i).ToString()+"Feature", (int)features[i]);
+        //    }
+        //}
+
+        //private void SaveColorsToPrefs()
+        //{
+        //    List<FeatureColor> colors = _colorPicker.GetCurrentColors();
+        //    for(int i = 0; i < _playerAvatar.Colors.Count; i++){
+        //        Debug.Log("Saving color: " +colors[i] + " to a string key named: " + ((FeatureSlot)i).ToString());
+        //        PlayerPrefs.SetInt(((FeatureSlot)i).ToString()+"Color", (int)colors[i]);
+        //    }
+        //}
+
+        //private void SaveScaleToPrefs()
+        //{
+        //    PlayerPrefs.SetFloat("ScaleX", _selectedScale.x);
+        //    PlayerPrefs.SetFloat("ScaleY", _selectedScale.y);
+        //}
+
+        //private void SaveDataToScriptableObject()
+        //{
+        //    _visualDataScriptableObject.sprites.Clear();
+        //    _visualDataScriptableObject.colors.Clear();
+        //    foreach(Image image in _avatarVisualsParent.GetComponentsInChildren<Image>())
+        //    {
+        //        _visualDataScriptableObject.sprites.Add(image.sprite);
+        //        _visualDataScriptableObject.colors.Add(image.color);
+        //    }
+        //}
+
+        private IEnumerator SavePlayerData(PlayerData playerData, System.Action<PlayerData> callback) //TODO: Remove when available in AltMonoBehaviour.
         {
-            _visualDataScriptableObject.sprites.Clear();
-            _visualDataScriptableObject.colors.Clear();
-            foreach(Image image in _avatarVisualsParent.GetComponentsInChildren<Image>())
-            {
-                _visualDataScriptableObject.sprites.Add(image.sprite);
-                _visualDataScriptableObject.colors.Add(image.color);
-            }
-            
+            //Cant' save to server because server manager doesn't have functionality!
+            //Storefront.Get().SavePlayerData(playerData, callback);
+
+            //if (callback == null)
+            //{
+            //    StartCoroutine(ServerManager.Instance.UpdatePlayerToServer( playerData., content =>
+            //    {
+            //        if (content != null)
+            //            callback(new(content));
+            //        else
+            //        {
+            //            Debug.LogError("Could not connect to server and save player");
+            //            return;
+            //        }
+            //    }));
+            //}
+
+            //yield return new WaitUntil(() => callback != null);
+
+            //Testing code
+            callback(playerData);
+
+            yield return true;
         }
 
         #endregion
-    }
-    enum AvatarEditorMode
-    {
-        FeaturePicker = 0,
-        ColorPicker = 1,
-        AvatarScaler = 2,
+
+        /// <summary>
+        /// Used to get and save player data to/from server.
+        /// </summary>
+        /// <param name="operationType">"get" or "save"</param>
+        /// <param name="unsavedData">If saving: insert unsaved data.<br/> If getting: insert <c>null</c>.</param>
+        /// <param name="timeoutCallback">Returns value if timeout with server.</param>
+        /// <param name="dataCallback">Returns <c>PlayerData</c>.</param>
+        private IEnumerator PlayerDataTransferer(string operationType, PlayerData unsavedData, System.Action<bool> timeoutCallback, System.Action<PlayerData> dataCallback)
+        {
+            PlayerData receivedData = null;
+            bool? timeout = null;
+            Coroutine playerCoroutine;
+
+            switch (operationType.ToLower())
+            {
+                case "get":
+                    {
+                        //Get player data.
+                        playerCoroutine = StartCoroutine(CoroutineWithTimeout(GetPlayerData, receivedData, _timeoutSeconds, timeoutCallBack => timeout = timeoutCallBack, data => receivedData = data));
+                        break;
+                    }
+                case "save":
+                    {
+                        //Save player data.
+                        playerCoroutine = StartCoroutine(CoroutineWithTimeout(SavePlayerData, unsavedData, receivedData, _timeoutSeconds, timeoutCallBack => timeout = timeoutCallBack, data => receivedData = data));
+                        break;
+                    }
+                default: Debug.LogError($"Received: {operationType}, when expecting \"get\" or \"save\"."); yield break;
+            }
+
+            yield return new WaitUntil(() => (receivedData != null || timeout != null));
+
+            if (receivedData == null)
+            {
+                timeoutCallback(true);
+                Debug.LogError($"Player data operation: \"{operationType}\" timeout or null.");
+                yield break;
+            }
+
+            dataCallback(receivedData);
+        }
     }
 }

--- a/Assets/MenuUi/Scripts/AvatarEditor/CharacterLoader.cs
+++ b/Assets/MenuUi/Scripts/AvatarEditor/CharacterLoader.cs
@@ -5,7 +5,6 @@ using Altzone.Scripts.Model.Poco.Player;
 using Altzone.Scripts;
 using UnityEngine;
 using UnityEngine.UI;
-using System.Runtime.CompilerServices;
 using System.Collections;
 
 namespace MenuUi.Scripts.AvatarEditor

--- a/Assets/MenuUi/Scripts/AvatarEditor/ColorPicker.cs
+++ b/Assets/MenuUi/Scripts/AvatarEditor/ColorPicker.cs
@@ -122,7 +122,7 @@ namespace MenuUi.Scripts.AvatarEditor
             for (int i = 0; i < colors.Count; i++)
             {
                 SelectFeature((FeatureSlot)i);
-                Debug.LogError(colors[i]);
+                //Debug.LogError(colors[i]);
                 if(features[i] == FeatureID.None)
                 {
                     SetTransparentColor();

--- a/Assets/MenuUi/Scripts/AvatarEditor/ColorPicker.cs
+++ b/Assets/MenuUi/Scripts/AvatarEditor/ColorPicker.cs
@@ -1,43 +1,43 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using Altzone.Scripts.Model.Poco.Game;
-using System;
+using System.Linq;
 
 namespace MenuUi.Scripts.AvatarEditor
 {
     public class ColorPicker : MonoBehaviour
     {
-        [SerializeField]private GameObject _colorButtonPrefab;
-        [SerializeField]private GameObject _defaultColorButtonPrefab;
-        [SerializeField]private List<Color> _colors;
-        [SerializeField]private List<Transform> _colorButtonPositions;
-        [SerializeField]private Transform _characterImageParent;
+        [SerializeField] private GameObject _colorButtonPrefab;
+        [SerializeField] private GameObject _defaultColorButtonPrefab;
+        [SerializeField] private List<Color> _colors;
+        [SerializeField] private List<Transform> _colorButtonPositions;
+        [SerializeField] private Transform _characterImageParent;
         private Image _colorChangeTarget;
         private CharacterClassID _characterClassID;
-        private List<FeatureColor> _currentColors = new(){
-            FeatureColor.White,
-            FeatureColor.White,
-            FeatureColor.White,
-            FeatureColor.White,
-            FeatureColor.White,
-            FeatureColor.White,
-            FeatureColor.White,
-            FeatureColor.White,
-            FeatureColor.White,     
+        private List<string> _currentColors = new(){
+            "#ffffff",
+            "#ffffff",
+            "#ffffff",
+            "#ffffff",
+            "#ffffff",
+            "#ffffff",
+            "#ffffff",
+            "#ffffff",
+            "#ffffff",
         };
         private FeatureSlot _currentlySelectedCategory;
+
         public void OnEnable()
         {
             // _colorChangeTarget = _characterImageParent.GetChild(0).GetChild(2).GetComponent<Image>();
             InstantiateColorButtons();
         }
+
         public void OnDisable()
         {
             DestroyColorButtons();
         }
-
 
         public void SelectFeature(FeatureSlot feature)
         {
@@ -49,17 +49,20 @@ namespace MenuUi.Scripts.AvatarEditor
         {
             for (int i = 0; i < _colors.Count; i++){
                 int j = i;
-                if(i == 0){
+                if(i == 0)
+                {
                     Button button = Instantiate(_defaultColorButtonPrefab, _colorButtonPositions[i]).GetComponent<Button>();
                     button.onClick.AddListener(delegate{SetColor(_colors[j]);});
                 }
-                else{
+                else
+                {
                     Button button = Instantiate(_colorButtonPrefab, _colorButtonPositions[i]).GetComponent<Button>();
                     button.GetComponent<Image>().color = _colors[i];
                     button.onClick.AddListener(delegate{SetColor(_colors[j]);});
                 }
             }
         }
+
         private void DestroyColorButtons()
         {
             foreach(Transform pos in _colorButtonPositions){
@@ -70,20 +73,29 @@ namespace MenuUi.Scripts.AvatarEditor
                     }
                 }
         }
+
         private void SetColor(Color color)
         {
-            _currentColors[(int)_currentlySelectedCategory] = (FeatureColor)_colors.IndexOf(color);
-            if(_colorChangeTarget != null){
+            if ((int)_currentlySelectedCategory != 0)
+                return;
+
+            _currentColors[(int)_currentlySelectedCategory] = "#" + ColorUtility.ToHtmlStringRGB(color);
+
+            if(_colorChangeTarget != null)
+            {
                 _colorChangeTarget.color = color;
-                if(_characterClassID == CharacterClassID.Confluent){
+                if(_characterClassID == CharacterClassID.Confluent)
+                {
                     _colorChangeTarget.transform.GetChild(0).GetComponent<Image>().color = color;
                 }
             }
         }
+
         private void SetDefaultColor()
         {
 
         }
+
         private void SetTransparentColor(){
             if(_colorChangeTarget != null){
                 _colorChangeTarget.color = new Color(255,255,255,0);
@@ -92,33 +104,43 @@ namespace MenuUi.Scripts.AvatarEditor
                 }
             }
         }
+
         public void SetCharacterClassID(CharacterClassID id)
         {
             _characterClassID = id;
         }
-        public List<FeatureColor> GetCurrentColors()
+
+        public List<string> GetCurrentColors()
         {
-            return _currentColors;
+            string[] colors = new string[_currentColors.Count];
+            _currentColors.CopyTo(colors);
+            return colors.ToList();
         }
-        public void SetLoadedColors(List<FeatureColor> colors, List<FeatureID> features)
+
+        public void SetLoadedColors(List<string> colors, List<FeatureID> features)
         {
             for (int i = 0; i < colors.Count; i++)
             {
                 SelectFeature((FeatureSlot)i);
-                if(features[i] == FeatureID.None){
+                Debug.LogError(colors[i]);
+                if(features[i] == FeatureID.None)
+                {
                     SetTransparentColor();
                 }
-                else if (features[i] == FeatureID.Default){
-                    Debug.Log("feature was default when cioloring!");
+                else if (features[i] == FeatureID.Default)
+                {
+                    Debug.Log("feature was default when coloring!");
                 }
-                else{
-                    SetColor(_colors[(int)colors[i]]);
+                else
+                {
+                    if(ColorUtility.TryParseHtmlString(colors[i], out Color color))
+                        SetColor(color);
                 }
-                
             }
         }
-        public void RestoreDefaultColor(FeatureSlot slot){
-            _currentColors[(int)slot] = FeatureColor.White;
+        public void RestoreDefaultColor(FeatureSlot slot)
+        {
+            _currentColors[(int)slot] = "#ffffff";
         }
 
         // internal void SetCurrentCategoryAndColors(FeatureSlot category, List<FeatureColor> colors) {

--- a/Assets/MenuUi/Scripts/AvatarEditor/FeaturePicker.cs
+++ b/Assets/MenuUi/Scripts/AvatarEditor/FeaturePicker.cs
@@ -263,6 +263,7 @@ namespace MenuUi.Scripts.AvatarEditor
 
         private void InstantiateRightSideButtons()
         {
+            //Debug.LogError(_currentCategoryFeatureDataPlaceholder.Count);
             for (int i = 4; i < 8; i++)
             {
                 //int j = i;
@@ -498,7 +499,7 @@ namespace MenuUi.Scripts.AvatarEditor
         public void SetLoadedFeatures(List<FeatureID> features)
         {
             for (int i = 0; i < features.Count; i++){
-                _currentCategoryFeatureDataPlaceholder = GetSpritesByCategory((FeatureSlot)i);
+                List<FeatureData> currentCategoryFeatureDataPlaceholder = GetSpritesByCategory((FeatureSlot)i);
                 //Debug.Log("Getting sprite at index: " + (int)features[i] + ", Sprite list count is: " + _currentCategorySpritesPlaceholder.Count);
                 // Debug.Log("The feature in slot " + ((FeatureSlot)i).ToString() + " is " + features[i].ToString() );
 
@@ -513,7 +514,7 @@ namespace MenuUi.Scripts.AvatarEditor
                 }
                 else
                 {
-                    FeatureData featureData = _currentCategoryFeatureDataPlaceholder.Find(x => x.id == features[i]);
+                    FeatureData featureData = currentCategoryFeatureDataPlaceholder.Find(x => x.id == features[i]);
                     SetFeature(featureData, i);
                 }
             }

--- a/Assets/MenuUi/Scripts/AvatarEditor/FeaturePicker.cs
+++ b/Assets/MenuUi/Scripts/AvatarEditor/FeaturePicker.cs
@@ -42,7 +42,7 @@ namespace MenuUi.Scripts.AvatarEditor
         [Header("Default features of each avatar archetype")]
         List<FeatureID> __ConfluenceGirlsOneDefaults = new()
             {
-            FeatureID.BlankHeadTwo,
+            FeatureID.BlankHeadOne,
             FeatureID.ConfluenceGirlsOneHair,
             FeatureID.ConfluenceGirlsOneEyes,
             FeatureID.ConfluenceGirlsOneNose,
@@ -52,7 +52,7 @@ namespace MenuUi.Scripts.AvatarEditor
             FeatureID.None,
             FeatureID.None
             };
-            List<FeatureID> __ConfluenceGirlsTwoDefaults = new()
+        List<FeatureID> __ConfluenceGirlsTwoDefaults = new()
             {
             FeatureID.BlankHeadTwo,
             FeatureID.ConfluenceGirlsTwoHair,
@@ -76,7 +76,7 @@ namespace MenuUi.Scripts.AvatarEditor
             FeatureID.None,
             FeatureID.None
             };
-            List<FeatureID> _bodybuilderDefaults = new()
+        List<FeatureID> _bodybuilderDefaults = new()
             {
             FeatureID.BlankHeadOne,
             FeatureID.ResearcherHair,
@@ -88,7 +88,7 @@ namespace MenuUi.Scripts.AvatarEditor
             FeatureID.None,
             FeatureID.None
             };
-            List<FeatureID> _comedianDefaults = new()
+        List<FeatureID> _comedianDefaults = new()
             {
             FeatureID.BlankHeadOne,
             FeatureID.ResearcherHair,
@@ -112,7 +112,7 @@ namespace MenuUi.Scripts.AvatarEditor
             FeatureID.None,
             FeatureID.None
             };
-            List<FeatureID> _overeaterDefaults = new()
+        List<FeatureID> _overeaterDefaults = new()
             {
             FeatureID.BlankHeadTwo,
             FeatureID.OvereaterHair,
@@ -124,7 +124,7 @@ namespace MenuUi.Scripts.AvatarEditor
             FeatureID.None,
             FeatureID.None
             };
-            List<FeatureID> _preacherDefaults = new()
+        List<FeatureID> _preacherDefaults = new()
             {
             FeatureID.BlankHeadTwo,
             FeatureID.PreacherHair,
@@ -170,8 +170,6 @@ namespace MenuUi.Scripts.AvatarEditor
         // private AvatarEditorSwipe _swiper;
         private RectTransform _swipeArea;
 
-
-
         public void Start()
         {
             _swipeArea = GetComponent<RectTransform>();
@@ -180,17 +178,20 @@ namespace MenuUi.Scripts.AvatarEditor
             _pageButtons[0].GetComponent<Button>().onClick.AddListener(LoadNextPage);
             _pageButtons[1].GetComponent<Button>().onClick.AddListener(LoadPreviousPage);
         }
+
         public void OnEnable()
         {
             _currentlySelectedCategory = _defaultCategory;
             SwitchFeatureCategory();
             SwipeHandler.OnSwipe += OnFeaturePickerSwipe;
         }
+
         public void OnDisable()
         {
             DestroyFeatureButtons();
             SwipeHandler.OnSwipe -= OnFeaturePickerSwipe;
         }
+
         private void OnFeaturePickerSwipe(SwipeDirection direction, Vector2 swipeStartPoint, Vector2 swipeEndPoint)
         {
             Debug.Log("swipe detected!");
@@ -214,6 +215,7 @@ namespace MenuUi.Scripts.AvatarEditor
                 }
             }
         }
+
         private void LoadNextPage()
         {
             if(_currentPageNumber < _pageCount-1 && _animator.GetCurrentAnimatorStateInfo(0).IsName("Idle")){
@@ -221,6 +223,7 @@ namespace MenuUi.Scripts.AvatarEditor
                 StartCoroutine(PlayNextPageAnimation());      
             }
         }
+
         private IEnumerator PlayNextPageAnimation()
         {
             DestroyRightSideButtons();
@@ -232,6 +235,7 @@ namespace MenuUi.Scripts.AvatarEditor
             DestroyLeftSideButtons();
             InstantiateLeftSideButtons();
         }
+
         private void LoadPreviousPage()
         {
             if (_currentPageNumber > 0 && _animator.GetCurrentAnimatorStateInfo(0).IsName("Idle")){
@@ -239,6 +243,7 @@ namespace MenuUi.Scripts.AvatarEditor
                 StartCoroutine(PlayPreviousPageAnimation());
             }
         }
+
         private IEnumerator PlayPreviousPageAnimation()
         {
             DestroyLeftSideButtons();
@@ -249,104 +254,140 @@ namespace MenuUi.Scripts.AvatarEditor
             DestroyRightSideButtons();
             InstantiateRightSideButtons();
         }
+
         private void InstantiateFeatureButtons()
         {
             InstantiateRightSideButtons();
             InstantiateLeftSideButtons();
         }
+
         private void InstantiateRightSideButtons()
         {
             for (int i = 4; i < 8; i++)
             {
-                int j = i;
-                if ((i + (8*_currentPageNumber) < _currentCategoryFeatureDataPlaceholder.Count) || 
-                (i + (8*_currentPageNumber) == _currentCategoryFeatureDataPlaceholder.Count && (_currentPageNumber != 0||i!=8)) )
+                //int j = i;
+                int categoryFeatureIndex = i + (8 * _currentPageNumber);
+
+                if ((categoryFeatureIndex < _currentCategoryFeatureDataPlaceholder.Count) || 
+                (categoryFeatureIndex == _currentCategoryFeatureDataPlaceholder.Count && (_currentPageNumber != 0|| i !=8 )))
                 {
                     Button featureButton = Instantiate(_featureButtonPrefab, _featureButtonPositions[i]).GetComponent<Button>();
                     // featureButton._sprite = _currentCategoryFeatureDataPlaceholder[i+ (8*_currentPageNumber)-1].sprite;
                     // featureButton._slot = _currentlySelectedCategory;
-                    if(_currentCategoryFeatureDataPlaceholder[i+ (8*_currentPageNumber)-1].iconSprite != null){
-                        featureButton.gameObject.GetComponent<Image>().sprite = _currentCategoryFeatureDataPlaceholder[i+ (8*_currentPageNumber)-1].iconSprite;
+                    if(_currentCategoryFeatureDataPlaceholder[categoryFeatureIndex - 1].iconSprite != null){
+                        featureButton.gameObject.GetComponent<Image>().sprite = _currentCategoryFeatureDataPlaceholder[categoryFeatureIndex - 1].iconSprite;
                     }
                     else{
-                        featureButton.gameObject.GetComponent<Image>().sprite = _currentCategoryFeatureDataPlaceholder[i+ (8*_currentPageNumber)-1].sprite;
+                        featureButton.gameObject.GetComponent<Image>().sprite = _currentCategoryFeatureDataPlaceholder[categoryFeatureIndex - 1].sprite;
                     }
                     featureButton.gameObject.GetComponent<Button>().onClick.AddListener
-                    (delegate { FeatureButtonClicked(_currentCategoryFeatureDataPlaceholder[j+ (8*_currentPageNumber)-1], (int)_currentlySelectedCategory); });
+                    (delegate { FeatureButtonClicked(_currentCategoryFeatureDataPlaceholder[categoryFeatureIndex - 1], (int)_currentlySelectedCategory); });
                 }
             }
         }
+
         private void InstantiateLeftSideButtons()
         {
+            //Debug.LogError(_currentCategoryFeatureDataPlaceholder.Count);
             for (int i = 0; i < 4; i++)
             {
-                int j = i;
-                if(i == 0 && _currentPageNumber == 0){
+                //int j = i;
+                int categoryFeatureIndex = i + (8 * _currentPageNumber);
+
+                if (i == 0 && _currentPageNumber == 0)
+                {
                     Button featureButton = Instantiate(_defaultFeatureButtonPrefab, _featureButtonPositions[i]).GetComponent<Button>();
                     // featureButton._slot = _currentlySelectedCategory;
                     featureButton.gameObject.GetComponent<Button>().onClick.AddListener
                     (delegate { SetFeatureToNone((int)_currentlySelectedCategory); });
                 }
-                else if ((i + (8*_currentPageNumber) < _currentCategoryFeatureDataPlaceholder.Count) || 
-                (i + (8*_currentPageNumber) == _currentCategoryFeatureDataPlaceholder.Count && (_currentPageNumber != 0||i!=8)) )
+                else if ((categoryFeatureIndex < _currentCategoryFeatureDataPlaceholder.Count) || 
+                (categoryFeatureIndex == _currentCategoryFeatureDataPlaceholder.Count && ((_currentPageNumber != 0) || (i != 8))))
                 {
                     Button featureButton = Instantiate(_featureButtonPrefab, _featureButtonPositions[i]).GetComponent<Button>();
                     // featureButton._sprite = _currentCategoryFeatureDataPlaceholder[i+ (8*_currentPageNumber)-1].sprite;
                     // featureButton._slot = _currentlySelectedCategory;
-                    if(_currentCategoryFeatureDataPlaceholder[i+ (8*_currentPageNumber)-1].iconSprite != null){
-                        featureButton.gameObject.GetComponent<Image>().sprite = _currentCategoryFeatureDataPlaceholder[i+ (8*_currentPageNumber)-1].iconSprite;
+                    if(_currentCategoryFeatureDataPlaceholder[categoryFeatureIndex - 1].iconSprite != null)
+                    {
+                        featureButton.gameObject.GetComponent<Image>().sprite = _currentCategoryFeatureDataPlaceholder[categoryFeatureIndex - 1].iconSprite;
                     }
-                    else{
-                        featureButton.gameObject.GetComponent<Image>().sprite = _currentCategoryFeatureDataPlaceholder[i+ (8*_currentPageNumber)-1].sprite;
+                    else
+                    {
+                        featureButton.gameObject.GetComponent<Image>().sprite = _currentCategoryFeatureDataPlaceholder[categoryFeatureIndex - 1].sprite;
                     }
-                    
                     featureButton.gameObject.GetComponent<Button>().onClick.AddListener
-                    (delegate { FeatureButtonClicked(_currentCategoryFeatureDataPlaceholder[j+ (8*_currentPageNumber)-1], (int)_currentlySelectedCategory); });
+                    (delegate { FeatureButtonClicked(_currentCategoryFeatureDataPlaceholder[categoryFeatureIndex - 1], (int)_currentlySelectedCategory); });
                 }
             }
         }
+
         private void DestroyFeatureButtons()
         {
             DestroyLeftSideButtons();
             DestroyRightSideButtons();
         }
+
         private void DestroyLeftSideButtons()
         {
-            for(int i = 0; i < 4; i++){
-                if(_featureButtonPositions[i].childCount > 0){
-                    foreach(Transform child in _featureButtonPositions[i]){
+            for(int i = 0; i < 4; i++)
+            {
+                if(_featureButtonPositions[i].childCount > 0)
+                {
+                    foreach(Transform child in _featureButtonPositions[i])
+                    {
                         Destroy(child.gameObject);
                     }
                 }
             }
         }
+
         private void DestroyRightSideButtons()
         {
-            for(int i = 4; i < 8; i++){
-                if(_featureButtonPositions[i].childCount > 0){
-                    foreach(Transform child in _featureButtonPositions[i]){
+            for(int i = 4; i < 8; i++)
+            {
+                if(_featureButtonPositions[i].childCount > 0)
+                {
+                    foreach(Transform child in _featureButtonPositions[i])
+                    {
                         Destroy(child.gameObject);
                     }
                 }
             }
         }
-        private void FeatureButtonClicked(FeatureData featureToChange, int slot){
+
+        private void FeatureButtonClicked(FeatureData featureToChange, int slot)
+        {
             SetFeature(featureToChange, slot);
             _restoreDefaultColor?.Invoke();
         }
+
         private void SetFeature(FeatureData featureToChange, int slot)
         {
-            Debug.Log("_selectedFeatures[slot] is" + _selectedFeatures[slot] );
+            //Debug.Log("_selectedFeatures[slot] is" + _selectedFeatures[slot] );
             _selectedFeatures[slot] = featureToChange.id;
             _characterImage = _characterImageParent.GetChild(0);
-            _characterImage.GetChild(slot).GetComponent<Image>().sprite = featureToChange.sprite;
-            _characterImage.GetChild(slot).GetComponent<Image>().color = new Color(255, 255, 255,255);
-            if(_characterClassID == CharacterClassID.Confluent){
-                _characterImage.GetChild(slot).GetChild(0).GetComponent<Image>().sprite = featureToChange.sprite;
-                _characterImage.GetChild(slot).GetChild(0).GetComponent<Image>().color = new Color(255, 255, 255,255);
+
+            if (featureToChange.sprite == null)
+                _characterImage.GetChild(slot).gameObject.SetActive(false);
+            else
+            {
+                _characterImage.GetChild(slot).gameObject.SetActive(true);
+                _characterImage.GetChild(slot).GetComponent<Image>().sprite = featureToChange.sprite;
+                _characterImage.GetChild(slot).GetComponent<Image>().color = new Color(255, 255, 255,255);
             }
-            
+
+            if(_characterClassID == CharacterClassID.Confluent){
+                if (featureToChange.sprite == null)
+                    _characterImage.GetChild(slot).GetChild(0).gameObject.SetActive(false);
+                else
+                {
+                    _characterImage.GetChild(slot).GetChild(0).gameObject.SetActive(true);
+                    _characterImage.GetChild(slot).GetChild(0).GetComponent<Image>().sprite = featureToChange.sprite;
+                    _characterImage.GetChild(slot).GetChild(0).GetComponent<Image>().color = new Color(255, 255, 255, 255);
+                }
+            }
         }
+
         private void SetFeatureToNone(int slot)
         {
             _selectedFeatures[slot] = FeatureID.None;
@@ -358,18 +399,22 @@ namespace MenuUi.Scripts.AvatarEditor
                 _characterImage.GetChild(slot).GetChild(0).GetComponent<Image>().sprite = null;
             }
         }
+
         private void LoadNextCategory()
         {
             _currentlySelectedCategory++ ;
-            if( (int)_currentlySelectedCategory >= Enum.GetNames(typeof(FeatureSlot)).Length ){
+            if( (int)_currentlySelectedCategory >= Enum.GetNames(typeof(FeatureSlot)).Length )
+            {
                 _currentlySelectedCategory = 0 ;
             }
             SwitchFeatureCategory();
         }
+
         private void LoadPreviousCategory()
         {
             _currentlySelectedCategory--;
-            if( (int)_currentlySelectedCategory < 0){
+            if( (int)_currentlySelectedCategory < 0)
+            {
                 _currentlySelectedCategory = (FeatureSlot)(Enum.GetNames(typeof(FeatureSlot)).Length-1);
             }
             SwitchFeatureCategory();
@@ -379,10 +424,11 @@ namespace MenuUi.Scripts.AvatarEditor
         {
             //placeholder until available features can be read from player inventory
             _currentCategoryFeatureDataPlaceholder = GetSpritesByCategory(_currentlySelectedCategory);
-
+            //Debug.LogError(_currentCategoryFeatureDataPlaceholder.Count);
             _currentPageNumber = 0;
-            _pageCount = (_currentCategoryFeatureDataPlaceholder.Count+1) / 8;
-            if((_currentCategoryFeatureDataPlaceholder.Count+1) % 8 != 0){
+            _pageCount = (_currentCategoryFeatureDataPlaceholder.Count + 1) / 8;
+            if((_currentCategoryFeatureDataPlaceholder.Count + 1) % 8 != 0)
+            {
                 _pageCount++;
             }
 
@@ -411,13 +457,12 @@ namespace MenuUi.Scripts.AvatarEditor
             _categoryText.text = name;
         }
 
-
         //placeholder until available features can be read from player inventory
         private List<FeatureData> GetSpritesByCategory(FeatureSlot slot)
         {
             return slot switch
             {
-                FeatureSlot.WholeHead => _blankHeadDataPlaceholder,        
+                FeatureSlot.WholeHead => _blankHeadDataPlaceholder,
                 FeatureSlot.Hair => _hairDataPlaceholder,
                 FeatureSlot.Eyes => _eyesDataPlaceholder,
                 FeatureSlot.Nose => _noseDataPlaceholder,
@@ -429,10 +474,12 @@ namespace MenuUi.Scripts.AvatarEditor
                 _ => null,
             };
         }
+
         public FeatureSlot GetCurrentlySelectedCategory()
         {
             return _currentlySelectedCategory;
         }
+
         public List<FeatureID> GetCurrentlySelectedFeatures()
         {
             return _selectedFeatures;
@@ -442,12 +489,14 @@ namespace MenuUi.Scripts.AvatarEditor
         {
             _characterClassID = id;
         }
+
         public void RestoreDefaultColorToFeature(Action restore)
         {
             _restoreDefaultColor = restore;
         }
     
-        public void SetLoadedFeatures(List<FeatureID> features){
+        public void SetLoadedFeatures(List<FeatureID> features)
+        {
             for (int i = 0; i < features.Count; i++){
                 _currentCategoryFeatureDataPlaceholder = GetSpritesByCategory((FeatureSlot)i);
                 //Debug.Log("Getting sprite at index: " + (int)features[i] + ", Sprite list count is: " + _currentCategorySpritesPlaceholder.Count);
@@ -457,17 +506,19 @@ namespace MenuUi.Scripts.AvatarEditor
                 {
                     features[i] = ResolveCharacterDefaultFeature(i);
                 }
-                if (features[i] == FeatureID.None){
+
+                if (features[i] == FeatureID.None)
+                {
                     SetFeatureToNone(i);
                 }
-                else{
+                else
+                {
                     FeatureData featureData = _currentCategoryFeatureDataPlaceholder.Find(x => x.id == features[i]);
                     SetFeature(featureData, i);
                 }
-                
-                
             }
         }
+
         public FeatureID ResolveCharacterDefaultFeature(int slotIndex)
         {
             return _characterClassID switch
@@ -482,7 +533,5 @@ namespace MenuUi.Scripts.AvatarEditor
                 _ => FeatureID.None,
             };
         }
-
-        
     }
 }

--- a/Assets/MenuUi/Scripts/AvatarEditor/PlayerAvatar.cs
+++ b/Assets/MenuUi/Scripts/AvatarEditor/PlayerAvatar.cs
@@ -1,5 +1,5 @@
-using System.Collections;
 using System.Collections.Generic;
+using Assets.Altzone.Scripts.Model.Poco.Player;
 using UnityEngine;
 
 namespace MenuUi.Scripts.AvatarEditor
@@ -11,6 +11,14 @@ namespace MenuUi.Scripts.AvatarEditor
         private List<FeatureColor> _colors;
         private Vector2 _scale;
 
+        public PlayerAvatar(List<FeatureID> featureIds)
+        {
+            _characterName = "";
+            _features = featureIds;
+            _colors = new List<FeatureColor>();
+            _scale = Vector2.one;
+        }
+
         public PlayerAvatar(string name, List<FeatureID> features, List<FeatureColor> colors, Vector2 scale)
         {
             _characterName = name;
@@ -18,6 +26,55 @@ namespace MenuUi.Scripts.AvatarEditor
             _colors = colors;
             _scale = scale;
         }
+
+        public PlayerAvatar(AvatarData data)
+        {
+            _characterName = data.Name;
+            _features = ToFeaturesListEnum(data.Features);
+            _colors = ToFeatureColorListEnum(data.Colors);
+            _scale = data.Scale;
+        }
+
+        private List<FeatureID> ToFeaturesListEnum(List<int> indexes)
+        {
+            List<FeatureID> tempList = new List<FeatureID>();
+
+            foreach (var index in indexes)
+                tempList.Add((FeatureID)index);
+
+            return (tempList);
+        }
+
+        public List<int> ToFeaturesListInt(List<FeatureID> featureIds)
+        {
+            List<int> tempList = new List<int>();
+
+            foreach (var featureId in featureIds)
+                tempList.Add((int)featureId);
+
+            return (tempList);
+        }
+
+        private List<FeatureColor> ToFeatureColorListEnum(List<int> indexes)
+        {
+            List<FeatureColor> tempList = new List<FeatureColor>();
+
+            foreach (var index in indexes)
+                tempList.Add((FeatureColor)index);
+
+            return (tempList);
+        }
+
+        public List<int> ToFeatureColorListInt(List<FeatureColor> featureColors)
+        {
+            List<int> tempList = new List<int>();
+
+            foreach (var featureColor in featureColors)
+                tempList.Add((int)featureColor);
+
+            return (tempList);
+        }
+
         public string Name
         {
             get => _characterName;

--- a/Assets/MenuUi/Scripts/AvatarEditor/PlayerAvatar.cs
+++ b/Assets/MenuUi/Scripts/AvatarEditor/PlayerAvatar.cs
@@ -8,18 +8,18 @@ namespace MenuUi.Scripts.AvatarEditor
     {
         private string _characterName;
         private List<FeatureID> _features;
-        private List<FeatureColor> _colors;
+        private List<string> _colors;
         private Vector2 _scale;
 
         public PlayerAvatar(List<FeatureID> featureIds)
         {
             _characterName = "";
             _features = featureIds;
-            _colors = new List<FeatureColor>();
+            _colors = new List<string>();
             _scale = Vector2.one;
         }
 
-        public PlayerAvatar(string name, List<FeatureID> features, List<FeatureColor> colors, Vector2 scale)
+        public PlayerAvatar(string name, List<FeatureID> features, List<string> colors, Vector2 scale)
         {
             _characterName = name;
             _features = features;
@@ -31,7 +31,7 @@ namespace MenuUi.Scripts.AvatarEditor
         {
             _characterName = data.Name;
             _features = ToFeaturesListEnum(data.Features);
-            _colors = ToFeatureColorListEnum(data.Colors);
+            _colors = data.Colors;
             _scale = data.Scale;
         }
 
@@ -55,26 +55,6 @@ namespace MenuUi.Scripts.AvatarEditor
             return (tempList);
         }
 
-        private List<FeatureColor> ToFeatureColorListEnum(List<int> indexes)
-        {
-            List<FeatureColor> tempList = new List<FeatureColor>();
-
-            foreach (var index in indexes)
-                tempList.Add((FeatureColor)index);
-
-            return (tempList);
-        }
-
-        public List<int> ToFeatureColorListInt(List<FeatureColor> featureColors)
-        {
-            List<int> tempList = new List<int>();
-
-            foreach (var featureColor in featureColors)
-                tempList.Add((int)featureColor);
-
-            return (tempList);
-        }
-
         public string Name
         {
             get => _characterName;
@@ -84,7 +64,7 @@ namespace MenuUi.Scripts.AvatarEditor
             get => _features;
             set => _features = value;
         }
-        public List<FeatureColor> Colors{
+        public List<string> Colors{
             get => _colors;
             set => _colors = value;
         }


### PR DESCRIPTION
- Changed saving and loading in AvatarEditor from local to server.
- Fixed a bug where in AvatarEditor where multiple different customization choices didn't show up correctly in the book.
- Made a few code files slightly more readable regarding AvatarEditor.
- Fixed an issue where if there was no sprite image for a customization part it would show a big white box which would cover up majority of the avatar character.
- Bug: When AvatarEditor page is opened the books head selection is broken until the page is switched.