### PR TITLE
Duplicate characters bug fixed for gallery and battle popup, other gallery fixes

### DIFF
--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
@@ -226,7 +226,7 @@ MonoBehaviour:
   m_fontColor32:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/SelectedCharacterInventorySlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/SelectedCharacterInventorySlot.prefab
@@ -301,7 +301,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 6845068988401538286}
-  - {fileID: 978708161471739503}
   - {fileID: 4446701218286156652}
   - {fileID: 1384255858663696716}
   m_Father: {fileID: 0}
@@ -333,7 +332,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _animator: {fileID: 2882276164179685324}
   _selectButton: {fileID: 1784020564661175013}
-  _selectedImage: {fileID: 0}
+  IsLocked: 0
   SlotIndex: 0
 --- !u!95 &2882276164179685324
 Animator:
@@ -356,81 +355,6 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!1 &6164511984087834122
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 978708161471739503}
-  - component: {fileID: 2271888084446167577}
-  - component: {fileID: 2838483451103392805}
-  m_Layer: 5
-  m_Name: DetailsOverlay
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &978708161471739503
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6164511984087834122}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6762374876794546724}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &2271888084446167577
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6164511984087834122}
-  m_CullTransparentMesh: 1
---- !u!114 &2838483451103392805
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6164511984087834122}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 71d674438388ba84aa04ee4e1cc04f81, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6294324379657879964
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/Windows/DefenceScreen/DefenceView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DefenceScreen/DefenceView.prefab
@@ -85,13 +85,13 @@ RectTransform:
   m_GameObject: {fileID: 8490628801868288283}
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: -1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4874288492435854606}
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
-  m_AnchorMin: {x: 0.1, y: 0.1}
-  m_AnchorMax: {x: 0.3, y: 1.2}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.25, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -768,7 +768,7 @@ PrefabInstance:
     - target: {fileID: 2609038723656894371, guid: f8adbf41952228b4980d80ecace0ef68,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 229.6936
+      value: 216.1936
       objectReference: {fileID: 0}
     - target: {fileID: 3326469629065364767, guid: f8adbf41952228b4980d80ecace0ef68,
         type: 3}

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
@@ -132,7 +132,7 @@ namespace MenuUi.Scripts.CharacterGallery
                 {
                     characterIds[i] = _playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == selectedCharacterIds[i]) == null ? 0 : (int)_playerData.CustomCharacters.FirstOrDefault(x => x.ServerID == selectedCharacterIds[i]).Id;
                 }
-                var characters = playerData.CustomCharacters.ToList();
+                var characters = playerData.CustomCharacters.GroupBy(x => x.Id).Select(x => x.First()).ToList(); // ensuring no duplicate characters if account is bugged
                 characters.Sort((a, b) => a.Id.CompareTo(b.Id));
                 // Set characters in the ModelView
                 _view.SetCharacters(characters, characterIds);

--- a/Assets/MenuUi/Scripts/Lobby/SelectedCharacters/BattlePopupSelectedCharacter.cs
+++ b/Assets/MenuUi/Scripts/Lobby/SelectedCharacters/BattlePopupSelectedCharacter.cs
@@ -140,7 +140,7 @@ namespace MenuUi.Scripts.Lobby.SelectedCharacters
         {
             StartCoroutine(GetPlayerData(playerData =>
             {
-                var characters = playerData.CustomCharacters.ToList();
+                var characters = playerData.CustomCharacters.GroupBy(x => x.Id).Select(x => x.First()).ToList(); // ensuring no duplicate characters are shown
 
                 foreach (CustomCharacter character in characters)
                 {

--- a/Assets/MenuUi/Scripts/Lobby/SelectedCharacters/BattlePopupSelectedCharacter.cs
+++ b/Assets/MenuUi/Scripts/Lobby/SelectedCharacters/BattlePopupSelectedCharacter.cs
@@ -141,6 +141,7 @@ namespace MenuUi.Scripts.Lobby.SelectedCharacters
             StartCoroutine(GetPlayerData(playerData =>
             {
                 var characters = playerData.CustomCharacters.GroupBy(x => x.Id).Select(x => x.First()).ToList(); // ensuring no duplicate characters are shown
+                characters.Sort((a, b) => a.Id.CompareTo(b.Id));
 
                 foreach (CustomCharacter character in characters)
                 {


### PR DESCRIPTION
- Fixed showing duplicate characters in gallery and battle popup selected characters dropdown.
- Removed missing detail sprite from SelectedCharacterInventorySlot which made the three slots white in gallery.
- Updated gallery shield image anchoring to be similar to stats window.
- Changed CharacterInventorySlot character name text to be black like GalleryCharacter.
- Sorting battle popup selected character dropdown similarly to character gallery so that it's easier to navigate.