### PR TITLE
Add unowned character from gallery and swipe back from character stats window

### DIFF
--- a/Assets/Altzone/Resources/Characters/CharacterSpec_102.asset
+++ b/Assets/Altzone/Resources/Characters/CharacterSpec_102.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   Id: 102
   CharacterId: 102
   IsApproved: 1
-  Name: Bodari
+  Name: Lihamuuri
   ClassType: 100
   Hp:
     Level: 0
@@ -23,7 +23,7 @@ MonoBehaviour:
   Speed:
     Level: 0
     Coefficient: 0
-  Resistance:
+  CharacterSize:
     Level: 0
     Coefficient: 0
   Attack:

--- a/Assets/Altzone/Resources/Characters/CharacterSpec_201.asset
+++ b/Assets/Altzone/Resources/Characters/CharacterSpec_201.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   Id: 201
   CharacterId: 201
   IsApproved: 1
-  Name: Humoristi
+  Name: "Vitsinv\xE4\xE4nt\xE4j\xE4"
   ClassType: 200
   Hp:
     Level: 0

--- a/Assets/Altzone/Resources/Characters/CharacterSpec_401.asset
+++ b/Assets/Altzone/Resources/Characters/CharacterSpec_401.asset
@@ -14,9 +14,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Id: 401
   CharacterId: 401
-  Name: Taiteilija
   IsApproved: 1
+  Name: Provokaattori
   ClassType: 400
+  Hp:
+    Level: 0
+    Coefficient: 0
+  Speed:
+    Level: 0
+    Coefficient: 0
+  CharacterSize:
+    Level: 0
+    Coefficient: 0
+  Attack:
+    Level: 0
+    Coefficient: 0
+  Defence:
+    Level: 0
+    Coefficient: 0
   GalleryImage: {fileID: 21300000, guid: c3ccef0c9c6027b46848eb4ad73c7a2d, type: 3}
   BattleSprite: {fileID: 0}
-  Image: {fileID: 21300000, guid: c3ccef0c9c6027b46848eb4ad73c7a2d, type: 3}

--- a/Assets/Altzone/Resources/Characters/CharacterSpec_603.asset
+++ b/Assets/Altzone/Resources/Characters/CharacterSpec_603.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   Id: 603
   CharacterId: 603
   IsApproved: 1
-  Name: Unikeko
+  Name: "Valveenv\xE4lttelij\xE4"
   ClassType: 600
   Hp:
     Level: 0

--- a/Assets/Altzone/Resources/Characters/CharacterSpec_701.asset
+++ b/Assets/Altzone/Resources/Characters/CharacterSpec_701.asset
@@ -14,9 +14,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Id: 701
   CharacterId: 701
-  Name: Tietoviisas
   IsApproved: 1
+  Name: Viisastelija
   ClassType: 700
+  Hp:
+    Level: 0
+    Coefficient: 0
+  Speed:
+    Level: 0
+    Coefficient: 0
+  CharacterSize:
+    Level: 0
+    Coefficient: 0
+  Attack:
+    Level: 0
+    Coefficient: 0
+  Defence:
+    Level: 0
+    Coefficient: 0
   GalleryImage: {fileID: 21300000, guid: f18115989b2eb6c41814556747fde0dc, type: 3}
   BattleSprite: {fileID: 0}
-  Image: {fileID: 21300000, guid: f18115989b2eb6c41814556747fde0dc, type: 3}

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
@@ -287,6 +287,126 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3787461569119996055
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 238660308610784203}
+  - component: {fileID: 1071761546767883214}
+  - component: {fileID: 4293059418501489457}
+  - component: {fileID: 6091851420338286691}
+  m_Layer: 5
+  m_Name: AddCharacterButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &238660308610784203
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3787461569119996055}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6762374876794546724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.55, y: 0.05}
+  m_AnchorMax: {x: 0.95, y: 0.25}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1071761546767883214
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3787461569119996055}
+  m_CullTransparentMesh: 1
+--- !u!114 &4293059418501489457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3787461569119996055}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: bb286cc9815658a46ad77858957dfd59, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6091851420338286691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3787461569119996055}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4293059418501489457}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &4297384447084397024
 GameObject:
   m_ObjectHideFlags: 0
@@ -329,6 +449,7 @@ RectTransform:
   - {fileID: 8467504842734029194}
   - {fileID: 5024676260890555381}
   - {fileID: 8223340465562428939}
+  - {fileID: 238660308610784203}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -787,6 +908,11 @@ PrefabInstance:
       propertyPath: initialSlot
       value: 
       objectReference: {fileID: 6762374876794546724}
+    - target: {fileID: 5574122708305743662, guid: 00dd9bde2849f9c498dd00c084457690,
+        type: 3}
+      propertyPath: _addCharacterButton
+      value: 
+      objectReference: {fileID: 6091851420338286691}
     - target: {fileID: 8755021714922067558, guid: 00dd9bde2849f9c498dd00c084457690,
         type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/MenuUi/Prefabs/Windows/DefenceScreen/CharacterStatsWindowView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DefenceScreen/CharacterStatsWindowView.prefab
@@ -703,6 +703,8 @@ GameObject:
   - component: {fileID: 3918795687960719334}
   - component: {fileID: 7550082918384091370}
   - component: {fileID: 6405207172733369044}
+  - component: {fileID: 5158419458400868755}
+  - component: {fileID: 2160977431121218550}
   m_Layer: 5
   m_Name: SwipeUI
   m_TagString: Untagged
@@ -792,6 +794,32 @@ MonoBehaviour:
   isEnabled: 0
   _isInMainMenu: 0
   _willRotate: 0
+--- !u!114 &5158419458400868755
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8446825354444719657}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: abcb222a881e3234f98051491acc0259, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _swipeThreshold: 500
+--- !u!114 &2160977431121218550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8446825354444719657}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b44774a969c719b46b53b8f0fcf475f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _swipeUi: {fileID: 6405207172733369044}
 --- !u!1 &8461862895016730330
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelView.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelView.cs
@@ -184,6 +184,12 @@ namespace MenuUi.Scripts.CharacterGallery
                     charSlot.IsLocked = true;
                 }
             }
+
+            // ensures character slots are selectable if edit toggle is on, it can happen if adding unowned character from the + button while edit mode is on
+            if (_editModeToggle.isOn) 
+            {
+                SetCharacterSlotsSelectable(true);
+            }
         }
 
 

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/SwipeBack.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/SwipeBack.cs
@@ -27,7 +27,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
         private void HandleSwipe(SwipeDirection direction, Vector2 swipeStartPoint, Vector2 swipeEndPoint)
         {
-            if (_swipeUi.CurrentPage == 0 && direction == SwipeDirection.Right && _swipeUi.ScrollbarValue == 0)
+            if (_swipeUi.CurrentPage == 0 && direction == SwipeDirection.Right && _swipeUi.ScrollbarValue < 0.01f)
             {
                 WindowManager.Get().GoBack();
             }

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/SwipeBack.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/SwipeBack.cs
@@ -1,0 +1,36 @@
+using SwipeHandler = MenuUi.Scripts.AvatarEditor.SwipeHandler;
+using MenuUi.Scripts.SwipeNavigation;
+using UnityEngine;
+using MenuUi.Scripts.AvatarEditor;
+using MenuUi.Scripts.Window;
+
+namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
+{
+    /// <summary>
+    /// Is used to handle swiping back from character stats window.
+    /// </summary>
+    public class SwipeBack : MonoBehaviour
+    {
+        [SerializeField] SwipeUI _swipeUi;
+
+        private void Awake()
+        {
+            SwipeHandler.OnSwipe += HandleSwipe;
+        }
+
+
+        private void OnDestroy()
+        {
+            SwipeHandler.OnSwipe -= HandleSwipe;
+        }
+
+
+        private void HandleSwipe(SwipeDirection direction, Vector2 swipeStartPoint, Vector2 swipeEndPoint)
+        {
+            if (_swipeUi.CurrentPage == 0 && direction == SwipeDirection.Right && _swipeUi.ScrollbarValue == 0)
+            {
+                WindowManager.Get().GoBack();
+            }
+        }
+    }
+}

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/SwipeBack.cs.meta
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/SwipeBack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b44774a969c719b46b53b8f0fcf475f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Scripts/SwipeNavigation/SwipeUI.cs
+++ b/Assets/MenuUi/Scripts/SwipeNavigation/SwipeUI.cs
@@ -90,6 +90,8 @@ namespace MenuUi.Scripts.SwipeNavigation
 
         public bool IsInMainMenu { get => _isInMainMenu;}
 
+        public float ScrollbarValue { get => scrollBar.value; }
+
         private void Awake()
         {
             scrollPageValues = new float[slides.Length];


### PR DESCRIPTION
(Accidentally published pull request before I wrote it, that's why the name changed. Branch can be deleted)
- Added plus button to character inventory slot to add unowned character to account. 
- Updated character names to character specs.
- Implemented swiping back from the character stats window by swiping left. 