### PR TITLE
TabLineBase code update

### DIFF
--- a/Assets/MenuUi/Prefabs/Canvas/UICanvas.prefab
+++ b/Assets/MenuUi/Prefabs/Canvas/UICanvas.prefab
@@ -364,10 +364,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _headerPanelRectTransfrom: {fileID: 2853600601693954760}
-  _headerHeight: 300
+  _headerHeight: 0
   _tablinePanelRectTransfrom: {fileID: 6398403803529559136}
-  _tablineHeight: 150
+  _tablineHeight: 240
   _contentPanelRectTransfrom: {fileID: 8620236399698832103}
+  _sideMarginPercent: 4.4
 --- !u!1 &7695168990374541657
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterStatsWindow/TabLineStatsWindow.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterStatsWindow/TabLineStatsWindow.prefab
@@ -678,6 +678,12 @@ PrefabInstance:
       propertyPath: _tabLineButtons.Array.data[1]._detailImageComponent
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 691666503692277821, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f9502a761bdb9d443a2586af83639324,
+        type: 3}
     - target: {fileID: 1404414662961198789, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_Color.b
@@ -718,6 +724,12 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4446425129320008669, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: c433a4178a90cc34c821393bcf41915e,
+        type: 3}
     - target: {fileID: 4789815415191667178, guid: e22bdd3e0c370fc4b80581ecb7a9da83,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size

--- a/Assets/MenuUi/Prefabs/UI Components/TabLineBase.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/TabLineBase.prefab
@@ -1,5 +1,80 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &258274524171755608
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5933796935965987536}
+  - component: {fileID: 9013570597165320928}
+  - component: {fileID: 691666503692277821}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5933796935965987536
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 258274524171755608}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5481847502602699424}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9013570597165320928
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 258274524171755608}
+  m_CullTransparentMesh: 1
+--- !u!114 &691666503692277821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 258274524171755608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 218a0d74e6232c74a95b4febf37458c1, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1581564565178853607
 GameObject:
   m_ObjectHideFlags: 0
@@ -139,26 +214,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _getActiveButtonFromSwipe: 0
   _tabLineButtons:
-  - _activeTabSprite: {fileID: 0}
-    _activeDetailSprite: {fileID: 0}
-    _inactiveTabSprite: {fileID: 0}
-    _inactiveDetailSprite: {fileID: 0}
-    ButtonComponent: {fileID: 4920232304727102816}
-    _tabImageComponent: {fileID: 6682411111857242805}
+  - _tabImageComponent: {fileID: 691666503692277821}
     _detailImageComponent: {fileID: 8342995491120871134}
-  - _activeTabSprite: {fileID: 0}
-    _activeDetailSprite: {fileID: 0}
-    _inactiveTabSprite: {fileID: 0}
-    _inactiveDetailSprite: {fileID: 0}
-    ButtonComponent: {fileID: 472687744616341565}
-    _tabImageComponent: {fileID: 4972399519487402402}
+  - _tabImageComponent: {fileID: 4446425129320008669}
     _detailImageComponent: {fileID: 7155573576286643043}
-  - _activeTabSprite: {fileID: 0}
-    _activeDetailSprite: {fileID: 0}
-    _inactiveTabSprite: {fileID: 0}
-    _inactiveDetailSprite: {fileID: 0}
-    ButtonComponent: {fileID: 4789815415191667178}
-    _tabImageComponent: {fileID: 1404414662961198789}
+  - _tabImageComponent: {fileID: 7568300063729769355}
     _detailImageComponent: {fileID: 8593413527962958490}
 --- !u!114 &3713396448592114125
 MonoBehaviour:
@@ -592,6 +652,81 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6062859111145985214
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8244517282282759826}
+  - component: {fileID: 4146308306407852127}
+  - component: {fileID: 7568300063729769355}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8244517282282759826
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6062859111145985214}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 967324241565757491}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4146308306407852127
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6062859111145985214}
+  m_CullTransparentMesh: 1
+--- !u!114 &7568300063729769355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6062859111145985214}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 218a0d74e6232c74a95b4febf37458c1, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6550600573153545701
 GameObject:
   m_ObjectHideFlags: 0
@@ -729,6 +864,81 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6623981909853504828
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4598407965264247056}
+  - component: {fileID: 6533519791317298954}
+  - component: {fileID: 4446425129320008669}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4598407965264247056
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623981909853504828}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3083645397524688902}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6533519791317298954
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623981909853504828}
+  m_CullTransparentMesh: 1
+--- !u!114 &4446425129320008669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6623981909853504828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 218a0d74e6232c74a95b4febf37458c1, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6770141693460230907
 GameObject:
   m_ObjectHideFlags: 0
@@ -814,10 +1024,10 @@ GameObject:
   m_Component:
   - component: {fileID: 967324241565757491}
   - component: {fileID: 1507820355924492803}
-  - component: {fileID: 1404414662961198789}
   - component: {fileID: 2156363974896026552}
   - component: {fileID: 4789815415191667178}
   - component: {fileID: 6929618301302178271}
+  - component: {fileID: 1618817436301805729}
   m_Layer: 5
   m_Name: Tab3
   m_TagString: Untagged
@@ -837,6 +1047,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 8244517282282759826}
   - {fileID: 6248046967856910512}
   - {fileID: 8344569462132350313}
   m_Father: {fileID: 8203757857133268421}
@@ -854,36 +1065,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8769779974361688627}
   m_CullTransparentMesh: 1
---- !u!114 &1404414662961198789
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8769779974361688627}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 218a0d74e6232c74a95b4febf37458c1, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &2156363974896026552
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -944,7 +1125,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 1404414662961198789}
+  m_TargetGraphic: {fileID: 7568300063729769355}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -965,6 +1146,36 @@ MonoBehaviour:
   _audioName: 
   _audioId: 0
   _playType: 0
+--- !u!114 &1618817436301805729
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8769779974361688627}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8814453850970363211
 GameObject:
   m_ObjectHideFlags: 0
@@ -1112,9 +1323,9 @@ GameObject:
   m_Component:
   - component: {fileID: 5481847502602699424}
   - component: {fileID: 6231890896208705229}
-  - component: {fileID: 6682411111857242805}
   - component: {fileID: 7199942720947860399}
   - component: {fileID: 4920232304727102816}
+  - component: {fileID: 7669899189156203559}
   - component: {fileID: 2548392813359834845}
   m_Layer: 5
   m_Name: Tab1
@@ -1135,6 +1346,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 5933796935965987536}
   - {fileID: 3214811803715067279}
   - {fileID: 6491052246776402545}
   m_Father: {fileID: 8203757857133268421}
@@ -1152,36 +1364,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8942873394016518354}
   m_CullTransparentMesh: 1
---- !u!114 &6682411111857242805
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8942873394016518354}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 218a0d74e6232c74a95b4febf37458c1, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &7199942720947860399
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1242,10 +1424,40 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 6682411111857242805}
+  m_TargetGraphic: {fileID: 691666503692277821}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &7669899189156203559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8942873394016518354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &2548392813359834845
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1348,10 +1560,10 @@ GameObject:
   m_Component:
   - component: {fileID: 3083645397524688902}
   - component: {fileID: 547449346485082341}
-  - component: {fileID: 4972399519487402402}
   - component: {fileID: 6986359796901339571}
   - component: {fileID: 472687744616341565}
   - component: {fileID: 6590668127655172773}
+  - component: {fileID: 1066527191964011387}
   m_Layer: 5
   m_Name: Tab2
   m_TagString: Untagged
@@ -1371,6 +1583,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 4598407965264247056}
   - {fileID: 719586555136371328}
   - {fileID: 4228070945647309752}
   m_Father: {fileID: 8203757857133268421}
@@ -1388,36 +1601,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9086470811603517342}
   m_CullTransparentMesh: 1
---- !u!114 &4972399519487402402
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9086470811603517342}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 218a0d74e6232c74a95b4febf37458c1, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &6986359796901339571
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1478,7 +1661,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 4972399519487402402}
+  m_TargetGraphic: {fileID: 4446425129320008669}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -1499,3 +1682,33 @@ MonoBehaviour:
   _audioName: 
   _audioId: 0
   _playType: 0
+--- !u!114 &1066527191964011387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9086470811603517342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/MenuUi/Prefabs/UI Components/TabLineBase.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/TabLineBase.prefab
@@ -283,7 +283,7 @@ RectTransform:
   m_Father: {fileID: 190456095295517285}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.6}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -358,7 +358,7 @@ RectTransform:
   - {fileID: 967324241565757491}
   m_Father: {fileID: 190456095295517285}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.6}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -972,7 +972,7 @@ RectTransform:
   m_Father: {fileID: 190456095295517285}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.6}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1508,7 +1508,7 @@ RectTransform:
   m_Father: {fileID: 190456095295517285}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.6}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/MenuUi/Scripts/TabLine/TabLine.cs
+++ b/Assets/MenuUi/Scripts/TabLine/TabLine.cs
@@ -18,6 +18,11 @@ namespace MenuUi.Scripts.TabLine
 
         private void Awake()
         {
+            foreach (TabLineButton button in _tabLineButtons)
+            {
+                button.SetImageRectTransform();
+            }
+
             if (_getActiveButtonFromSwipe)
             {
                 _swipe = FindObjectOfType<SwipeUI>();
@@ -85,42 +90,47 @@ namespace MenuUi.Scripts.TabLine
         [Serializable]
         private class TabLineButton
         {
-            [Header("Sprite assets (detail sprites are optional)")]
-            [SerializeField] private Sprite _activeTabSprite;
-            [SerializeField] private Sprite _activeDetailSprite;
-            [SerializeField] private Sprite _inactiveTabSprite;
-            [SerializeField] private Sprite _inactiveDetailSprite;
-
             [Header("References to components")]
-            [SerializeField] public Button ButtonComponent;
             [SerializeField] private Image _tabImageComponent;
             [SerializeField] private Image _detailImageComponent;
+
+            private RectTransform _imageRectTransform;
+            private RectTransform _detailImageRectTransform;
+
+            private const float OffsetAmount = -20.0f;
+
+            private Vector2 _offset = new Vector2(0, OffsetAmount);
+
+            public void SetImageRectTransform()
+            {
+                _imageRectTransform = _tabImageComponent.gameObject.GetComponent<RectTransform>();
+                if (_detailImageComponent != null ) _detailImageRectTransform = _tabImageComponent.gameObject.GetComponent<RectTransform>();
+            }
 
 
             public void SetActiveVisuals()
             {
-                if (_tabImageComponent != null && _activeTabSprite != null)
-                {
-                    _tabImageComponent.sprite = _activeTabSprite;
-                }
+                _imageRectTransform.offsetMin = Vector2.zero;
+                _imageRectTransform.offsetMax = Vector2.zero;
 
-                if (_detailImageComponent != null && _activeDetailSprite != null)
+                if (_detailImageComponent != null )
                 {
-                    _detailImageComponent.sprite = _activeDetailSprite;
+                    _detailImageRectTransform.offsetMin = Vector2.zero;
+                    _detailImageRectTransform.offsetMax = Vector2.zero;
                 }
             }
 
 
             public void SetInactiveVisuals()
             {
-                if (_tabImageComponent != null && _inactiveTabSprite != null)
-                {
-                    _tabImageComponent.sprite = _inactiveTabSprite;
-                }
+                
+                _imageRectTransform.offsetMin = _offset;
+                _imageRectTransform.offsetMax = _offset;
 
-                if (_detailImageComponent != null && _inactiveDetailSprite != null)
+                if (_detailImageComponent != null)
                 {
-                    _detailImageComponent.sprite = _inactiveDetailSprite;
+                    _detailImageRectTransform.offsetMin = _offset;
+                    _detailImageRectTransform.offsetMax = _offset;
                 }
             }
         }


### PR DESCRIPTION
- Changed the way the TabLine.cs code works. Instead of separate sprites moving the image gameobject lower. 
- This breaks every tab line in game where the old system was implemented because the Image component is now a separate gameobject under the Tab gameobject. The tab Image component is only for raycast blocking now so that the squished tabs have the same touch are as active tabs.
- Fixed the tab line in character stats window.
- Made tab ribbon thicker.