### PR TITLE
Battle/fix -  SoulWallHotFix

### DIFF
--- a/Assets/QuantumUser/Resources/Prefabs/SoulWall/SoulWallBaseViewModel.prefab
+++ b/Assets/QuantumUser/Resources/Prefabs/SoulWall/SoulWallBaseViewModel.prefab
@@ -26,7 +26,7 @@ Transform:
   m_GameObject: {fileID: 2250820785126713692}
   serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.25, y: 0, z: 0}
   m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -84,7 +84,7 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
+  m_SpriteSortPoint: 1
 --- !u!1 &5304101879190269854
 GameObject:
   m_ObjectHideFlags: 0
@@ -172,7 +172,7 @@ Transform:
   m_GameObject: {fileID: 6537143282256487563}
   serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.25, y: 0, z: -0.25}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -230,7 +230,7 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
+  m_SpriteSortPoint: 1
 --- !u!1 &8669846514663460406
 GameObject:
   m_ObjectHideFlags: 0
@@ -257,7 +257,7 @@ Transform:
   m_GameObject: {fileID: 8669846514663460406}
   serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.25, y: 0, z: -0.25}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -314,4 +314,4 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
+  m_SpriteSortPoint: 1

--- a/Assets/QuantumUser/Resources/Prefabs/SoulWall/SoulWallSegmentType1.prefab
+++ b/Assets/QuantumUser/Resources/Prefabs/SoulWall/SoulWallSegmentType1.prefab
@@ -315,6 +315,16 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4648919006187227021, guid: cf6114ddf4664f330a499fb4cca33ed8,
         type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 4648919006187227021, guid: cf6114ddf4664f330a499fb4cca33ed8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 4648919006187227021, guid: cf6114ddf4664f330a499fb4cca33ed8,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 90
       objectReference: {fileID: 0}
@@ -346,8 +356,23 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8224459561721514793, guid: cf6114ddf4664f330a499fb4cca33ed8,
         type: 3}
+      propertyPath: m_SpriteSortPoint
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8224459561721514793, guid: cf6114ddf4664f330a499fb4cca33ed8,
+        type: 3}
       propertyPath: m_WasSpriteAssigned
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8671197901361138759, guid: cf6114ddf4664f330a499fb4cca33ed8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8671197901361138759, guid: cf6114ddf4664f330a499fb4cca33ed8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.25
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/QuantumUser/Resources/Prefabs/SoulWall/SoulWallSegmentType2.prefab
+++ b/Assets/QuantumUser/Resources/Prefabs/SoulWall/SoulWallSegmentType2.prefab
@@ -341,7 +341,7 @@ PrefabInstance:
     - target: {fileID: 4648919006187227021, guid: cf6114ddf4664f330a499fb4cca33ed8,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.5
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 5304101879190269854, guid: cf6114ddf4664f330a499fb4cca33ed8,
         type: 3}
@@ -392,7 +392,7 @@ PrefabInstance:
     - target: {fileID: 8671197901361138759, guid: cf6114ddf4664f330a499fb4cca33ed8,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.5
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 8671197901361138759, guid: cf6114ddf4664f330a499fb4cca33ed8,
         type: 3}

--- a/Assets/QuantumUser/Resources/Specs/BattleArenaSpec.asset
+++ b/Assets/QuantumUser/Resources/Specs/BattleArenaSpec.asset
@@ -35,403 +35,313 @@ MonoBehaviour:
     Col: 6
   SoulWallTeamAlphaTemplates:
   - Position:
-      Row: 0
-      Col: -1
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 0
-      Col: 1
-    Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 0
-      Col: 3
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 0
-      Col: 5
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 0
-      Col: 7
-    Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 0
-      Col: 9
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 0
-      Col: 11
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 0
-      Col: 13
-    Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 0
-      Col: 15
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 0
-      Col: 17
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 0
-      Col: 19
-    Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 0
-      Col: 21
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 0
-      Col: 23
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 1
-      Col: -1
-    Width: 1
-    ColorIndex: 1
-  - Position:
       Row: 1
       Col: 0
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 1
-      Col: 2
-    Width: 2
+    Width: 4
     ColorIndex: 0
   - Position:
       Row: 1
       Col: 4
-    Width: 2
+    Width: 4
     ColorIndex: 1
-  - Position:
-      Row: 1
-      Col: 6
-    Width: 2
-    ColorIndex: 2
   - Position:
       Row: 1
       Col: 8
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 1
-      Col: 10
-    Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 1
-      Col: 12
-    Width: 2
+    Width: 4
     ColorIndex: 2
   - Position:
       Row: 1
-      Col: 14
-    Width: 2
+      Col: 12
+    Width: 4
     ColorIndex: 0
   - Position:
       Row: 1
       Col: 16
-    Width: 2
+    Width: 4
     ColorIndex: 1
-  - Position:
-      Row: 1
-      Col: 18
-    Width: 2
-    ColorIndex: 2
   - Position:
       Row: 1
       Col: 20
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 1
-      Col: 22
-    Width: 2
-    ColorIndex: 1
+    Width: 4
+    ColorIndex: 2
   - Position:
       Row: 1
       Col: 24
-    Width: 1
-    ColorIndex: 2
-  - Position:
-      Row: 2
-      Col: -1
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 2
-      Col: 1
-    Width: 2
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 2
-      Col: 3
+      Row: 1
+      Col: 28
+    Width: 4
+    ColorIndex: 1
+  - Position:
+      Row: 1
+      Col: 32
+    Width: 4
+    ColorIndex: 2
+  - Position:
+      Row: 1
+      Col: 36
+    Width: 4
+    ColorIndex: 0
+  - Position:
+      Row: 3
+      Col: 0
     Width: 2
     ColorIndex: 1
   - Position:
-      Row: 2
-      Col: 5
-    Width: 2
+      Row: 3
+      Col: 2
+    Width: 4
     ColorIndex: 2
   - Position:
-      Row: 2
-      Col: 7
-    Width: 2
+      Row: 3
+      Col: 6
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 2
-      Col: 9
+      Row: 3
+      Col: 10
+    Width: 4
+    ColorIndex: 1
+  - Position:
+      Row: 3
+      Col: 14
+    Width: 4
+    ColorIndex: 2
+  - Position:
+      Row: 3
+      Col: 18
+    Width: 4
+    ColorIndex: 0
+  - Position:
+      Row: 3
+      Col: 22
+    Width: 4
+    ColorIndex: 1
+  - Position:
+      Row: 3
+      Col: 26
+    Width: 4
+    ColorIndex: 2
+  - Position:
+      Row: 3
+      Col: 30
+    Width: 4
+    ColorIndex: 0
+  - Position:
+      Row: 3
+      Col: 34
+    Width: 4
+    ColorIndex: 1
+  - Position:
+      Row: 3
+      Col: 38
     Width: 2
     ColorIndex: 1
   - Position:
-      Row: 2
-      Col: 11
-    Width: 2
+      Row: 5
+      Col: 0
+    Width: 4
     ColorIndex: 2
   - Position:
-      Row: 2
-      Col: 13
-    Width: 2
+      Row: 5
+      Col: 4
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 2
-      Col: 15
-    Width: 2
+      Row: 5
+      Col: 8
+    Width: 4
     ColorIndex: 1
   - Position:
-      Row: 2
-      Col: 17
-    Width: 2
+      Row: 5
+      Col: 12
+    Width: 4
     ColorIndex: 2
   - Position:
-      Row: 2
-      Col: 19
-    Width: 2
+      Row: 5
+      Col: 16
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 2
-      Col: 21
-    Width: 2
+      Row: 5
+      Col: 20
+    Width: 4
     ColorIndex: 1
   - Position:
-      Row: 2
-      Col: 23
-    Width: 2
+      Row: 5
+      Col: 24
+    Width: 4
+    ColorIndex: 2
+  - Position:
+      Row: 5
+      Col: 28
+    Width: 4
+    ColorIndex: 0
+  - Position:
+      Row: 5
+      Col: 32
+    Width: 4
+    ColorIndex: 1
+  - Position:
+      Row: 5
+      Col: 36
+    Width: 4
     ColorIndex: 2
   SoulWallTeamBetaTemplates:
   - Position:
-      Row: 43
-      Col: 23
-    Width: 2
+      Row: 69
+      Col: 36
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 43
-      Col: 21
-    Width: 2
+      Row: 69
+      Col: 32
+    Width: 4
     ColorIndex: 1
   - Position:
-      Row: 43
-      Col: 19
-    Width: 2
+      Row: 69
+      Col: 28
+    Width: 4
     ColorIndex: 2
   - Position:
-      Row: 43
-      Col: 17
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 43
-      Col: 15
-    Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 43
-      Col: 13
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 43
-      Col: 11
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 43
-      Col: 9
-    Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 43
-      Col: 7
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 43
-      Col: 5
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 43
-      Col: 3
-    Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 43
-      Col: 1
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 43
-      Col: -1
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 42
+      Row: 69
       Col: 24
-    Width: 1
-    ColorIndex: 1
+    Width: 4
+    ColorIndex: 0
   - Position:
-      Row: 42
-      Col: 22
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 42
+      Row: 69
       Col: 20
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 42
-      Col: 18
-    Width: 2
+    Width: 4
     ColorIndex: 1
   - Position:
-      Row: 42
+      Row: 69
       Col: 16
-    Width: 2
+    Width: 4
     ColorIndex: 2
   - Position:
-      Row: 42
-      Col: 14
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 42
+      Row: 69
       Col: 12
-    Width: 2
-    ColorIndex: 1
+    Width: 4
+    ColorIndex: 0
   - Position:
-      Row: 42
-      Col: 10
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 42
+      Row: 69
       Col: 8
-    Width: 2
+    Width: 4
+    ColorIndex: 1
+  - Position:
+      Row: 69
+      Col: 4
+    Width: 4
+    ColorIndex: 2
+  - Position:
+      Row: 69
+      Col: 0
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 42
-      Col: 6
+      Row: 67
+      Col: 38
     Width: 2
     ColorIndex: 1
   - Position:
-      Row: 42
-      Col: 4
-    Width: 2
+      Row: 67
+      Col: 34
+    Width: 4
     ColorIndex: 2
   - Position:
-      Row: 42
-      Col: 2
-    Width: 2
+      Row: 67
+      Col: 30
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 42
+      Row: 67
+      Col: 26
+    Width: 4
+    ColorIndex: 1
+  - Position:
+      Row: 67
+      Col: 22
+    Width: 4
+    ColorIndex: 2
+  - Position:
+      Row: 67
+      Col: 18
+    Width: 4
+    ColorIndex: 0
+  - Position:
+      Row: 67
+      Col: 14
+    Width: 4
+    ColorIndex: 1
+  - Position:
+      Row: 67
+      Col: 10
+    Width: 4
+    ColorIndex: 2
+  - Position:
+      Row: 67
+      Col: 6
+    Width: 4
+    ColorIndex: 0
+  - Position:
+      Row: 67
+      Col: 2
+    Width: 4
+    ColorIndex: 1
+  - Position:
+      Row: 67
       Col: 0
     Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 42
-      Col: -1
-    Width: 1
     ColorIndex: 2
   - Position:
-      Row: 41
-      Col: 23
-    Width: 2
+      Row: 65
+      Col: 36
+    Width: 4
     ColorIndex: 2
   - Position:
-      Row: 41
-      Col: 21
-    Width: 2
+      Row: 65
+      Col: 32
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 41
-      Col: 19
-    Width: 2
+      Row: 65
+      Col: 28
+    Width: 4
     ColorIndex: 1
   - Position:
-      Row: 41
-      Col: 17
-    Width: 2
+      Row: 65
+      Col: 24
+    Width: 4
     ColorIndex: 2
   - Position:
-      Row: 41
-      Col: 15
-    Width: 2
+      Row: 65
+      Col: 20
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 41
-      Col: 13
-    Width: 2
+      Row: 65
+      Col: 16
+    Width: 4
     ColorIndex: 1
   - Position:
-      Row: 41
-      Col: 11
-    Width: 2
+      Row: 65
+      Col: 12
+    Width: 4
     ColorIndex: 2
   - Position:
-      Row: 41
-      Col: 9
-    Width: 2
+      Row: 65
+      Col: 8
+    Width: 4
     ColorIndex: 0
   - Position:
-      Row: 41
-      Col: 7
-    Width: 2
+      Row: 65
+      Col: 4
+    Width: 4
     ColorIndex: 1
   - Position:
-      Row: 41
-      Col: 5
-    Width: 2
-    ColorIndex: 2
-  - Position:
-      Row: 41
-      Col: 3
-    Width: 2
-    ColorIndex: 0
-  - Position:
-      Row: 41
-      Col: 1
-    Width: 2
-    ColorIndex: 1
-  - Position:
-      Row: 41
-      Col: -1
-    Width: 2
+      Row: 65
+      Col: 0
+    Width: 4
     ColorIndex: 2

--- a/Assets/QuantumUser/Resources/Specs/BattleArenaSpec.asset
+++ b/Assets/QuantumUser/Resources/Specs/BattleArenaSpec.asset
@@ -20,8 +20,8 @@ MonoBehaviour:
     RawValue: 589824
   WorldHeight:
     RawValue: 1048576
-  GridWidth: 24
-  GridHeight: 44
+  GridWidth: 38
+  GridHeight: 70
   MiddleAreaHeight: 4
   SoulWallHeight: 0
   PlayerSpawnPositions:

--- a/Assets/QuantumUser/Scenes/31-QuantumBattle.unity
+++ b/Assets/QuantumUser/Scenes/31-QuantumBattle.unity
@@ -554,6 +554,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1957537065}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &113196676 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5685116848877297894, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+    type: 3}
+  m_PrefabInstance: {fileID: 1735170625}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6dd1380afc79a6409c69e363b2e93aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &120694984
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3635,6 +3647,89 @@ MonoBehaviour:
   View:
     Id:
       Value: 0
+--- !u!1001 &1735170625
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 986755674777429635, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5685116848877297894, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: _colorA.a
+      value: 0.078431375
+      objectReference: {fileID: 0}
+    - target: {fileID: 5685116848877297894, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: _colorB.a
+      value: 0.078431375
+      objectReference: {fileID: 0}
+    - target: {fileID: 5685116848877297894, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: _gridParent
+      value: 
+      objectReference: {fileID: 20218209}
+    - target: {fileID: 7492090454604236184, guid: 4c9026e52048f4c4a9a4b484571e84ed,
+        type: 3}
+      propertyPath: m_Name
+      value: BattleGridViewController
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4c9026e52048f4c4a9a4b484571e84ed, type: 3}
 --- !u!1 &1957537064
 GameObject:
   m_ObjectHideFlags: 0
@@ -3958,6 +4053,11 @@ PrefabInstance:
       objectReference: {fileID: 2118663608}
     - target: {fileID: 8816702143117302233, guid: 7e0904d2b2ca0f145ad03f5086282bbb,
         type: 3}
+      propertyPath: _gridViewController
+      value: 
+      objectReference: {fileID: 113196676}
+    - target: {fileID: 8816702143117302233, guid: 7e0904d2b2ca0f145ad03f5086282bbb,
+        type: 3}
       propertyPath: _screenEffectViewController
       value: 
       objectReference: {fileID: 1538956172}
@@ -4088,6 +4188,7 @@ SceneRoots:
   - {fileID: 848240679}
   - {fileID: 4759642362552276933}
   - {fileID: 2433098026093766787}
+  - {fileID: 1735170625}
   - {fileID: 1957537065}
   - {fileID: 2118663603}
   - {fileID: 1117656564}

--- a/Assets/QuantumUser/Simulation/Scripts/SoulWall/SoulWallSystem.cs
+++ b/Assets/QuantumUser/Simulation/Scripts/SoulWall/SoulWallSystem.cs
@@ -53,7 +53,7 @@ namespace Quantum.QuantumUser.Simulation.SoulWall
             FPVector2 soulWallColliderExtents;
 
             // set all soulwall common temp variables (used for all soulwalls on this side)
-            soulWallScale  = GridManager.GridScaleFactor;
+            soulWallScale  = GridManager.GridScaleFactor * 2;
             soulWallNormal = new FPVector2(0, teamNumber == BattleTeamNumber.TeamAlpha ? FP._1 : FP.Minus_1);
 
             // soulwall variables
@@ -66,7 +66,7 @@ namespace Quantum.QuantumUser.Simulation.SoulWall
             foreach (SoulWallTemplate soulWallTemplate in soulWallTemplates)
             {
                 // create entity
-                soulWallEntity    = f.Create(soulWallPrototypes[soulWallTemplate.Width-1]);
+                soulWallEntity    = f.Create(soulWallPrototypes[(soulWallTemplate.Width /2) -1]);
 
                 // get components
                 soulWall          = f.Unsafe.GetPointer<Quantum.SoulWall>(soulWallEntity);
@@ -86,7 +86,7 @@ namespace Quantum.QuantumUser.Simulation.SoulWall
                 // initialize collider
                 soulWallCollider->Shape = Shape2D.CreateBox(
                     soulWallColliderExtents * soulWallScale,
-                    new FPVector2((soulWallColliderExtents.X - FP._0_50) * soulWallScale, 0
+                    new FPVector2((soulWallColliderExtents.X - FP._0_75) * soulWallScale, (soulWallColliderExtents.Y - FP._0_75) * soulWallScale
                 ));
 
                 // teleport entity


### PR DESCRIPTION
Battle arena's gridsize made smaller to scale players smaller. SoulWalls needed to be updated to fit the new grid.

- Battle arena is now 38 x 70 gridcells (used to be 24 x 44)
- SoulWalls updated to snap on the new grid
- SoulWall positions redefined
- SoulWall pieces size doubled in order to remain the same size as before the grid resizing
- SoulWall template selection logic changed to accommodate new sizing
- Grid is now faintly visible on background