### PR TITLE
Battle/feature - BattleCamera

### DIFF
--- a/Assets/QuantumUser/Resources/QuantumMap.asset
+++ b/Assets/QuantumUser/Resources/QuantumMap.asset
@@ -483,7 +483,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 2
     - rid: 913064374447374336
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -548,7 +548,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 1
     - rid: 1328971346486493184
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -613,7 +613,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 1
     - rid: 2088931844912316416
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -808,7 +808,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 2
     - rid: 3169004087781883904
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -938,7 +938,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 3
     - rid: 4099470505776513024
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -1013,7 +1013,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 2
     - rid: 4544874563732766720
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -1143,7 +1143,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 1
     - rid: 4747002504288403456
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -1270,7 +1270,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 3
     - rid: 5490577773346947072
       type: {class: GameSessionPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
@@ -1557,7 +1557,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 2
     - rid: 6392158612130627584
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -1622,7 +1622,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 3
     - rid: 6448816403360251904
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -1749,7 +1749,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 1
     - rid: 6616239857112973312
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -1814,7 +1814,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 3
     - rid: 6973906860017451008
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -2074,7 +2074,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 3
     - rid: 7740059535200485376
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -2269,7 +2269,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 1
     - rid: 8278934809653280768
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
@@ -2374,7 +2374,7 @@ MonoBehaviour:
             RawValue: -65536
         CollisionMinOffset:
           RawValue: 13107
-        Layer: 0
+        Layer: 2
     - rid: 8922606233861488640
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:

--- a/Assets/QuantumUser/Scenes/QuantumGameScene.unity
+++ b/Assets/QuantumUser/Scenes/QuantumGameScene.unity
@@ -122,6 +122,20 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!114 &8648785
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5756210810806569140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01fc2f98fef0e664d9275ea569ef0cd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetAspectRatio: {x: 9, y: 16}
+  _letterBoxOrPillarColor: {r: 0.23137257, g: 0.23137257, b: 0.23137257, a: 1}
 --- !u!1 &24359552
 GameObject:
   m_ObjectHideFlags: 0
@@ -8918,95 +8932,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1173031904}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1175640448
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 637648641814191721, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: _camera
-      value: 
-      objectReference: {fileID: 1175640450}
-    - target: {fileID: 637648641814191721, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: _background
-      value: 
-      objectReference: {fileID: 368801155}
-    - target: {fileID: 637648641814191721, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: _gridOverlay
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5756210811780550964, guid: beeca0598aa323045953bf66df53ccbf,
-        type: 3}
-      propertyPath: m_Name
-      value: Main Camera
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: beeca0598aa323045953bf66df53ccbf, type: 3}
---- !u!4 &1175640450 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5756210811780550961, guid: beeca0598aa323045953bf66df53ccbf,
-    type: 3}
-  m_PrefabInstance: {fileID: 1175640448}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1198122345
 GameObject:
   m_ObjectHideFlags: 0
@@ -12462,6 +12387,113 @@ MonoBehaviour:
     Name: {fileID: 897294480}
     Value: {fileID: 1737853509}
   _referenceText: {fileID: 258981062}
+--- !u!4 &5756210810806569137
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5756210810806569140}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 10, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &5756210810806569140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5756210810806569137}
+  - component: {fileID: 5756210810806569144}
+  - component: {fileID: 8648785}
+  - component: {fileID: 5756210810806569142}
+  - component: {fileID: 5756210810806569143}
+  m_Layer: 0
+  m_Name: BattleCamera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &5756210810806569142
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5756210810806569140}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 8
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &5756210810806569143
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5756210810806569140}
+  m_Enabled: 1
+--- !u!114 &5756210810806569144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5756210810806569140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 348cb0c3bea012b4390feb0c1db08db7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _camera: {fileID: 5756210810806569142}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -12473,7 +12505,7 @@ SceneRoots:
   - {fileID: 120694984}
   - {fileID: 992096346}
   - {fileID: 677758279}
-  - {fileID: 1175640448}
+  - {fileID: 5756210810806569137}
   - {fileID: 848240679}
   - {fileID: 503723467}
   - {fileID: 88804847}

--- a/Assets/QuantumUser/Scripts/Game.meta
+++ b/Assets/QuantumUser/Scripts/Game.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5f46e7cbee24014f838ed98115e3acb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/QuantumUser/Scripts/Game/BattleCamera.cs
+++ b/Assets/QuantumUser/Scripts/Game/BattleCamera.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace QuantumUser.Scripts
+{
+    public class BattleCamera : MonoBehaviour
+    {
+        [SerializeField] private Camera _camera;
+
+        public static Camera Camera { get; private set; }
+
+        public static void Rotate180()
+        {
+            Camera.transform.rotation *= Quaternion.Euler(0, 0, 180);
+        }
+
+        private void Awake()
+        {
+            Assert.IsNotNull(_camera, "_camera must be assigned in Editor");
+            Camera = _camera;
+        }
+    }
+}

--- a/Assets/QuantumUser/Scripts/Game/BattleCamera.cs.meta
+++ b/Assets/QuantumUser/Scripts/Game/BattleCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 348cb0c3bea012b4390feb0c1db08db7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/QuantumUser/Scripts/Player/PlayerInput.cs
+++ b/Assets/QuantumUser/Scripts/Player/PlayerInput.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 
 using Prg.Scripts.Common;
 
+using QuantumUser.Scripts;
+
 namespace Quantum
 {
     public class PlayerInput : MonoBehaviour
@@ -24,7 +26,7 @@ namespace Quantum
             Input i = new()
             {
                 MouseClick = mouseClick,
-                MousePosition = mouseClick ? Camera.main.ScreenToWorldPoint(ClickStateHandler.GetClickPosition()).ToFPVector3() : FPVector3.Zero,
+                MousePosition = mouseClick ? BattleCamera.Camera.ScreenToWorldPoint(ClickStateHandler.GetClickPosition()).ToFPVector3() : FPVector3.Zero,
                 //RotateMotion = twoFingers,
                 RotationDirection = twoFingers ? FP.FromFloat_UNSAFE(ClickStateHandler.GetRotationDirection()) : 0,
             };


### PR DESCRIPTION
Merged GameCamera and CameraRotate into BattleCamera.

[Altzone/Assets/Battle1/Scripts/Battle/Game/GameCamera.cs](https://github.com/Alt-Org/Altzone/blob/7d867c984f4420ea618f471941ccedd6368e5aaf/Assets/Battle1/Scripts/Battle/Game/GameCamera.cs)
[Altzone/Assets/Battle1/Scripts/Battle/Game/CameraRotate.cs](https://github.com/Alt-Org/Altzone/blob/7d867c984f4420ea618f471941ccedd6368e5aaf/Assets/Battle1/Scripts/Battle/Game/CameraRotate.cs)

BattleCamera provides static way to handle the Camera by providing a static reference the Camera and implementing static methods (currently only one) to control the Camera.

However BattleCamera does not do all the unnecessary stuff which should not be the cameras responsibility to do that the CameraRotate did.