### PR TITLE
Battle/feature - PlayerHitboxCollisionTypes

### DIFF
--- a/Assets/QuantumUser/Simulation/Battle/Scripts/Projectile/BattleProjectileQSystem.cs
+++ b/Assets/QuantumUser/Simulation/Battle/Scripts/Projectile/BattleProjectileQSystem.cs
@@ -66,7 +66,7 @@ namespace Battle.QSimulation.Projectile
 
         public void BattleOnProjectileHitSoulWall(Frame f, BattleProjectileQComponent* projectile, EntityRef projectileEntity, BattleSoulWallQComponent* soulWall, EntityRef soulWallEntity)
         {
-            ProjectileDirectionReflect(f, projectile, projectileEntity, soulWallEntity, soulWall->Normal, soulWall->CollisionMinOffset);
+            ProjectileDirectionUpdate(f, projectile, projectileEntity, soulWallEntity, soulWall->Normal, soulWall->CollisionMinOffset);
 
             // change projectile's emotion to soulwall's emotion
             projectile->Emotion = soulWall->Emotion;
@@ -75,19 +75,16 @@ namespace Battle.QSimulation.Projectile
 
         public void BattleOnProjectileHitArenaBorder(Frame f, BattleProjectileQComponent* projectile, EntityRef projectileEntity, BattleArenaBorderQComponent* arenaBorder, EntityRef arenaBorderEntity)
         {
-            ProjectileDirectionReflect(f, projectile,  projectileEntity, arenaBorderEntity, arenaBorder->Normal, arenaBorder->CollisionMinOffset);
+            ProjectileDirectionUpdate(f, projectile,  projectileEntity, arenaBorderEntity, arenaBorder->Normal, arenaBorder->CollisionMinOffset);
         }
 
         public void BattleOnProjectileHitPlayerHitbox(Frame f, BattleProjectileQComponent* projectile, EntityRef projectileEntity, BattlePlayerHitboxQComponent* playerHitbox, EntityRef playerEntity)
         {
-            // pick a method depending on hitbox collision type
-            if (playerHitbox->CollisionType == BattlePlayerCollisionType.Reflect)
-                ProjectileDirectionReflect(f, projectile,  projectileEntity, playerEntity, playerHitbox->Normal, playerHitbox->CollisionMinOffset);
-            else if (playerHitbox->CollisionType == BattlePlayerCollisionType.Override)
-                ProjectileDirectionOverrider(f, projectile,  projectileEntity, playerEntity, playerHitbox->Normal, playerHitbox->CollisionMinOffset);
+            if (playerHitbox->CollisionType == BattlePlayerCollisionType.None) return;
+            ProjectileDirectionUpdate(f, projectile,  projectileEntity, playerEntity, playerHitbox->Normal, playerHitbox->CollisionMinOffset, playerHitbox->CollisionType);
         }
 
-        private void ProjectileDirectionReflect(Frame f, BattleProjectileQComponent* projectile, EntityRef projectileEntity, EntityRef otherEntity, FPVector2 normal, FP collisionMinOffset)
+        private void ProjectileDirectionUpdate(Frame f, BattleProjectileQComponent* projectile, EntityRef projectileEntity, EntityRef otherEntity, FPVector2 normal, FP collisionMinOffset, BattlePlayerCollisionType collisionType = BattlePlayerCollisionType.Reflect)
         {
             if (IsCollisionFlagSet(f, projectile, BattleProjectileCollisionFlags.Projectile)) return;
 
@@ -99,7 +96,8 @@ namespace Battle.QSimulation.Projectile
             FP collisionOffset = FPVector2.Rotate(offsetVector, -FPVector2.RadiansSigned(FPVector2.Up, normal)).Y;
 
             // set new projectile direction
-            projectile->Direction = FPVector2.Reflect(projectile->Direction, normal);
+            if      (collisionType == BattlePlayerCollisionType.Reflect)  projectile->Direction = FPVector2.Reflect(projectile->Direction, normal);
+            else if (collisionType == BattlePlayerCollisionType.Override) projectile->Direction = normal;
 
             // if projectile accidentally went inside another entity, lift it out
             if (collisionOffset - projectile->Radius < collisionMinOffset)
@@ -108,15 +106,6 @@ namespace Battle.QSimulation.Projectile
             }
 
             SetCollisionFlag(f, projectile, BattleProjectileCollisionFlags.Projectile);
-        }
-
-        private void ProjectileDirectionOverrider(Frame f, BattleProjectileQComponent* projectile, EntityRef projectileEntity, EntityRef otherEntity, FPVector2 normal, FP collisionMinOffset)
-        {
-            // use reflect method to do offset checks
-            ProjectileDirectionReflect(f, projectile,  projectileEntity, otherEntity, normal, collisionMinOffset);
-
-            // override projectile direction
-            projectile->Direction = normal;
         }
     }
 }


### PR DESCRIPTION
When projectile hits player's hitbox, right collision logic is chosen depending on hitbox's collisiontype.

- Renamed ProjectileBounce method to ~~ProjectileDirectionReflect~~
- ~~Added ProjectileDirectionOverrider method.~~
- Merged ProjectileDirectionReflect and ProjectileDirectionOverrider methods to ProjectileDirectionUpdate
  because of the amount of shared code
- Public methods moved before private methods