### PR TITLE
Battle/feature - PlayerMovementLimits

### DIFF
--- a/Assets/QuantumUser/Resources/Prefabs/Player/Player.prefab
+++ b/Assets/QuantumUser/Resources/Prefabs/Player/Player.prefab
@@ -453,6 +453,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Prototype:
+    GridExtendTop: 4
+    GridExtendBottom: 1
     HitboxListShield:
     - Position:
         X: 0

--- a/Assets/QuantumUser/Resources/Specs/BattleArenaSpec.asset
+++ b/Assets/QuantumUser/Resources/Specs/BattleArenaSpec.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   GridWidth: 38
   GridHeight: 70
   MiddleAreaHeight: 4
-  SoulWallHeight: 0
+  SoulWallHeight: 6
   PlayerSpawnPositions:
   - Row: 15
     Col: 10

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
@@ -752,9 +752,9 @@ namespace Quantum {
   }
   [StructLayout(LayoutKind.Explicit)]
   public unsafe partial struct PlayerData : Quantum.IComponent {
-    public const Int32 SIZE = 104;
+    public const Int32 SIZE = 112;
     public const Int32 ALIGNMENT = 8;
-    [FieldOffset(16)]
+    [FieldOffset(24)]
     public PlayerRef PlayerRef;
     [FieldOffset(0)]
     public BattlePlayerSlot Slot;
@@ -764,29 +764,33 @@ namespace Quantum {
     public Int32 CharacterId;
     [FieldOffset(8)]
     public Int32 CharacterClass;
-    [FieldOffset(72)]
-    public FP StatHp;
     [FieldOffset(80)]
-    public FP StatSpeed;
-    [FieldOffset(56)]
-    public FP StatCharacterSize;
-    [FieldOffset(48)]
-    public FP StatAttack;
-    [FieldOffset(64)]
-    public FP StatDefence;
+    public FP StatHp;
     [FieldOffset(88)]
-    public FPVector2 TargetPosition;
-    [FieldOffset(32)]
-    public FP RotationBase;
-    [FieldOffset(40)]
-    public FP RotationOffset;
+    public FP StatSpeed;
+    [FieldOffset(64)]
+    public FP StatCharacterSize;
+    [FieldOffset(56)]
+    public FP StatAttack;
+    [FieldOffset(72)]
+    public FP StatDefence;
     [FieldOffset(20)]
-    [FreeOnComponentRemoved()]
-    public QListPtr<PlayerHitboxLink> HitboxListAll;
+    public Int32 GridExtendTop;
+    [FieldOffset(16)]
+    public Int32 GridExtendBottom;
+    [FieldOffset(96)]
+    public FPVector2 TargetPosition;
+    [FieldOffset(40)]
+    public FP RotationBase;
+    [FieldOffset(48)]
+    public FP RotationOffset;
     [FieldOffset(28)]
     [FreeOnComponentRemoved()]
+    public QListPtr<PlayerHitboxLink> HitboxListAll;
+    [FieldOffset(36)]
+    [FreeOnComponentRemoved()]
     public QListPtr<PlayerHitboxLink> HitboxListShield;
-    [FieldOffset(24)]
+    [FieldOffset(32)]
     [FreeOnComponentRemoved()]
     public QListPtr<PlayerHitboxLink> HitboxListCharacter;
     public override Int32 GetHashCode() {
@@ -802,6 +806,8 @@ namespace Quantum {
         hash = hash * 31 + StatCharacterSize.GetHashCode();
         hash = hash * 31 + StatAttack.GetHashCode();
         hash = hash * 31 + StatDefence.GetHashCode();
+        hash = hash * 31 + GridExtendTop.GetHashCode();
+        hash = hash * 31 + GridExtendBottom.GetHashCode();
         hash = hash * 31 + TargetPosition.GetHashCode();
         hash = hash * 31 + RotationBase.GetHashCode();
         hash = hash * 31 + RotationOffset.GetHashCode();
@@ -826,6 +832,8 @@ namespace Quantum {
         serializer.Stream.Serialize((Int32*)&p->TeamNumber);
         serializer.Stream.Serialize(&p->CharacterClass);
         serializer.Stream.Serialize(&p->CharacterId);
+        serializer.Stream.Serialize(&p->GridExtendBottom);
+        serializer.Stream.Serialize(&p->GridExtendTop);
         PlayerRef.Serialize(&p->PlayerRef, serializer);
         QList.Serialize(&p->HitboxListAll, serializer, Statics.SerializePlayerHitboxLink);
         QList.Serialize(&p->HitboxListCharacter, serializer, Statics.SerializePlayerHitboxLink);
@@ -842,17 +850,23 @@ namespace Quantum {
   }
   [StructLayout(LayoutKind.Explicit)]
   public unsafe partial struct PlayerDataTemplate : Quantum.IComponent {
-    public const Int32 SIZE = 8;
+    public const Int32 SIZE = 16;
     public const Int32 ALIGNMENT = 4;
     [FieldOffset(4)]
+    public Int32 GridExtendTop;
+    [FieldOffset(0)]
+    public Int32 GridExtendBottom;
+    [FieldOffset(12)]
     [FreeOnComponentRemoved()]
     public QListPtr<PlayerHitboxTemplate> HitboxListShield;
-    [FieldOffset(0)]
+    [FieldOffset(8)]
     [FreeOnComponentRemoved()]
     public QListPtr<PlayerHitboxTemplate> HitboxListCharacter;
     public override Int32 GetHashCode() {
       unchecked { 
         var hash = 181;
+        hash = hash * 31 + GridExtendTop.GetHashCode();
+        hash = hash * 31 + GridExtendBottom.GetHashCode();
         hash = hash * 31 + HitboxListShield.GetHashCode();
         hash = hash * 31 + HitboxListCharacter.GetHashCode();
         return hash;
@@ -868,6 +882,8 @@ namespace Quantum {
     }
     public static void Serialize(void* ptr, FrameSerializer serializer) {
         var p = (PlayerDataTemplate*)ptr;
+        serializer.Stream.Serialize(&p->GridExtendBottom);
+        serializer.Stream.Serialize(&p->GridExtendTop);
         QList.Serialize(&p->HitboxListCharacter, serializer, Statics.SerializePlayerHitboxTemplate);
         QList.Serialize(&p->HitboxListShield, serializer, Statics.SerializePlayerHitboxTemplate);
     }

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Prototypes.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Prototypes.cs
@@ -143,6 +143,8 @@ namespace Quantum.Prototypes {
     public FP StatCharacterSize;
     public FP StatAttack;
     public FP StatDefence;
+    public Int32 GridExtendTop;
+    public Int32 GridExtendBottom;
     public FPVector2 TargetPosition;
     public FP RotationBase;
     public FP RotationOffset;
@@ -171,6 +173,8 @@ namespace Quantum.Prototypes {
         result.StatCharacterSize = this.StatCharacterSize;
         result.StatAttack = this.StatAttack;
         result.StatDefence = this.StatDefence;
+        result.GridExtendTop = this.GridExtendTop;
+        result.GridExtendBottom = this.GridExtendBottom;
         result.TargetPosition = this.TargetPosition;
         result.RotationBase = this.RotationBase;
         result.RotationOffset = this.RotationOffset;
@@ -209,6 +213,8 @@ namespace Quantum.Prototypes {
   [System.SerializableAttribute()]
   [Quantum.Prototypes.Prototype(typeof(Quantum.PlayerDataTemplate))]
   public unsafe partial class PlayerDataTemplatePrototype : ComponentPrototype<Quantum.PlayerDataTemplate> {
+    public Int32 GridExtendTop;
+    public Int32 GridExtendBottom;
     [FreeOnComponentRemoved()]
     [DynamicCollectionAttribute()]
     public Quantum.Prototypes.PlayerHitboxTemplatePrototype[] HitboxListShield = {};
@@ -222,6 +228,8 @@ namespace Quantum.Prototypes {
         return f.Set(entity, component) == SetResult.ComponentAdded;
     }
     public void Materialize(Frame frame, ref Quantum.PlayerDataTemplate result, in PrototypeMaterializationContext context = default) {
+        result.GridExtendTop = this.GridExtendTop;
+        result.GridExtendBottom = this.GridExtendBottom;
         if (this.HitboxListShield.Length == 0) {
           result.HitboxListShield = default;
         } else {

--- a/Assets/QuantumUser/Simulation/Qtn/Player/PlayerData.qtn
+++ b/Assets/QuantumUser/Simulation/Qtn/Player/PlayerData.qtn
@@ -20,6 +20,9 @@ component PlayerData
     FP StatAttack;
     FP StatDefence;
 
+    int GridExtendTop;
+    int GridExtendBottom;
+
     FPVector2 TargetPosition;
     FP RotationBase;
     FP RotationOffset;
@@ -43,6 +46,9 @@ struct PlayerHitboxTemplate
 
 component PlayerDataTemplate
 {
+    int GridExtendTop;
+    int GridExtendBottom;
+
     [FreeOnComponentRemoved] list<PlayerHitboxTemplate> HitboxListShield;
     [FreeOnComponentRemoved] list<PlayerHitboxTemplate> HitboxListCharacter;
 }

--- a/Assets/QuantumUser/Simulation/Scripts/Grid/GridManager.cs
+++ b/Assets/QuantumUser/Simulation/Scripts/Grid/GridManager.cs
@@ -23,10 +23,10 @@ namespace Quantum
             Rows = battleArenaSpec.GridHeight;
             Columns = battleArenaSpec.GridWidth;
 
-            TeamAlphaFieldStart = 0;
+            TeamAlphaFieldStart = battleArenaSpec.SoulWallHeight;
             TeamAlphaFieldEnd = (battleArenaSpec.GridHeight - battleArenaSpec.MiddleAreaHeight) / 2 - 1;
             TeamBetaFieldStart = TeamAlphaFieldEnd + battleArenaSpec.MiddleAreaHeight + 1;
-            TeamBetaFieldEnd = battleArenaSpec.GridWidth;
+            TeamBetaFieldEnd = battleArenaSpec.GridHeight - 1 - battleArenaSpec.SoulWallHeight;
 
             GridScaleFactor = battleArenaSpec.WorldHeight / battleArenaSpec.GridHeight;
 

--- a/Assets/QuantumUser/Simulation/Scripts/Player/PlayerManager.cs
+++ b/Assets/QuantumUser/Simulation/Scripts/Player/PlayerManager.cs
@@ -51,6 +51,9 @@ namespace Quantum
                 PlayerDataTemplate* playerDataTemplate;
                 FPVector2           playerSpawnPosition;
                 FP                  playerRotationBase;
+                int                 playerGridExtendTop;
+                int                 playerGridExtendBottom;
+                bool                playerFlipped;
                 // player - hitBox temp variables
                 QList<PlayerHitboxTemplate> playerHitboxListShieldTemplate;
                 QList<PlayerHitboxTemplate> playerHitboxListCharacterTemplate;
@@ -67,7 +70,16 @@ namespace Quantum
 
                 playerHitboxExtents = GridManager.GridScaleFactor * FP._0_50;
 
-                playerRotationBase = teamNumber == BattleTeamNumber.TeamAlpha ? FP._0 : FP.Rad_180;
+                if (teamNumber == BattleTeamNumber.TeamAlpha)
+                {
+                    playerRotationBase = FP._0;
+                    playerFlipped = false;
+                }
+                else
+                {
+                    playerRotationBase = FP.Rad_180;
+                    playerFlipped = true;
+                }
 
                 //} set player common temp variables
 
@@ -87,8 +99,6 @@ namespace Quantum
 
                 for (int i = 0; i < playerCharacterEntityArray.Length; i++)
                 {
-                    // set spawnPosition
-                    playerSpawnPosition = playerHandle.GetOutOfPlayPosition(i, teamNumber);
 
                     // create entity
                     playerEntity = f.Create(entityPrototypeAsset);
@@ -98,13 +108,27 @@ namespace Quantum
                     playerHitboxListShieldTemplateCount    = f.TryResolveList(playerDataTemplate->HitboxListShield,    out playerHitboxListShieldTemplate   ) ? playerHitboxListShieldTemplate    .Count : 0;
                     playerHitboxListCharacterTemplateCount = f.TryResolveList(playerDataTemplate->HitboxListCharacter, out playerHitboxListCharacterTemplate) ? playerHitboxListCharacterTemplate .Count : 0;
 
-                    //{ allocate playerHitboxLists
+                    //{ set temp variables
 
+                    playerSpawnPosition = playerHandle.GetOutOfPlayPosition(i, teamNumber);
+
+                    if (!playerFlipped)
+                    {
+                        playerGridExtendTop    = playerDataTemplate->GridExtendTop;
+                        playerGridExtendBottom = playerDataTemplate->GridExtendBottom;
+                    }
+                    else
+                    {
+                        playerGridExtendTop    = playerDataTemplate->GridExtendBottom;
+                        playerGridExtendBottom = playerDataTemplate->GridExtendTop;
+                    }
+
+                    //} set temp variables
+
+                    // allocate playerHitboxLists
                     if (playerHitboxListShieldTemplateCount + playerHitboxListCharacterTemplateCount > 0) playerHitboxListAll       = f.AllocateList<PlayerHitboxLink>(playerHitboxListShieldTemplateCount + playerHitboxListCharacterTemplateCount);
                     if (playerHitboxListShieldTemplateCount                                          > 0) playerHitboxListShield    = f.AllocateList<PlayerHitboxLink>(playerHitboxListShieldTemplateCount                                         );
                     if (                                      playerHitboxListCharacterTemplateCount > 0) playerHitboxListCharacter = f.AllocateList<PlayerHitboxLink>(                                      playerHitboxListCharacterTemplateCount);
-
-                    //} allocate playerHitboxLists
 
                     // initialize playerData
                     playerData = new PlayerData
@@ -120,6 +144,9 @@ namespace Quantum
                         StatCharacterSize   = data.Characters[i].CharacterSize,
                         StatAttack          = data.Characters[i].Attack,
                         StatDefence         = data.Characters[i].Defence,
+
+                        GridExtendTop       = playerGridExtendTop,
+                        GridExtendBottom    = playerGridExtendBottom,
 
                         TargetPosition      = playerSpawnPosition,
                         RotationBase        = playerRotationBase,

--- a/Assets/QuantumUser/Simulation/Scripts/Player/PlayerMovementSystem.cs
+++ b/Assets/QuantumUser/Simulation/Scripts/Player/PlayerMovementSystem.cs
@@ -8,6 +8,10 @@ using Quantum.Collections;
 
 namespace Quantum
 {
+    /// <summary>
+    /// PlayerMovement <a href="https://doc.photonengine.com/quantum/current/manual/quantum-ecs/systems">Quantum System</a>.<br/>
+    /// Handles player input, movement and rotations.<br/>
+    /// </summary>
     [Preserve]
     public unsafe class PlayerMovementSystem : SystemMainThreadFilter<PlayerMovementSystem.Filter>
     {
@@ -18,6 +22,15 @@ namespace Quantum
             public PlayerData* PlayerData;
         }
 
+        /// <summary>
+        /// <a href="https://doc.photonengine.com/quantum/current/manual/quantum-ecs/systems">Quantum system update method</a>.<br/>
+        /// Handles player input, movement and rotations.<br/>
+        /// (this method should only be called by Quantum)
+        /// </summary>
+        /// Skips players that have PlayerRef = none.<br/>
+        /// Gets player's Quantum Input and calls <see cref="UpdatePlayerMovement(Frame, ref Filter, Input*)">UpdatePlayerMovement</see> method.
+        /// <param name="f">Current Quantum Frame</param>
+        /// <param name="filter">Reference to <a href="https://doc.photonengine.com/quantum/current/manual/quantum-ecs/systems">Quantum Filter</a>.</param>
         public override void Update(Frame f, ref Filter filter)
         {
             if (filter.PlayerData->PlayerRef == PlayerRef.None) return;
@@ -98,6 +111,18 @@ namespace Quantum
             }
         }
 
+        /// <summary>
+        /// Private helper method for the public <see cref="Update(Frame, ref Filter)">Update</see> method.<br/>
+        /// Handles player's movement and rotation.
+        /// </summary>
+        /// Checks Quantum Input for player's actions.<br/>
+        /// When movement action is taken: Checks and updates player's TargetPosition based on input.<br/>
+        /// When rotation action is taken: updates player's RotationOffset based on input.<br/>
+        /// When rotation action is not taken: updates player's RotationOffset back to zero.<br/>
+        /// Always: updates player's position and rotation based on the current TargetPosition and RotationOffset.<br/>
+        /// <param name="f">Current Quantum Frame</param>
+        /// <param name="filter">Reference to <a href="https://doc.photonengine.com/quantum/current/manual/quantum-ecs/systems">Quantum Filter</a>.</param>
+        /// <param name="input">Player's Quantum Input</param>
         private void UpdatePlayerMovement(Frame f, ref Filter filter, Input* input)
         {
             // constant

--- a/Assets/QuantumUser/Simulation/Scripts/Player/PlayerMovementSystem.cs
+++ b/Assets/QuantumUser/Simulation/Scripts/Player/PlayerMovementSystem.cs
@@ -100,6 +100,7 @@ namespace Quantum
 
         private void UpdatePlayerMovement(Frame f, ref Filter filter, Input* input)
         {
+            // constant
             FP rotationSpeed = FP._0_20;
 
             // unpack filter
@@ -109,13 +110,35 @@ namespace Quantum
             // handle movement
             if (input->MouseClick)
             {
-                playerData->TargetPosition = GridManager.GridPositionToWorldPosition(input->MovementPosition);
-                //checks if player is allowed to move to that side of the arena
-                if (((playerData->TeamNumber == BattleTeamNumber.TeamAlpha) && playerData->TargetPosition.Y > 0)
-                    || ((playerData->TeamNumber == BattleTeamNumber.TeamBeta) && playerData->TargetPosition.Y < 0))
+                // get players TargetPosition
+                GridPosition targetGridPosition = input->MovementPosition;
+
+                // clamp the TargetPosition inside sidebounds
+                targetGridPosition.Col = Mathf.Clamp(targetGridPosition.Col, 0, GridManager.Columns-1);
+
+                // clamp the TargetPosition inside teams playfield for alphateam
+                if (playerData->TeamNumber == BattleTeamNumber.TeamAlpha)
                 {
-                    playerData->TargetPosition.Y = 0;
+                    targetGridPosition.Row = Mathf.Clamp(
+                        targetGridPosition.Row,
+                        GridManager.TeamAlphaFieldStart + playerData->GridExtendBottom,
+                        GridManager.TeamAlphaFieldEnd   - playerData->GridExtendTop
+                    );
                 }
+
+                // clamp the TargetPosition inside teams playfield for betateam
+                else
+                {
+                    targetGridPosition.Row = Mathf.Clamp(
+                        targetGridPosition.Row,
+                        GridManager.TeamBetaFieldStart + playerData->GridExtendBottom,
+                        GridManager.TeamBetaFieldEnd   - playerData->GridExtendTop
+                    );
+                }
+
+                // get players TargetPositions as WorldPosition
+                playerData->TargetPosition = GridManager.GridPositionToWorldPosition(targetGridPosition);
+
                 Debug.LogFormat("[PlayerMovementSystem] Mouse clicked (mouse position: {0}", playerData->TargetPosition);
             }
 

--- a/Assets/QuantumUser/View/Generated/Quantum.CodeGen.UnityPrototypeAdapters.cs
+++ b/Assets/QuantumUser/View/Generated/Quantum.CodeGen.UnityPrototypeAdapters.cs
@@ -61,6 +61,8 @@ namespace Quantum.Prototypes.Unity {
     public FP StatCharacterSize;
     public FP StatAttack;
     public FP StatDefence;
+    public Int32 GridExtendTop;
+    public Int32 GridExtendBottom;
     public FPVector2 TargetPosition;
     public FP RotationBase;
     public FP RotationOffset;
@@ -86,6 +88,8 @@ namespace Quantum.Prototypes.Unity {
       converter.Convert(this.StatCharacterSize, out result.StatCharacterSize);
       converter.Convert(this.StatAttack, out result.StatAttack);
       converter.Convert(this.StatDefence, out result.StatDefence);
+      converter.Convert(this.GridExtendTop, out result.GridExtendTop);
+      converter.Convert(this.GridExtendBottom, out result.GridExtendBottom);
       converter.Convert(this.TargetPosition, out result.TargetPosition);
       converter.Convert(this.RotationBase, out result.RotationBase);
       converter.Convert(this.RotationOffset, out result.RotationOffset);


### PR DESCRIPTION
Player can no longer move outside of sidewalls, under SoulWalls or on MiddleArea.

- SoulWallHeight defined
- GridExtendTop and -Bottom added for players
- GridExtendTop and -Bottom values set (how many grids player extends from heart sprite on top and bottom sides)
- GridManager now takes SoulWallHeight into account when calculating team playfields
- PlayerMovementSystem checks player's TargetPosition and clamps it inside allowed bounds.
- Documentation added