### PR TITLE
BattlePopup bug fixes

### DIFF
--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -784,7 +784,7 @@ namespace Altzone.Scripts.Lobby
                 yield return null;
                 if (isCloseRoom)
                 {
-                    PhotonRealtimeClient.CloseRoom(true);
+                    PhotonRealtimeClient.CloseRoom(false);
                     yield return null;
                 }
             }

--- a/Assets/MenuUi/Graphics/CommonGraphics/CommonLock.png
+++ b/Assets/MenuUi/Graphics/CommonGraphics/CommonLock.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:109116ed31ea96146034b0a66a0ceed4d0719bf4f95695eefa3d110421d90e5a
-size 5765
+oid sha256:9b70170de2812a1187aa93a2939ae123af7f00917c067b58ce8a751a3fc01921
+size 7926

--- a/Assets/MenuUi/Graphics/CommonGraphics/CommonLockOpen.png
+++ b/Assets/MenuUi/Graphics/CommonGraphics/CommonLockOpen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b70170de2812a1187aa93a2939ae123af7f00917c067b58ce8a751a3fc01921
-size 7926
+oid sha256:109116ed31ea96146034b0a66a0ceed4d0719bf4f95695eefa3d110421d90e5a
+size 5765

--- a/Assets/MenuUi/Prefabs/UI Components/Battle Popup/RoomSlot.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/Battle Popup/RoomSlot.prefab
@@ -124,8 +124,8 @@ MonoBehaviour:
   _roomName: {fileID: 9209887669312282381}
   _roomPlayerCount: {fileID: 8767638111158360799}
   _openStatusLockImage: {fileID: 2949993932622736737}
-  _lockedSprite: {fileID: 21300000, guid: 71e4f36c084957447943ab9c40454a8d, type: 3}
-  _unlockedSprite: {fileID: 21300000, guid: daab1c2df6045d24c9d60297b2625ba8, type: 3}
+  _lockedSprite: {fileID: 21300000, guid: daab1c2df6045d24c9d60297b2625ba8, type: 3}
+  _unlockedSprite: {fileID: 21300000, guid: 71e4f36c084957447943ab9c40454a8d, type: 3}
 --- !u!1 &6265875191432868131
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Scenes/10-MenuUi.unity
+++ b/Assets/MenuUi/Scenes/10-MenuUi.unity
@@ -523,7 +523,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd274334cf8643b46904835d7fb16d0b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _isCloseRoomOnGameStart: 0
+  _isCloseRoomOnGameStart: 1
   _blueTeamName: Alpha
   _redTeamName: Beta
   _player:

--- a/Assets/MenuUi/Scripts/Lobby/InRoom/RoomSetupManager.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InRoom/RoomSetupManager.cs
@@ -118,7 +118,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
             var room = PhotonRealtimeClient.LobbyCurrentRoom;
             var player = PhotonRealtimeClient.LocalLobbyPlayer;
 
-            // Checking if player is already in the room and if so only update status and return (can happen if battle popup is minimized while in room)
+            // Checking if player is already in the room (can happen if battle popup is minimized while in room)
             string positionValue1 = room.GetCustomProperty(PlayerPositionKey1, "");
             string positionValue2 = room.GetCustomProperty(PlayerPositionKey2, "");
             string positionValue3 = room.GetCustomProperty(PlayerPositionKey3, "");
@@ -126,6 +126,17 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
             if (player.UserId == positionValue1 || player.UserId == positionValue2 || player.UserId == positionValue3 || player.UserId == positionValue3)
             {
+                // Checking if we have to update defence characters
+                StartCoroutine(GetPlayerData(playerData => {
+
+                    if (player.GetCustomProperty<int[]>(PlayerCharactersKey) != GetSelectedCharacterIds(playerData))
+                    {
+                        UpdateCharactersAndStatsKey();
+                    }
+
+                }));
+
+                // Updating room status and stopping coroutine
                 UpdateStatus();
                 yield break;
             }


### PR DESCRIPTION
- Closing and hiding the room when game starts because currently there is no reason to keep it open since players don't return to the room after game.
- Swapped CommonLock and CommonLockOpen sprite names because they were wrong.
- Fixed defence characters not updating in room if they were changed in the main menu. They update after player opens the popup again, because GetPlayerData coroutine couldn't be started while the popup was inactive.