### PR TITLE
Battle UI editor created

### DIFF
--- a/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiDiamonds.prefab
+++ b/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiDiamonds.prefab
@@ -34,10 +34,10 @@ RectTransform:
   - {fileID: 355790017856211977}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.75, y: 0.01}
-  m_AnchorMax: {x: 0.98, y: 0.08}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 250, y: 135}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4486672301830422361
 MonoBehaviour:

--- a/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiDiamonds.prefab
+++ b/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiDiamonds.prefab
@@ -227,12 +227,12 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 72
+  m_fontSize: 115.05
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
   m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_fontSizeMax: 512
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512

--- a/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiGiveUpButton.prefab
+++ b/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiGiveUpButton.prefab
@@ -232,7 +232,7 @@ MonoBehaviour:
   m_fontWeight: 400
   m_enableAutoSizing: 1
   m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_fontSizeMax: 512
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512

--- a/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiGiveUpButton.prefab
+++ b/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiGiveUpButton.prefab
@@ -35,10 +35,10 @@ RectTransform:
   - {fileID: 355790017856211977}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.02, y: 0.01}
-  m_AnchorMax: {x: 0.3, y: 0.08}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 300, y: 135}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4486672301830422361
 MonoBehaviour:
@@ -227,7 +227,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 60.65
+  m_fontSize: 60.2
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiPlayerInfo.prefab
+++ b/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiPlayerInfo.prefab
@@ -189,7 +189,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 9aa5e625812e131439a894722f0b1d66, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 5131a110bcd73344e96b67b3bb3b7ad5, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -512,7 +512,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: dfdefd46f5298ca45bfe06badbfaa956, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 264579adf0250584c86aab628d5aadce, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -587,7 +587,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: a8195e5c386ed2345988b958495c4c19, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 6dd28bde0e188434eb4ea8bb5500833a, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -1449,7 +1449,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: a8195e5c386ed2345988b958495c4c19, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 6dd28bde0e188434eb4ea8bb5500833a, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -1974,7 +1974,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: dfdefd46f5298ca45bfe06badbfaa956, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 264579adf0250584c86aab628d5aadce, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -2623,7 +2623,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 9aa5e625812e131439a894722f0b1d66, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 5131a110bcd73344e96b67b3bb3b7ad5, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1

--- a/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiPlayerInfo.prefab
+++ b/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiPlayerInfo.prefab
@@ -631,10 +631,10 @@ RectTransform:
   - {fileID: 5799155549615607461}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.05, y: 0.45}
-  m_AnchorMax: {x: 0.375, y: 0.55}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 360, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2926530640854380273
 MonoBehaviour:
@@ -649,7 +649,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _horizontalConfiguration: {fileID: 5848932082496495538}
-  _horizontalAspectRatio: 1.3
+  _horizontalAspectRatio: 1.8
   _verticalConfiguration: {fileID: 7764124849608936206}
   _verticalAspectRatio: 0.3
 --- !u!222 &1554362590128268219
@@ -2915,7 +2915,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 40.9
+  m_fontSize: 42.6
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiTimer.prefab
+++ b/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiTimer.prefab
@@ -106,12 +106,12 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 72
+  m_fontSize: 85.25
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
   m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_fontSizeMax: 512
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512

--- a/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiTimer.prefab
+++ b/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiTimer.prefab
@@ -36,7 +36,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 200}
+  m_SizeDelta: {x: 200, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4486672301830422361
 MonoBehaviour:

--- a/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiTimer.prefab
+++ b/Assets/Altzone/Resources/Prefabs/BattleUiShared/BattleUiTimer.prefab
@@ -33,10 +33,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.4, y: 0.45}
-  m_AnchorMax: {x: 0.6, y: 0.55}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4486672301830422361
 MonoBehaviour:

--- a/Assets/Altzone/Scripts/BattleUiShared/BattleUiMovableElement.cs
+++ b/Assets/Altzone/Scripts/BattleUiShared/BattleUiMovableElement.cs
@@ -8,6 +8,8 @@ namespace Altzone.Scripts.BattleUiShared
     [RequireComponent(typeof(RectTransform))]
     public class BattleUiMovableElement : MonoBehaviour
     {
+        public RectTransform RectTransformComponent => _rectTransform;
+
         /// <summary>
         /// Set BattleUiMovableElementData to this Ui element.
         /// </summary>

--- a/Assets/Altzone/Scripts/BattleUiShared/BattleUiMovableElementData.cs
+++ b/Assets/Altzone/Scripts/BattleUiShared/BattleUiMovableElementData.cs
@@ -11,15 +11,19 @@ namespace Altzone.Scripts.BattleUiShared
     [Serializable]
     public class BattleUiMovableElementData
     {
+        public bool IsFlippedHorizontally;
+        public bool IsFlippedVertically;
         public Vector2 AnchorMin;
         public Vector2 AnchorMax;
         public OrientationType Orientation;
 
-        public BattleUiMovableElementData(Vector2 anchorMin, Vector2 anchorMax, OrientationType orientation = OrientationType.None)
+        public BattleUiMovableElementData(Vector2 anchorMin, Vector2 anchorMax, OrientationType orientation = OrientationType.None, bool isFlippedHorizontally = false, bool isFlippedVertically = false)
         {
             AnchorMin = anchorMin;
             AnchorMax = anchorMax;
             Orientation = orientation;
+            IsFlippedHorizontally = isFlippedHorizontally;
+            IsFlippedVertically = isFlippedVertically;
         }
     }
 }

--- a/Assets/Altzone/Scripts/BattleUiShared/BattleUiMultiOrientationElement.cs
+++ b/Assets/Altzone/Scripts/BattleUiShared/BattleUiMultiOrientationElement.cs
@@ -21,6 +21,8 @@ namespace Altzone.Scripts.BattleUiShared
         }
 
         public OrientationType Orientation => _orientation;
+        public GameObject HorizontalConfiguration => _horizontalConfiguration;
+        public GameObject VerticalConfiguration => _verticalConfiguration;
         public bool IsFlippedHorizontally => _isFlippedHorizontally;
         public bool IsFlippedVertically => _isFlippedVertically;
         public float HorizontalAspectRatio => _horizontalAspectRatio;

--- a/Assets/Altzone/Scripts/BattleUiShared/BattleUiMultiOrientationElement.cs
+++ b/Assets/Altzone/Scripts/BattleUiShared/BattleUiMultiOrientationElement.cs
@@ -76,7 +76,7 @@ namespace Altzone.Scripts.BattleUiShared
             }
         }
 
-        private OrientationType _orientation;
+        private OrientationType _orientation = OrientationType.Horizontal;
 
         private void SetOrientation(OrientationType newOrientation)
         {

--- a/Assets/Altzone/Scripts/BattleUiShared/BattleUiMultiOrientationElement.cs
+++ b/Assets/Altzone/Scripts/BattleUiShared/BattleUiMultiOrientationElement.cs
@@ -116,46 +116,40 @@ namespace Altzone.Scripts.BattleUiShared
                 if (_horizontalConfiguration == null) return;
 
                 // Repositioning every horizontal configuration child anchor
-                for (int i = 0; i < _horizontalConfiguration.transform.childCount; i++)
-                {
-                    Transform child = _horizontalConfiguration.transform.GetChild(i);
-                    RectTransform childRectTransform = child.GetComponent<RectTransform>();
-                    if (childRectTransform != null)
-                    {
-                        FlipHorizontally(childRectTransform);
-                    }
-                }
+                FlipChildrenHorizontally(_horizontalConfiguration.transform);
             }
             else if (_orientation == OrientationType.Vertical || _orientation == OrientationType.VerticalFlipped)
             {
                 if (_verticalConfiguration == null) return;
 
                 // Repositioning every vertical configuration child anchor
-                for (int i = 0; i < _verticalConfiguration.transform.childCount; i++)
-                {
-                    Transform child = _verticalConfiguration.transform.GetChild(i);
-                    RectTransform childRectTransform = child.GetComponent<RectTransform>();
-                    if (childRectTransform != null)
-                    {
-                        FlipHorizontally(childRectTransform);
-                    }
-                }
+                FlipChildrenHorizontally(_verticalConfiguration.transform);
             }
         }
 
-        private void FlipHorizontally(RectTransform childRectTransform)
+        private void FlipChildrenHorizontally(Transform parent)
         {
-            // Calculating flipped x anchors
-            float flippedXMin = GetFlippedAnchor(childRectTransform.anchorMax.x); // we have to get the value from anchorMax so that it works
-            float flippedXMax = GetFlippedAnchor(childRectTransform.anchorMin.x); // same here we have to get it from anchorMin
+            for (int i = 0; i < parent.childCount; i++)
+            {
+                RectTransform childRectTransform = parent.GetChild(i).GetComponent<RectTransform>();
 
-            // Setting new x anchors
-            childRectTransform.anchorMin = new Vector2(flippedXMin, childRectTransform.anchorMin.y);
-            childRectTransform.anchorMax = new Vector2(flippedXMax, childRectTransform.anchorMax.y);
+                if (childRectTransform == null) return;
 
-            // Resetting offset values in case they changed
-            childRectTransform.offsetMin = Vector2.zero;
-            childRectTransform.offsetMax = Vector2.zero;
+                // Calculating flipped x anchors
+                float flippedXMin = GetFlippedAnchor(childRectTransform.anchorMax.x); // we have to get the value from anchorMax so that it works
+                float flippedXMax = GetFlippedAnchor(childRectTransform.anchorMin.x); // same here we have to get it from anchorMin
+
+                // Setting new x anchors
+                childRectTransform.anchorMin = new Vector2(flippedXMin, childRectTransform.anchorMin.y);
+                childRectTransform.anchorMax = new Vector2(flippedXMax, childRectTransform.anchorMax.y);
+
+                // Resetting offset values in case they changed
+                childRectTransform.offsetMin = Vector2.zero;
+                childRectTransform.offsetMax = Vector2.zero;
+
+                // Flipping the child's children
+                FlipChildrenHorizontally(childRectTransform);
+            }
         }
 
         private float GetFlippedAnchor(float anchorValue)

--- a/Assets/Altzone/Scripts/BattleUiShared/BattleUiMultiOrientationElement.cs
+++ b/Assets/Altzone/Scripts/BattleUiShared/BattleUiMultiOrientationElement.cs
@@ -23,6 +23,8 @@ namespace Altzone.Scripts.BattleUiShared
         }
 
         public OrientationType Orientation => _orientation;
+        public float HorizontalAspectRatio => _horizontalAspectRatio;
+        public float VerticalAspectRatio => _verticalAspectRatio;
 
         public bool IsHorizontal
         {

--- a/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorChangeOrientation.png
+++ b/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorChangeOrientation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ee5ac2b7a7b8d8e3078b2671ce560e633a9886f0e67e38d06ae19843c6f039a
+size 2902

--- a/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorChangeOrientation.png.meta
+++ b/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorChangeOrientation.png.meta
@@ -1,0 +1,179 @@
+fileFormatVersion: 2
+guid: 66094a058d136f04da5b88261eafab81
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 120
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 256
+    resizeAlgorithm: 1
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 512
+    resizeAlgorithm: 0
+    textureFormat: 10
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorFlip.png
+++ b/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorFlip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2508c97e7245307a667c3c2121ad5105849dbf691995b3c5507e0a9a1dfbd4d3
+size 2518

--- a/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorFlip.png.meta
+++ b/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorFlip.png.meta
@@ -1,0 +1,179 @@
+fileFormatVersion: 2
+guid: 2a026d323ae3c524a8ce5107e8b10221
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 120
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 256
+    resizeAlgorithm: 1
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 512
+    resizeAlgorithm: 0
+    textureFormat: 10
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorScaleHandle.png
+++ b/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorScaleHandle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9692db17c5de516a7af259256062db0bfaf53fdb983927322694beb6258be61a
+size 4334

--- a/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorScaleHandle.png.meta
+++ b/Assets/MenuUi/Graphics/SettingsGraphics/SettingsBattleUiEditorScaleHandle.png.meta
@@ -1,0 +1,179 @@
+fileFormatVersion: 2
+guid: bc59dd8703c33824db5590d6317677be
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 120
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 256
+    resizeAlgorithm: 1
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 512
+    resizeAlgorithm: 0
+    textureFormat: 10
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Prefabs/Settings.meta
+++ b/Assets/MenuUi/Prefabs/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e2c8b52eca2f5345bde52d9c46c81ca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor.meta
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2dc1c2a739e5e524f92d8fc1fce085a5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
@@ -181,7 +181,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -376,7 +376,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -523,9 +523,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1680916854445050396}
+  - component: {fileID: 4413306757010301692}
   - component: {fileID: 3578143720487820442}
   - component: {fileID: 5825138239432314174}
-  - component: {fileID: 6974701924046025480}
+  - component: {fileID: 1757323302625952980}
   m_Layer: 5
   m_Name: BattleUiEditingComponent
   m_TagString: Untagged
@@ -555,6 +556,21 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4413306757010301692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23ff2b9bc1743cc439a2417e481ae6a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scaleHandleButton: {fileID: 1169118915381496566}
+  _flipButton: {fileID: 7242317894940450536}
+  _changeOrientationButton: {fileID: 7586337019653692880}
 --- !u!222 &3578143720487820442
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -593,7 +609,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &6974701924046025480
+--- !u!114 &1757323302625952980
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -602,41 +618,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 7795057816738114330}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 11500000, guid: cabc7ab297e9ab44a96e83ec36e516df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 5825138239432314174}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
+  _blockType: 0
+  _swipe: {fileID: 0}
 --- !u!1 &8428815247614695722
 GameObject:
   m_ObjectHideFlags: 0
@@ -696,7 +682,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -771,7 +757,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
@@ -1,5 +1,230 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &848000105823905641
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3503585971207212443}
+  - component: {fileID: 7723443395963967290}
+  - component: {fileID: 5977843023710382750}
+  m_Layer: 5
+  m_Name: OverlayImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3503585971207212443
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 848000105823905641}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3149344774402744751}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7723443395963967290
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 848000105823905641}
+  m_CullTransparentMesh: 1
+--- !u!114 &5977843023710382750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 848000105823905641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4f018b342230544449b0ee23425d15c5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2040002287775706711
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6267728757232761725}
+  - component: {fileID: 3111517785749372820}
+  - component: {fileID: 5044171505485014252}
+  m_Layer: 5
+  m_Name: IconImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6267728757232761725
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2040002287775706711}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3149344774402744751}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3111517785749372820
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2040002287775706711}
+  m_CullTransparentMesh: 1
+--- !u!114 &5044171505485014252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2040002287775706711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2a026d323ae3c524a8ce5107e8b10221, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2619168791383856882
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 433549130175143669}
+  - component: {fileID: 7327910739647968124}
+  - component: {fileID: 209936690070195600}
+  m_Layer: 5
+  m_Name: IconImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &433549130175143669
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2619168791383856882}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1774366634876720465}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7327910739647968124
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2619168791383856882}
+  m_CullTransparentMesh: 1
+--- !u!114 &209936690070195600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2619168791383856882}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2a026d323ae3c524a8ce5107e8b10221, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2941110168119836668
 GameObject:
   m_ObjectHideFlags: 0
@@ -13,7 +238,7 @@ GameObject:
   - component: {fileID: 6544172410186010186}
   - component: {fileID: 625760459563029879}
   m_Layer: 5
-  m_Name: FlipVerticallyButton
+  m_Name: FlipVerticallyButtonRight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -122,6 +347,128 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &3242060640214693354
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5330510531259397418}
+  - component: {fileID: 2554710736720051328}
+  - component: {fileID: 3014481793865592717}
+  - component: {fileID: 6590103694441971894}
+  m_Layer: 5
+  m_Name: SwapOrientationButtonBottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5330510531259397418
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3242060640214693354}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2351478305575642141}
+  - {fileID: 5917661806751334901}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 1.1, y: 1}
+--- !u!222 &2554710736720051328
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3242060640214693354}
+  m_CullTransparentMesh: 1
+--- !u!114 &3014481793865592717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3242060640214693354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.0039215684, g: 0.33594787, b: 1, a: 0.23529412}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 0c92e3e599ba5874fbe884a528b55175, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6590103694441971894
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3242060640214693354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3014481793865592717}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &4143598682504340498
 GameObject:
   m_ObjectHideFlags: 0
@@ -135,7 +482,7 @@ GameObject:
   - component: {fileID: 1401291228584605973}
   - component: {fileID: 7242317894940450536}
   m_Layer: 5
-  m_Name: FlipHorizontallyButton
+  m_Name: FlipHorizontallyButtonTop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -244,6 +591,201 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &4250031963686490461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1400288841713503440}
+  - component: {fileID: 3635069247572373266}
+  - component: {fileID: 5075025329939642615}
+  - component: {fileID: 115531692600822696}
+  m_Layer: 5
+  m_Name: ScaleHandleTopLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1400288841713503440
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4250031963686490461}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 1, y: 0}
+--- !u!222 &3635069247572373266
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4250031963686490461}
+  m_CullTransparentMesh: 1
+--- !u!114 &5075025329939642615
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4250031963686490461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: bc59dd8703c33824db5590d6317677be, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &115531692600822696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4250031963686490461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5075025329939642615}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &4360774589490014617
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5917661806751334901}
+  - component: {fileID: 9005202110752444284}
+  - component: {fileID: 98216582500730433}
+  m_Layer: 5
+  m_Name: OverlayImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5917661806751334901
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4360774589490014617}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5330510531259397418}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9005202110752444284
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4360774589490014617}
+  m_CullTransparentMesh: 1
+--- !u!114 &98216582500730433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4360774589490014617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4f018b342230544449b0ee23425d15c5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4484866586899276593
 GameObject:
   m_ObjectHideFlags: 0
@@ -394,6 +936,81 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5048695674560064794
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5319804879705940733}
+  - component: {fileID: 224788605282168207}
+  - component: {fileID: 8328130252704310802}
+  m_Layer: 5
+  m_Name: OverlayImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5319804879705940733
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5048695674560064794}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1774366634876720465}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &224788605282168207
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5048695674560064794}
+  m_CullTransparentMesh: 1
+--- !u!114 &8328130252704310802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5048695674560064794}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4f018b342230544449b0ee23425d15c5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5103450274299061361
 GameObject:
   m_ObjectHideFlags: 0
@@ -407,7 +1024,7 @@ GameObject:
   - component: {fileID: 1843246168137334438}
   - component: {fileID: 1169118915381496566}
   m_Layer: 5
-  m_Name: ScaleHandle
+  m_Name: ScaleHandleBottomRight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -511,6 +1128,126 @@ MonoBehaviour:
     m_DisabledTrigger: Disabled
   m_Interactable: 1
   m_TargetGraphic: {fileID: 1843246168137334438}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &5231994074673739833
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2083173321310351625}
+  - component: {fileID: 2917282509171572858}
+  - component: {fileID: 1137820625080680285}
+  - component: {fileID: 5339597919997836077}
+  m_Layer: 5
+  m_Name: ScaleHandleTopRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2083173321310351625
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5231994074673739833}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: -1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 1, y: 0}
+--- !u!222 &2917282509171572858
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5231994074673739833}
+  m_CullTransparentMesh: 1
+--- !u!114 &1137820625080680285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5231994074673739833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: bc59dd8703c33824db5590d6317677be, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5339597919997836077
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5231994074673739833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1137820625080680285}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -752,7 +1489,7 @@ GameObject:
   - component: {fileID: 1708578680297791042}
   - component: {fileID: 7586337019653692880}
   m_Layer: 5
-  m_Name: SwapOrientationButton
+  m_Name: SwapOrientationButtonTop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -861,6 +1598,203 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &7405502457585859535
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1774366634876720465}
+  - component: {fileID: 7396693529435552523}
+  - component: {fileID: 4043702993004449661}
+  - component: {fileID: 5757882108579956304}
+  m_Layer: 5
+  m_Name: FlipHorizontallyButtonBottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1774366634876720465
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7405502457585859535}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 433549130175143669}
+  - {fileID: 5319804879705940733}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: -0.1, y: 1}
+--- !u!222 &7396693529435552523
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7405502457585859535}
+  m_CullTransparentMesh: 1
+--- !u!114 &4043702993004449661
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7405502457585859535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.0039215684, g: 0.33594787, b: 1, a: 0.23529412}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5757882108579956304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7405502457585859535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4043702993004449661}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &7628295537009667374
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2351478305575642141}
+  - component: {fileID: 7831926909782530402}
+  - component: {fileID: 5040342419768106838}
+  m_Layer: 5
+  m_Name: IconImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2351478305575642141
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7628295537009667374}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5330510531259397418}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7831926909782530402
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7628295537009667374}
+  m_CullTransparentMesh: 1
+--- !u!114 &5040342419768106838
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7628295537009667374}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 66094a058d136f04da5b88261eafab81, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7795057816738114330
 GameObject:
   m_ObjectHideFlags: 0
@@ -894,9 +1828,15 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 899479764255355894}
+  - {fileID: 5330510531259397418}
   - {fileID: 1766343117652090356}
+  - {fileID: 1774366634876720465}
   - {fileID: 7368570754493280832}
+  - {fileID: 3149344774402744751}
+  - {fileID: 1400288841713503440}
+  - {fileID: 2083173321310351625}
   - {fileID: 7220820988905473836}
+  - {fileID: 8798936731066562761}
   - {fileID: 8476889802509655228}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -917,10 +1857,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23ff2b9bc1743cc439a2417e481ae6a3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _scaleHandleButton: {fileID: 1169118915381496566}
-  _flipHorizontallyButton: {fileID: 7242317894940450536}
-  _flipVerticallyButton: {fileID: 625760459563029879}
-  _changeOrientationButton: {fileID: 7586337019653692880}
+  _scaleHandleTopLeft: {fileID: 115531692600822696}
+  _scaleHandleTopRight: {fileID: 5339597919997836077}
+  _scaleHandleBottomRight: {fileID: 1169118915381496566}
+  _scaleHandleBottomLeft: {fileID: 6131957162846904274}
+  _changeOrientationButtonTop: {fileID: 7586337019653692880}
+  _changeOrientationButtonBottom: {fileID: 6590103694441971894}
+  _flipHorizontallyButtonTop: {fileID: 7242317894940450536}
+  _flipHorizontallyButtonBottom: {fileID: 5757882108579956304}
+  _flipVerticallyButtonRight: {fileID: 625760459563029879}
+  _flipVerticallyButtonLeft: {fileID: 6635978180094959108}
   _dragDelayDisplay: {fileID: 8391802334114634874}
   _dragDelayFill: {fileID: 8194650848896032991}
 --- !u!222 &3578143720487820442
@@ -975,6 +1921,128 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _blockType: 0
   _swipe: {fileID: 0}
+--- !u!1 &7999281622567255484
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3149344774402744751}
+  - component: {fileID: 2284826905837721632}
+  - component: {fileID: 1247360879364161731}
+  - component: {fileID: 6635978180094959108}
+  m_Layer: 5
+  m_Name: FlipVerticallyButtonLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &3149344774402744751
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7999281622567255484}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6267728757232761725}
+  - {fileID: 3503585971207212443}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 1.1, y: 0.5}
+--- !u!222 &2284826905837721632
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7999281622567255484}
+  m_CullTransparentMesh: 1
+--- !u!114 &1247360879364161731
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7999281622567255484}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.0039215684, g: 0.33594787, b: 1, a: 0.23529412}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6635978180094959108
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7999281622567255484}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1247360879364161731}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &8391802334114634874
 GameObject:
   m_ObjectHideFlags: 0
@@ -1201,3 +2269,123 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &9040533647684102133
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8798936731066562761}
+  - component: {fileID: 6811758736887770256}
+  - component: {fileID: 400692375910725215}
+  - component: {fileID: 6131957162846904274}
+  m_Layer: 5
+  m_Name: ScaleHandleBottomLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &8798936731066562761
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9040533647684102133}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: -1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &6811758736887770256
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9040533647684102133}
+  m_CullTransparentMesh: 1
+--- !u!114 &400692375910725215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9040533647684102133}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: bc59dd8703c33824db5590d6317677be, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6131957162846904274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9040533647684102133}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 400692375910725215}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
@@ -39,7 +39,7 @@ RectTransform:
   m_AnchorMax: {x: 1, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 200, y: 200}
-  m_Pivot: {x: 0, y: 0.5}
+  m_Pivot: {x: -0.1, y: 0.5}
 --- !u!222 &4393494692667761113
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -159,9 +159,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 20, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 200, y: 200}
-  m_Pivot: {x: 0, y: 0}
+  m_Pivot: {x: -0.1, y: 0}
 --- !u!222 &5657381491522302344
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -514,6 +514,81 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &5412064040998709591
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 232316377665963994}
+  - component: {fileID: 2884060665074919936}
+  - component: {fileID: 8194650848896032991}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &232316377665963994
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5412064040998709591}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8476889802509655228}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2884060665074919936
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5412064040998709591}
+  m_CullTransparentMesh: 1
+--- !u!114 &8194650848896032991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5412064040998709591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5c28812a47a7fc9499672d414ebac12a, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 0
+  m_FillClockwise: 1
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6018938580987114696
 GameObject:
   m_ObjectHideFlags: 0
@@ -701,9 +776,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -20, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 200, y: 200}
-  m_Pivot: {x: 1, y: 0}
+  m_Pivot: {x: 1.1, y: 0}
 --- !u!222 &9009767953479863446
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -822,6 +897,7 @@ RectTransform:
   - {fileID: 1766343117652090356}
   - {fileID: 7368570754493280832}
   - {fileID: 7220820988905473836}
+  - {fileID: 8476889802509655228}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -845,6 +921,8 @@ MonoBehaviour:
   _flipHorizontallyButton: {fileID: 7242317894940450536}
   _flipVerticallyButton: {fileID: 625760459563029879}
   _changeOrientationButton: {fileID: 7586337019653692880}
+  _dragDelayDisplay: {fileID: 8391802334114634874}
+  _dragDelayFill: {fileID: 8194650848896032991}
 --- !u!222 &3578143720487820442
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -897,6 +975,82 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _blockType: 0
   _swipe: {fileID: 0}
+--- !u!1 &8391802334114634874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8476889802509655228}
+  - component: {fileID: 8612852817037830928}
+  - component: {fileID: 5346760229585348604}
+  m_Layer: 5
+  m_Name: DragDelay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &8476889802509655228
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8391802334114634874}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 232316377665963994}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: -0.2}
+--- !u!222 &8612852817037830928
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8391802334114634874}
+  m_CullTransparentMesh: 1
+--- !u!114 &5346760229585348604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8391802334114634874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3066038, g: 0.3066038, b: 0.3066038, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5c28812a47a7fc9499672d414ebac12a, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8428815247614695722
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.07058824}
+  m_Color: {r: 0.0039215684, g: 0.33594787, b: 1, a: 0.23529412}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -453,7 +453,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.07058824}
+  m_Color: {r: 0.0039215684, g: 0.33594787, b: 1, a: 0.23529412}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
@@ -35,11 +35,11 @@ RectTransform:
   - {fileID: 1162865874504071011}
   m_Father: {fileID: 1680916854445050396}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.75, y: 1}
-  m_AnchorMax: {x: 0.75, y: 1}
-  m_AnchoredPosition: {x: 0, y: 20}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 20, y: 0}
   m_SizeDelta: {x: 200, y: 200}
-  m_Pivot: {x: 0.5, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!222 &5657381491522302344
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -232,7 +232,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 20, y: -20}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 200, y: 200}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &5778042336730306620
@@ -427,11 +427,11 @@ RectTransform:
   - {fileID: 5909508375793520392}
   m_Father: {fileID: 1680916854445050396}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.25, y: 1}
-  m_AnchorMax: {x: 0.25, y: 1}
-  m_AnchoredPosition: {x: 9, y: 20}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -20, y: 0}
   m_SizeDelta: {x: 200, y: 200}
-  m_Pivot: {x: 0.5, y: 0}
+  m_Pivot: {x: 1, y: 0}
 --- !u!222 &9009767953479863446
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0.47843137, b: 0.5882353, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.07058824}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -453,7 +453,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0.4778642, b: 0.5896226, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.07058824}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
@@ -1,0 +1,789 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4143598682504340498
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1766343117652090356}
+  - component: {fileID: 5657381491522302344}
+  - component: {fileID: 1401291228584605973}
+  - component: {fileID: 7242317894940450536}
+  m_Layer: 5
+  m_Name: FlipHorizontallyButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1766343117652090356
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4143598682504340498}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3706798945180430429}
+  - {fileID: 1162865874504071011}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.75, y: 1}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 20}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &5657381491522302344
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4143598682504340498}
+  m_CullTransparentMesh: 1
+--- !u!114 &1401291228584605973
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4143598682504340498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.47843137, b: 0.5882353, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7242317894940450536
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4143598682504340498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1401291228584605973}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &4484866586899276593
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3475494775537494166}
+  - component: {fileID: 99382521228897830}
+  - component: {fileID: 8337644744661343480}
+  m_Layer: 5
+  m_Name: IconImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3475494775537494166
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4484866586899276593}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 899479764255355894}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &99382521228897830
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4484866586899276593}
+  m_CullTransparentMesh: 1
+--- !u!114 &8337644744661343480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4484866586899276593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 66094a058d136f04da5b88261eafab81, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5103450274299061361
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7220820988905473836}
+  - component: {fileID: 5778042336730306620}
+  - component: {fileID: 1843246168137334438}
+  - component: {fileID: 1169118915381496566}
+  m_Layer: 5
+  m_Name: ScaleHandle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7220820988905473836
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5103450274299061361}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 20, y: -20}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &5778042336730306620
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5103450274299061361}
+  m_CullTransparentMesh: 1
+--- !u!114 &1843246168137334438
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5103450274299061361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: bc59dd8703c33824db5590d6317677be, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1169118915381496566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5103450274299061361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1843246168137334438}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &6168602152834881241
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5909508375793520392}
+  - component: {fileID: 7012684575991200110}
+  - component: {fileID: 598066365580994026}
+  m_Layer: 5
+  m_Name: OverlayImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5909508375793520392
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6168602152834881241}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 899479764255355894}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7012684575991200110
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6168602152834881241}
+  m_CullTransparentMesh: 1
+--- !u!114 &598066365580994026
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6168602152834881241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4f018b342230544449b0ee23425d15c5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6943804237923267933
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 899479764255355894}
+  - component: {fileID: 9009767953479863446}
+  - component: {fileID: 1708578680297791042}
+  - component: {fileID: 7586337019653692880}
+  m_Layer: 5
+  m_Name: SwapOrientationButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &899479764255355894
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6943804237923267933}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3475494775537494166}
+  - {fileID: 5909508375793520392}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 1}
+  m_AnchorMax: {x: 0.25, y: 1}
+  m_AnchoredPosition: {x: 9, y: 20}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &9009767953479863446
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6943804237923267933}
+  m_CullTransparentMesh: 1
+--- !u!114 &1708578680297791042
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6943804237923267933}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.4778642, b: 0.5896226, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 0c92e3e599ba5874fbe884a528b55175, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7586337019653692880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6943804237923267933}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1708578680297791042}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &7795057816738114330
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1680916854445050396}
+  - component: {fileID: 3578143720487820442}
+  - component: {fileID: 5825138239432314174}
+  - component: {fileID: 6974701924046025480}
+  m_Layer: 5
+  m_Name: BattleUiEditingComponent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1680916854445050396
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 899479764255355894}
+  - {fileID: 1766343117652090356}
+  - {fileID: 7220820988905473836}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3578143720487820442
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_CullTransparentMesh: 1
+--- !u!114 &5825138239432314174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6974701924046025480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5825138239432314174}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &8428815247614695722
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1162865874504071011}
+  - component: {fileID: 3940592059706733935}
+  - component: {fileID: 2954472132616444076}
+  m_Layer: 5
+  m_Name: OverlayImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1162865874504071011
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8428815247614695722}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1766343117652090356}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3940592059706733935
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8428815247614695722}
+  m_CullTransparentMesh: 1
+--- !u!114 &2954472132616444076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8428815247614695722}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4f018b342230544449b0ee23425d15c5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8526807881212026179
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3706798945180430429}
+  - component: {fileID: 1240863281356990261}
+  - component: {fileID: 5098140216949451865}
+  m_Layer: 5
+  m_Name: IconImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3706798945180430429
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8526807881212026179}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1766343117652090356}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1240863281356990261
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8526807881212026179}
+  m_CullTransparentMesh: 1
+--- !u!114 &5098140216949451865
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8526807881212026179}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2a026d323ae3c524a8ce5107e8b10221, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab
@@ -1,5 +1,127 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2941110168119836668
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7368570754493280832}
+  - component: {fileID: 4393494692667761113}
+  - component: {fileID: 6544172410186010186}
+  - component: {fileID: 625760459563029879}
+  m_Layer: 5
+  m_Name: FlipVerticallyButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7368570754493280832
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2941110168119836668}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2572421520464669778}
+  - {fileID: 5072570532351362525}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &4393494692667761113
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2941110168119836668}
+  m_CullTransparentMesh: 1
+--- !u!114 &6544172410186010186
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2941110168119836668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.0039215684, g: 0.33594787, b: 1, a: 0.23529412}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &625760459563029879
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2941110168119836668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6544172410186010186}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &4143598682504340498
 GameObject:
   m_ObjectHideFlags: 0
@@ -197,6 +319,81 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4948195403934940545
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2572421520464669778}
+  - component: {fileID: 4882716923301128160}
+  - component: {fileID: 3725369390464040673}
+  m_Layer: 5
+  m_Name: IconImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2572421520464669778
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4948195403934940545}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7368570754493280832}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4882716923301128160
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4948195403934940545}
+  m_CullTransparentMesh: 1
+--- !u!114 &3725369390464040673
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4948195403934940545}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 2a026d323ae3c524a8ce5107e8b10221, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5103450274299061361
 GameObject:
   m_ObjectHideFlags: 0
@@ -317,6 +514,81 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &6018938580987114696
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5072570532351362525}
+  - component: {fileID: 7568211037022290187}
+  - component: {fileID: 7156098336349185052}
+  m_Layer: 5
+  m_Name: OverlayImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5072570532351362525
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6018938580987114696}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7368570754493280832}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7568211037022290187
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6018938580987114696}
+  m_CullTransparentMesh: 1
+--- !u!114 &7156098336349185052
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6018938580987114696}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4f018b342230544449b0ee23425d15c5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6168602152834881241
 GameObject:
   m_ObjectHideFlags: 0
@@ -548,6 +820,7 @@ RectTransform:
   m_Children:
   - {fileID: 899479764255355894}
   - {fileID: 1766343117652090356}
+  - {fileID: 7368570754493280832}
   - {fileID: 7220820988905473836}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -569,7 +842,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _scaleHandleButton: {fileID: 1169118915381496566}
-  _flipButton: {fileID: 7242317894940450536}
+  _flipHorizontallyButton: {fileID: 7242317894940450536}
+  _flipVerticallyButton: {fileID: 625760459563029879}
   _changeOrientationButton: {fileID: 7586337019653692880}
 --- !u!222 &3578143720487820442
 CanvasRenderer:

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab.meta
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditingComponent.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2da1bc0d7742a4f419be8b03d44ba171
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -854,8 +854,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 242088613132244796}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.05, y: 0.05}
+  m_AnchorMax: {x: 0.8, y: 0.95}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -887,7 +887,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: '#'
+  m_text: Kohdista ruudukkoon
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
   m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
@@ -915,7 +915,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 81.8
+  m_fontSize: 29.45
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -959,6 +959,41 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4157852548233239349
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4039678384064123638}
+  m_Layer: 5
+  m_Name: OverlayImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4039678384064123638
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4157852548233239349}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 242088613132244796}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4340183268839438727
 GameObject:
   m_ObjectHideFlags: 0
@@ -1110,12 +1145,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 4039678384064123638}
   - {fileID: 8666209242975734668}
   - {fileID: 3003464538885304781}
   m_Father: {fileID: 1680916854445050396}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.9, y: 0.89}
-  m_AnchorMax: {x: 0.98, y: 0.94}
+  m_AnchorMin: {x: 0.01, y: 0.95}
+  m_AnchorMax: {x: 0.25, y: 0.99}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1140,14 +1176,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 0.25, g: 0.25, b: 0.25, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: 21300000, guid: 47f3804936cb29747bf9619ef5303fec, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1512,8 +1548,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 242088613132244796}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchorMin: {x: 0.8, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7795057816738114330
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1680916854445050396}
+  - component: {fileID: 3578143720487820442}
+  m_Layer: 5
+  m_Name: BattleUiEditor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1680916854445050396
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 75}
+  m_SizeDelta: {x: 0, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3578143720487820442
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_CullTransparentMesh: 1

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -1,5 +1,250 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1461493281532970003
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5075185318350001775}
+  - component: {fileID: 268698472427144110}
+  - component: {fileID: 8906215150768680588}
+  m_Layer: 5
+  m_Name: ArenaImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5075185318350001775
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461493281532970003}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &268698472427144110
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461493281532970003}
+  m_CullTransparentMesh: 1
+--- !u!114 &8906215150768680588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1461493281532970003}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.41960785}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6c75aa7c2b406eb48b72008f9794712a, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6606744864565165400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3557577885498150299}
+  m_Layer: 5
+  m_Name: UiElements
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3557577885498150299
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6606744864565165400}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &6883634282771826320
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 432415059231872337}
+  - component: {fileID: 8270987487138439107}
+  - component: {fileID: 5721876629299693019}
+  - component: {fileID: 5802049319318472387}
+  - component: {fileID: 5537668231924969656}
+  m_Layer: 5
+  m_Name: CloseButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &432415059231872337
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6883634282771826320}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.9, y: 0.99}
+  m_AnchorMax: {x: 0.98, y: 0.99}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &8270987487138439107
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6883634282771826320}
+  m_CullTransparentMesh: 1
+--- !u!114 &5721876629299693019
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6883634282771826320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 363a8ef59eb30824783d0725e2df10f5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5802049319318472387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6883634282771826320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5721876629299693019}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &5537668231924969656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6883634282771826320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 1
+  m_AspectRatio: 1
 --- !u!1 &7795057816738114330
 GameObject:
   m_ObjectHideFlags: 0
@@ -12,6 +257,7 @@ GameObject:
   - component: {fileID: 3578143720487820442}
   - component: {fileID: 2631945341480252299}
   - component: {fileID: 5825138239432314174}
+  - component: {fileID: 3993003692520607491}
   m_Layer: 5
   m_Name: BattleUiEditor
   m_TagString: Untagged
@@ -30,7 +276,10 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
-  m_Children: []
+  m_Children:
+  - {fileID: 5075185318350001775}
+  - {fileID: 432415059231872337}
+  - {fileID: 3557577885498150299}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -58,6 +307,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07fea859af56758409ab2d1e3c31e928, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _closeButton: {fileID: 5802049319318472387}
+  _uiElementsHolder: {fileID: 6606744864565165400}
+  _timer: {fileID: 1616917245377245213, guid: 96b37da3f89dc24429d5d3c8813ec4a0, type: 3}
+  _playerInfo: {fileID: 1616917245377245213, guid: 8f4ecb60d3a3e50488721264ca27122f,
+    type: 3}
+  _diamonds: {fileID: 1616917245377245213, guid: e2a77999f4d02104cb928e97462c132c,
+    type: 3}
+  _giveUpButton: {fileID: 1616917245377245213, guid: 8ed4dd9a40dd4514b9cf3cb595753384,
+    type: 3}
 --- !u!114 &5825138239432314174
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -71,14 +329,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.122641504, g: 0.122641504, b: 0.122641504, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.64705884}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: 21300000, guid: 6c75aa7c2b406eb48b72008f9794712a, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -88,3 +346,17 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3993003692520607491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cabc7ab297e9ab44a96e83ec36e516df, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _blockType: 0
+  _swipe: {fileID: 0}

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -1,80 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &1461493281532970003
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5075185318350001775}
-  - component: {fileID: 268698472427144110}
-  - component: {fileID: 8906215150768680588}
-  m_Layer: 5
-  m_Name: ArenaImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5075185318350001775
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1461493281532970003}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1680916854445050396}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &268698472427144110
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1461493281532970003}
-  m_CullTransparentMesh: 1
---- !u!114 &8906215150768680588
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1461493281532970003}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.41960785}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6c75aa7c2b406eb48b72008f9794712a, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6606744864565165400
 GameObject:
   m_ObjectHideFlags: 0
@@ -277,7 +202,6 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
-  - {fileID: 5075185318350001775}
   - {fileID: 432415059231872337}
   - {fileID: 3557577885498150299}
   m_Father: {fileID: 0}
@@ -308,7 +232,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _closeButton: {fileID: 5802049319318472387}
-  _uiElementsHolder: {fileID: 6606744864565165400}
+  _uiElementsHolder: {fileID: 3557577885498150299}
+  _editingComponent: {fileID: 7795057816738114330, guid: 2da1bc0d7742a4f419be8b03d44ba171,
+    type: 3}
   _timer: {fileID: 1616917245377245213, guid: 96b37da3f89dc24429d5d3c8813ec4a0, type: 3}
   _playerInfo: {fileID: 1616917245377245213, guid: 8f4ecb60d3a3e50488721264ca27122f,
     type: 3}
@@ -336,7 +262,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6c75aa7c2b406eb48b72008f9794712a, type: 3}
+  m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -202,6 +202,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
+  - {fileID: 701258777320508953}
   - {fileID: 3557577885498150299}
   - {fileID: 432415059231872337}
   m_Father: {fileID: 0}
@@ -255,7 +256,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.64705884}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -286,3 +287,78 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _blockType: 0
   _swipe: {fileID: 0}
+--- !u!1 &8189668658926161602
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 701258777320508953}
+  - component: {fileID: 4475095520249253549}
+  - component: {fileID: 7049804586350140998}
+  m_Layer: 5
+  m_Name: ArenaImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &701258777320508953
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8189668658926161602}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4475095520249253549
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8189668658926161602}
+  m_CullTransparentMesh: 1
+--- !u!114 &7049804586350140998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8189668658926161602}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6c75aa7c2b406eb48b72008f9794712a, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -202,8 +202,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
-  - {fileID: 432415059231872337}
   - {fileID: 3557577885498150299}
+  - {fileID: 432415059231872337}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -1,5 +1,448 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &893087887352098990
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8128630664376920366}
+  - component: {fileID: 7839260678199181534}
+  - component: {fileID: 7023558571966669558}
+  - component: {fileID: 8695014989208634311}
+  m_Layer: 5
+  m_Name: Contents
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8128630664376920366
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893087887352098990}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2611896946878390091}
+  - {fileID: 430047130965926392}
+  - {fileID: 1746766798648405005}
+  - {fileID: 7647380280109805249}
+  m_Father: {fileID: 4191613205202144846}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.3, y: 0.4}
+  m_AnchorMax: {x: 0.7, y: 0.6}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7839260678199181534
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893087887352098990}
+  m_CullTransparentMesh: 1
+--- !u!114 &7023558571966669558
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893087887352098990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.6156863, b: 0.56078434, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: fa8e4ffb86bf9e2439c498a9f6cc8226, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8695014989208634311
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 893087887352098990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7023558571966669558}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &1313701494920502350
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4191613205202144846}
+  - component: {fileID: 3378358740978069655}
+  - component: {fileID: 6955023554436840847}
+  - component: {fileID: 8252338872719668695}
+  m_Layer: 5
+  m_Name: SaveChangesPopup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &4191613205202144846
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1313701494920502350}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8128630664376920366}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3378358740978069655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1313701494920502350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6955023554436840847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1313701494920502350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 4
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 2631945341480252299}
+          m_TargetAssemblyTypeName: MenuUi.Scripts.Settings.BattleUiEditor.BattleUiEditor,
+            MainMenu
+          m_MethodName: CloseSaveChangesPopup
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+--- !u!222 &8252338872719668695
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1313701494920502350}
+  m_CullTransparentMesh: 1
+--- !u!1 &2058314370841198674
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2611896946878390091}
+  - component: {fileID: 2841606490294300634}
+  - component: {fileID: 6269352827104816766}
+  m_Layer: 5
+  m_Name: OverlayImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2611896946878390091
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2058314370841198674}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8128630664376920366}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2841606490294300634
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2058314370841198674}
+  m_CullTransparentMesh: 1
+--- !u!114 &6269352827104816766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2058314370841198674}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 96f5ba975f414d34bac6bada85f5f359, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2180607185624838090
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 430047130965926392}
+  - component: {fileID: 5455790479425737035}
+  - component: {fileID: 5494727294575861901}
+  m_Layer: 5
+  m_Name: SaveChangesText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &430047130965926392
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2180607185624838090}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8128630664376920366}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.5}
+  m_AnchorMax: {x: 0.9, y: 0.9}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5455790479425737035
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2180607185624838090}
+  m_CullTransparentMesh: 1
+--- !u!114 &5494727294575861901
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2180607185624838090}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Tallenna muutokset?
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 35c39ce28c397b848b84f7de2f26c5ac, type: 2}
+  m_sharedMaterial: {fileID: 2109022488393823743, guid: 35c39ce28c397b848b84f7de2f26c5ac,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 59.15
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &2193908003286017410
 GameObject:
   m_ObjectHideFlags: 0
@@ -516,6 +959,126 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4340183268839438727
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1746766798648405005}
+  - component: {fileID: 8929590394067382847}
+  - component: {fileID: 5808163540399811337}
+  - component: {fileID: 544604813055288685}
+  m_Layer: 5
+  m_Name: OkButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1746766798648405005
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4340183268839438727}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8128630664376920366}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.55, y: 0.1}
+  m_AnchorMax: {x: 0.95, y: 0.4}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8929590394067382847
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4340183268839438727}
+  m_CullTransparentMesh: 1
+--- !u!114 &5808163540399811337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4340183268839438727}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 7f4ac073adc3c05469ef4048b221b7ba, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &544604813055288685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4340183268839438727}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5808163540399811337}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &4373028281340898621
 GameObject:
   m_ObjectHideFlags: 0
@@ -642,6 +1205,126 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_IsOn: 1
+--- !u!1 &5652028334675305795
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7647380280109805249}
+  - component: {fileID: 3577742814380459564}
+  - component: {fileID: 4007243026978571142}
+  - component: {fileID: 4890329012955817898}
+  m_Layer: 5
+  m_Name: NoButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7647380280109805249
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5652028334675305795}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8128630664376920366}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.1}
+  m_AnchorMax: {x: 0.45, y: 0.4}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3577742814380459564
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5652028334675305795}
+  m_CullTransparentMesh: 1
+--- !u!114 &4007243026978571142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5652028334675305795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 363a8ef59eb30824783d0725e2df10f5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4890329012955817898
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5652028334675305795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4007243026978571142}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &6606744864565165400
 GameObject:
   m_ObjectHideFlags: 0
@@ -910,6 +1593,7 @@ RectTransform:
   - {fileID: 432415059231872337}
   - {fileID: 4566702985809148689}
   - {fileID: 242088613132244796}
+  - {fileID: 4191613205202144846}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -951,6 +1635,9 @@ MonoBehaviour:
     type: 3}
   _giveUpButton: {fileID: 1616917245377245213, guid: 8ed4dd9a40dd4514b9cf3cb595753384,
     type: 3}
+  _saveChangesPopup: {fileID: 1313701494920502350}
+  _okButton: {fileID: 544604813055288685}
+  _noButton: {fileID: 4890329012955817898}
 --- !u!114 &5825138239432314174
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -10,6 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 1680916854445050396}
   - component: {fileID: 3578143720487820442}
+  - component: {fileID: 2631945341480252299}
+  - component: {fileID: 5825138239432314174}
   m_Layer: 5
   m_Name: BattleUiEditor
   m_TagString: Untagged
@@ -33,8 +35,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 75}
-  m_SizeDelta: {x: 0, y: 150}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3578143720487820442
 CanvasRenderer:
@@ -44,3 +46,45 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7795057816738114330}
   m_CullTransparentMesh: 1
+--- !u!114 &2631945341480252299
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07fea859af56758409ab2d1e3c31e928, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5825138239432314174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795057816738114330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.122641504, g: 0.122641504, b: 0.122641504, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -1,5 +1,527 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2193908003286017410
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8256838755475218228}
+  - component: {fileID: 8621116789231531144}
+  - component: {fileID: 5683609660618175688}
+  m_Layer: 5
+  m_Name: ResetText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8256838755475218228
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2193908003286017410}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4566702985809148689}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0}
+  m_AnchorMax: {x: 0.9, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8621116789231531144
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2193908003286017410}
+  m_CullTransparentMesh: 1
+--- !u!114 &5683609660618175688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2193908003286017410}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Reset
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
+  m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 46.3
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2447601793991616838
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4566702985809148689}
+  - component: {fileID: 3419605329659924392}
+  - component: {fileID: 3289567691892441745}
+  - component: {fileID: 4557563786959623578}
+  m_Layer: 5
+  m_Name: ResetButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4566702985809148689
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2447601793991616838}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4673021165670695670}
+  - {fileID: 8256838755475218228}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.7, y: 0.95}
+  m_AnchorMax: {x: 0.85, y: 0.99}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3419605329659924392
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2447601793991616838}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4557563786959623578}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!222 &3289567691892441745
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2447601793991616838}
+  m_CullTransparentMesh: 1
+--- !u!114 &4557563786959623578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2447601793991616838}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.27450982, b: 0.2784314, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1d3bce7f71f04174b821fc369dd0de85, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3435161398115498787
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8666209242975734668}
+  - component: {fileID: 6488720172705935135}
+  - component: {fileID: 1256493804267341119}
+  m_Layer: 5
+  m_Name: GridText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8666209242975734668
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3435161398115498787}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 242088613132244796}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6488720172705935135
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3435161398115498787}
+  m_CullTransparentMesh: 1
+--- !u!114 &1256493804267341119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3435161398115498787}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: '#'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
+  m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 81.8
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 256
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4373028281340898621
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 242088613132244796}
+  - component: {fileID: 106771665394271315}
+  - component: {fileID: 3620791454413159910}
+  - component: {fileID: 3654744639999647962}
+  m_Layer: 5
+  m_Name: GridToggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &242088613132244796
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4373028281340898621}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8666209242975734668}
+  - {fileID: 3003464538885304781}
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.9, y: 0.89}
+  m_AnchorMax: {x: 0.98, y: 0.94}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &106771665394271315
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4373028281340898621}
+  m_CullTransparentMesh: 1
+--- !u!114 &3620791454413159910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4373028281340898621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3654744639999647962
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4373028281340898621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1256493804267341119}
+  toggleTransition: 1
+  graphic: {fileID: 5552844153415236340}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_IsOn: 1
 --- !u!1 &6606744864565165400
 GameObject:
   m_ObjectHideFlags: 0
@@ -47,7 +569,6 @@ GameObject:
   - component: {fileID: 8270987487138439107}
   - component: {fileID: 5721876629299693019}
   - component: {fileID: 5802049319318472387}
-  - component: {fileID: 5537668231924969656}
   m_Layer: 5
   m_Name: CloseButton
   m_TagString: Untagged
@@ -69,11 +590,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1680916854445050396}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.9, y: 0.99}
+  m_AnchorMin: {x: 0.9, y: 0.95}
   m_AnchorMax: {x: 0.98, y: 0.99}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 1}
+  m_Pivot: {x: 1, y: 1}
 --- !u!222 &8270987487138439107
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -156,20 +677,81 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &5537668231924969656
+--- !u!1 &7642212523721622913
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3003464538885304781}
+  - component: {fileID: 9178017345358403913}
+  - component: {fileID: 5552844153415236340}
+  m_Layer: 5
+  m_Name: CheckmarkImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3003464538885304781
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7642212523721622913}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 242088613132244796}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9178017345358403913
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7642212523721622913}
+  m_CullTransparentMesh: 1
+--- !u!114 &5552844153415236340
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6883634282771826320}
+  m_GameObject: {fileID: 7642212523721622913}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_AspectMode: 1
-  m_AspectRatio: 1
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 7f4ac073adc3c05469ef4048b221b7ba, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7795057816738114330
 GameObject:
   m_ObjectHideFlags: 0
@@ -205,6 +787,8 @@ RectTransform:
   - {fileID: 701258777320508953}
   - {fileID: 3557577885498150299}
   - {fileID: 432415059231872337}
+  - {fileID: 4566702985809148689}
+  - {fileID: 242088613132244796}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -233,6 +817,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _closeButton: {fileID: 5802049319318472387}
+  _resetButton: {fileID: 3419605329659924392}
+  _gridToggle: {fileID: 3654744639999647962}
   _uiElementsHolder: {fileID: 3557577885498150299}
   _editingComponent: {fileID: 7795057816738114330, guid: 2da1bc0d7742a4f419be8b03d44ba171,
     type: 3}
@@ -355,6 +941,81 @@ MonoBehaviour:
   m_Sprite: {fileID: 21300000, guid: 6c75aa7c2b406eb48b72008f9794712a, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8546624407442675849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4673021165670695670}
+  - component: {fileID: 3409151700851346260}
+  - component: {fileID: 7419218752422788612}
+  m_Layer: 5
+  m_Name: OverlayImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4673021165670695670
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8546624407442675849}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4566702985809148689}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3409151700851346260
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8546624407442675849}
+  m_CullTransparentMesh: 1
+--- !u!114 &7419218752422788612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8546624407442675849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4f51723f0cfd41e42a4fd316741fd829, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab
@@ -259,6 +259,126 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2737543280324462187
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1249122983299083727}
+  - component: {fileID: 8992654038655213279}
+  - component: {fileID: 5033272887052199268}
+  - component: {fileID: 7246965627836759804}
+  m_Layer: 5
+  m_Name: CloseButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1249122983299083727
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2737543280324462187}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1680916854445050396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.9, y: 0.95}
+  m_AnchorMax: {x: 0.98, y: 0.99}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &8992654038655213279
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2737543280324462187}
+  m_CullTransparentMesh: 1
+--- !u!114 &5033272887052199268
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2737543280324462187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 363a8ef59eb30824783d0725e2df10f5, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7246965627836759804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2737543280324462187}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5033272887052199268}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &3435161398115498787
 GameObject:
   m_ObjectHideFlags: 0
@@ -570,7 +690,7 @@ GameObject:
   - component: {fileID: 5721876629299693019}
   - component: {fileID: 5802049319318472387}
   m_Layer: 5
-  m_Name: CloseButton
+  m_Name: SaveButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -590,8 +710,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1680916854445050396}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.9, y: 0.95}
-  m_AnchorMax: {x: 0.98, y: 0.99}
+  m_AnchorMin: {x: 0.57, y: 0.95}
+  m_AnchorMax: {x: 0.65, y: 0.99}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 1, y: 1}
@@ -623,7 +743,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 363a8ef59eb30824783d0725e2df10f5, type: 3}
+  m_Sprite: {fileID: 21300000, guid: f34496c89b371bd479976768f666d31f, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -786,6 +906,7 @@ RectTransform:
   m_Children:
   - {fileID: 701258777320508953}
   - {fileID: 3557577885498150299}
+  - {fileID: 1249122983299083727}
   - {fileID: 432415059231872337}
   - {fileID: 4566702985809148689}
   - {fileID: 242088613132244796}
@@ -816,7 +937,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07fea859af56758409ab2d1e3c31e928, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _closeButton: {fileID: 5802049319318472387}
+  _closeButton: {fileID: 7246965627836759804}
+  _saveButton: {fileID: 5802049319318472387}
   _resetButton: {fileID: 3419605329659924392}
   _gridToggle: {fileID: 3654744639999647962}
   _uiElementsHolder: {fileID: 3557577885498150299}

--- a/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab.meta
+++ b/Assets/MenuUi/Prefabs/Settings/BattleUiEditor/BattleUiEditor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 333f39dbbf4842c4592131e56b1dcf5d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor.meta
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d2f01feb387d494c99fcc7213217cfd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -62,6 +62,10 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             }
             else
             {
+                // Calculating offset so that moving gameobject is relative to the click position and not the pivot
+                _moveOffset.x = _movableElement.transform.position.x - eventData.pressPosition.x;
+                _moveOffset.y = _movableElement.transform.position.y - eventData.pressPosition.y;
+
                 _currentAction = ActionType.Move;
             }
         }
@@ -71,7 +75,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             switch (_currentAction)
             {
                 case ActionType.Move:
-                    _movableElement.transform.position = eventData.position;
+                    Debug.Log(_moveOffset);
+                    _movableElement.transform.position = eventData.position + _moveOffset;
                     break;
                 case ActionType.Scale:
                     // Scaling while keeping aspect ratio
@@ -85,6 +90,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         public void OnEndDrag(PointerEventData eventData)
         {
             CalculateAndSetAnchors();
+            _currentAction = ActionType.None;
         }
 
         enum ActionType
@@ -99,6 +105,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private BattleUiMultiOrientationElement _multiOrientationElement;
         private BattleUiMovableElementData _movableElementData;
         private ActionType _currentAction;
+        private Vector2 _moveOffset;
 
         private void OnDestroy()
         {

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -207,11 +207,11 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private IEnumerator StartDragTimer(Action callback)
         {
             _dragDelayFill.fillAmount = 0;
-            _dragDelayDisplay.SetActive(true);
 
             float timePassed = 0f;
             while (timePassed < 0.5f)
             {
+                if (!_dragDelayDisplay.activeSelf && timePassed >= 0.2f) _dragDelayDisplay.SetActive(true);
                 _dragDelayFill.fillAmount = timePassed * 2;
                 yield return null;
                 timePassed += Time.deltaTime;

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using UnityEngine.EventSystems;
 
 using Altzone.Scripts.BattleUiShared;
+using OrientationType = Altzone.Scripts.BattleUiShared.BattleUiMultiOrientationElement.OrientationType;
 
 namespace MenuUi.Scripts.Settings.BattleUiEditor
 {
@@ -40,6 +41,9 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             SetControlButtonSize(_scaleHandleButton, 0.05f);
             SetControlButtonSize(_flipButton, 0.1f);
             SetControlButtonSize(_changeOrientationButton, 0.1f);
+
+            _flipButton.onClick.AddListener(FlipOrientation);
+            _changeOrientationButton.onClick.AddListener(ChangeOrientation);
 
             _movableElementData = multiOrientationElement.GetData();
         }
@@ -96,6 +100,12 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private BattleUiMovableElementData _movableElementData;
         private ActionType _currentAction;
 
+        private void OnDestroy()
+        {
+            _flipButton.onClick.RemoveAllListeners();
+            _changeOrientationButton.onClick.RemoveAllListeners();
+        }
+
         private void CalculateAndSetAnchors()
         {
             float holderWidth = _uiElementHolder.rect.width;
@@ -125,6 +135,32 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             float buttonWidth = _uiElementHolder.rect.width * sizeRatio;
             Vector2 buttonSize = new Vector2(buttonWidth, buttonWidth);
             button.GetComponent<RectTransform>().sizeDelta = buttonSize;
+        }
+
+        private void FlipOrientation()
+        {
+            switch (_multiOrientationElement.Orientation)
+            {
+                case OrientationType.Horizontal:
+                    _movableElementData.Orientation = OrientationType.HorizontalFlipped;
+                    break;
+                case OrientationType.HorizontalFlipped:
+                    _movableElementData.Orientation = OrientationType.Horizontal;
+                    break;
+                case OrientationType.Vertical:
+                    _movableElementData.Orientation = OrientationType.VerticalFlipped;
+                    break;
+                case OrientationType.VerticalFlipped:
+                    _movableElementData.Orientation = OrientationType.Vertical;
+                    break;
+            }
+            _multiOrientationElement.SetData(_movableElementData);
+        }
+
+        private void ChangeOrientation()
+        {
+            _movableElementData.Orientation = _multiOrientationElement.IsHorizontal ? OrientationType.Vertical : OrientationType.Horizontal;
+            _multiOrientationElement.SetData(_movableElementData);
         }
     }
 }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -125,7 +125,6 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         public void OnEndDrag(PointerEventData eventData)
         {
             CalculateAndSetAnchors();
-            CheckControlButtonsVisibility();
             _currentAction = ActionType.None;
         }
 
@@ -247,6 +246,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _data.AnchorMax = new(anchorXMax, anchorYMax);
 
             _movableElement.SetData(_data);
+            CheckControlButtonsVisibility();
         }
 
         private void FlipHorizontally()
@@ -308,9 +308,15 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         {
             Button[] buttons = new Button[] { _scaleHandleButton, _changeOrientationButton, _flipHorizontallyButton, _flipVerticallyButton };
 
+            RectTransform _changeOrientationRectTransform = null;
+            RectTransform _flipHorizontallyRectTransform = null;
+
             foreach (Button button in buttons)
             {
                 RectTransform buttonRectTransform = button.GetComponent<RectTransform>();
+
+                if (button == _changeOrientationButton) _changeOrientationRectTransform = buttonRectTransform;
+                if (button == _flipHorizontallyButton) _flipHorizontallyRectTransform = buttonRectTransform;
 
                 // Setting button to default position
                 buttonRectTransform.anchoredPosition = Vector2.zero;
@@ -370,6 +376,19 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
                     buttonRectTransform.anchoredPosition = newPosition;
                 }
+            }
+
+            // Ensuring the two top buttons are next to each other
+            if (_flipHorizontallyRectTransform == null || _changeOrientationRectTransform == null) return;
+            if (_changeOrientationRectTransform.anchoredPosition == _flipHorizontallyRectTransform.anchoredPosition) return;
+
+            if (_changeOrientationRectTransform.anchoredPosition != Vector2.zero)
+            {
+                _flipHorizontallyRectTransform.anchoredPosition += _changeOrientationRectTransform.anchoredPosition;
+            }
+            else if (_flipHorizontallyRectTransform.anchoredPosition != Vector2.zero)
+            {
+                _changeOrientationRectTransform.anchoredPosition += _flipHorizontallyRectTransform.anchoredPosition;
             }
         }
     }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -121,14 +121,16 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     break;
                 case ActionType.Scale:
                     // Scaling while keeping aspect ratio
-                    float sizeIncreaseX = eventData.delta.x;
+                    float sizeIncreaseX = (eventData.position.x - eventData.pressPosition.x) * 2;
                     float sizeIncreaseY = sizeIncreaseX / (_movableElement.RectTransformComponent.rect.width / _movableElement.RectTransformComponent.rect.height);
-                    _movableElement.RectTransformComponent.sizeDelta += new Vector2(sizeIncreaseX, sizeIncreaseY);
+                    _movableElement.RectTransformComponent.sizeDelta = new Vector2(sizeIncreaseX, sizeIncreaseY);
 
                     // Preventing out of bounds scaling or being scaled too small
                     if (_multiOrientationElement == null || _multiOrientationElement.IsHorizontal)
                     {
                         float clampedWidth = Mathf.Clamp(_movableElement.RectTransformComponent.rect.width, _minWidth, _maxWidth);
+                        if (_isGridToggled) clampedWidth = Mathf.Round(clampedWidth / (BattleUiEditor.GridCellWidth * 2)) * (BattleUiEditor.GridCellWidth * 2);
+
                         float aspectRatio = _multiOrientationElement == null ? _movableElementAspectRatio : _multiOrientationElement.HorizontalAspectRatio;
 
                         _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, clampedWidth);
@@ -137,6 +139,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     else if (!_multiOrientationElement.IsHorizontal)
                     {
                         float clampedHeight = Mathf.Clamp(_movableElement.RectTransformComponent.rect.height, _minHeight, _maxHeight);
+                        if (_isGridToggled) clampedHeight = Mathf.Round(clampedHeight / (BattleUiEditor.GridCellHeight * 2)) * (BattleUiEditor.GridCellHeight * 2);
 
                         _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, clampedHeight * _multiOrientationElement.VerticalAspectRatio);
                         _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, clampedHeight);
@@ -167,10 +170,10 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         }
 
         private RectTransform _uiElementHolder;
-        private float _maxWidth => _uiElementHolder.rect.width / 1.5f;
-        private float _maxHeight => _uiElementHolder.rect.height / 2;
-        private float _minWidth => _uiElementHolder.rect.width / 7.5f;
-        private float _minHeight => _uiElementHolder.rect.height / 10;
+        private float _maxWidth => BattleUiEditor.GridCellWidth * 14;
+        private float _maxHeight => BattleUiEditor.GridCellHeight * 20;
+        private float _minWidth => BattleUiEditor.GridCellWidth * 2;
+        private float _minHeight => BattleUiEditor.GridCellHeight * 4;
 
         private BattleUiMovableElement _movableElement;
         private BattleUiMultiOrientationElement _multiOrientationElement;

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -24,6 +24,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _uiElementHolder = uiElementHolder.GetComponent<RectTransform>();
 
             SetControlButtonSize(_scaleHandleButton, 0.05f);
+
+            _movableElementData = movableElement.GetData();
         }
 
         public void SetInfo(BattleUiMultiOrientationElement multiOrientationElement, Transform uiElementHolder)
@@ -38,6 +40,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             SetControlButtonSize(_scaleHandleButton, 0.05f);
             SetControlButtonSize(_flipButton, 0.1f);
             SetControlButtonSize(_changeOrientationButton, 0.1f);
+
+            _movableElementData = multiOrientationElement.GetData();
         }
 
         public void OnBeginDrag(PointerEventData eventData)
@@ -66,7 +70,10 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     _movableElement.transform.position = eventData.position;
                     break;
                 case ActionType.Scale:
-                    //eventData.delta
+                    // Scaling while keeping aspect ratio
+                    float sizeIncreaseX = eventData.delta.x * 2;
+                    float sizeIncreaseY = sizeIncreaseX / (_movableElement.RectTransformComponent.rect.width / _movableElement.RectTransformComponent.rect.height);
+                    _movableElement.RectTransformComponent.sizeDelta += new Vector2 (sizeIncreaseX, sizeIncreaseY);
                     break;
             }
         }
@@ -86,6 +93,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private RectTransform _uiElementHolder;
         private BattleUiMovableElement _movableElement;
         private BattleUiMultiOrientationElement _multiOrientationElement;
+        private BattleUiMovableElementData _movableElementData;
         private ActionType _currentAction;
 
         private void CalculateAndSetAnchors()
@@ -93,12 +101,11 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             float holderWidth = _uiElementHolder.rect.width;
             float holderHeight = _uiElementHolder.rect.height;
 
-            RectTransform _movableElementRect = _movableElement.GetComponent<RectTransform>();
-            float xPos = _movableElementRect.localPosition.x;
-            float yPos = _movableElementRect.localPosition.y;
+            float xPos = _movableElement.RectTransformComponent.localPosition.x;
+            float yPos = _movableElement.RectTransformComponent.localPosition.y;
 
-            float ownWidth = _movableElementRect.rect.width;
-            float ownHeight = _movableElementRect.rect.height;
+            float ownWidth = _movableElement.RectTransformComponent.rect.width;
+            float ownHeight = _movableElement.RectTransformComponent.rect.height;
 
             float anchorXMin = (xPos - ownWidth / 2.0f) / holderWidth + 0.5f;
             float anchorXMax = (xPos + ownWidth / 2.0f) / holderWidth + 0.5f;
@@ -106,17 +113,13 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             float anchorYMin = (yPos - ownHeight / 2.0f) / holderHeight + 0.5f;
             float anchorYMax = (yPos + ownHeight / 2.0f) / holderHeight + 0.5f;
 
-            Vector2 anchorMin = new(anchorXMin, anchorYMin);
-            Vector2 anchorMax = new(anchorXMax, anchorYMax);
+            _movableElementData.AnchorMin = new(anchorXMin, anchorYMin);
+            _movableElementData.AnchorMax = new(anchorXMax, anchorYMax);
 
-            _movableElementRect.anchorMin = anchorMin;
-            _movableElementRect.anchorMax = anchorMax;
-
-            _movableElementRect.offsetMin = Vector2.zero;
-            _movableElementRect.offsetMax = Vector2.zero;
+            _movableElement.SetData(_movableElementData);
         }
 
-        // Is used to calculate appropiate size for the control buttons, since if they were anchored they would grow with the element when it's scaled
+        // Method used to calculate appropiate size for the control buttons, since if they were anchored they would grow with the element when it's scaled
         private void SetControlButtonSize(Button button, float sizeRatio)
         {
             float buttonWidth = _uiElementHolder.rect.width * sizeRatio;

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -22,6 +22,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         [SerializeField] private GameObject _dragDelayDisplay;
         [SerializeField] private Image _dragDelayFill;
 
+        public Action UiElementEdited;
+
         public void SetInfo(BattleUiMovableElement movableElement, Transform uiElementHolder)
         {
             _movableElement = movableElement;
@@ -106,7 +108,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             switch (_currentAction)
             {
                 case ActionType.Move:
-                    if (_isGridToggled)
+                    if (_isGridToggled) // Snapping to grid while moving
                     {
                         Vector2 newPos = Vector2.zero;
                         newPos.x = Mathf.Round(eventData.position.x / BattleUiEditor.GridCellWidth) * BattleUiEditor.GridCellWidth;
@@ -114,7 +116,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
                         _movableElement.transform.position = newPos;
                     }
-                    else
+                    else // Free movement
                     {
                         _movableElement.transform.position = eventData.position;
                     }
@@ -129,6 +131,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     if (_multiOrientationElement == null || _multiOrientationElement.IsHorizontal)
                     {
                         float clampedWidth = Mathf.Clamp(_movableElement.RectTransformComponent.rect.width, _minWidth, _maxWidth);
+
+                        // Snapping scaling to grid
                         if (_isGridToggled) clampedWidth = Mathf.Round(clampedWidth / (BattleUiEditor.GridCellWidth * 2)) * (BattleUiEditor.GridCellWidth * 2);
 
                         float aspectRatio = _multiOrientationElement == null ? _movableElementAspectRatio : _multiOrientationElement.HorizontalAspectRatio;
@@ -139,6 +143,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     else if (!_multiOrientationElement.IsHorizontal)
                     {
                         float clampedHeight = Mathf.Clamp(_movableElement.RectTransformComponent.rect.height, _minHeight, _maxHeight);
+
+                        // Snapping scaling to grid
                         if (_isGridToggled) clampedHeight = Mathf.Round(clampedHeight / (BattleUiEditor.GridCellHeight * 2)) * (BattleUiEditor.GridCellHeight * 2);
 
                         _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, clampedHeight * _multiOrientationElement.VerticalAspectRatio);
@@ -150,7 +156,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         public void OnEndDrag(PointerEventData eventData)
         {
-            CalculateAndSetAnchors();
+            if (_currentAction == ActionType.Move || _currentAction == ActionType.Scale) CalculateAndSetAnchors();
             _currentAction = ActionType.None;
         }
 
@@ -274,18 +280,24 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             _movableElement.SetData(_data);
             CheckControlButtonsVisibility();
+
+            UiElementEdited?.Invoke();
         }
 
         private void FlipHorizontally()
         {
             _data.IsFlippedHorizontally = !_data.IsFlippedHorizontally;
             _multiOrientationElement.SetData(_data);
+
+            UiElementEdited?.Invoke();
         }
 
         private void FlipVertically()
         {
             _data.IsFlippedVertically = !_data.IsFlippedVertically;
             _multiOrientationElement.SetData(_data);
+
+            UiElementEdited?.Invoke();
         }
 
         private void ChangeOrientation()

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -133,18 +133,22 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             switch (_currentAction)
             {
                 case ActionType.Move:
+                    Vector2 newPos = Vector2.zero;
                     if (_isGridToggled) // Snapping to grid while moving
                     {
-                        Vector2 newPos = Vector2.zero;
                         newPos.x = Mathf.Round(eventData.position.x / BattleUiEditor.GridCellWidth) * BattleUiEditor.GridCellWidth;
                         newPos.y = Mathf.Round(eventData.position.y / BattleUiEditor.GridCellHeight) * BattleUiEditor.GridCellHeight;
-
-                        _movableElement.transform.position = newPos;
                     }
                     else // Free movement
                     {
-                        _movableElement.transform.position = eventData.position;
+                        newPos = eventData.position;
                     }
+
+                    // Clamping position to be inside the editor
+                    newPos.x = Mathf.Clamp(newPos.x, _minPosX, _maxPosX);
+                    newPos.y = Mathf.Clamp(newPos.y, _minPosY, _maxPosY);
+
+                    _movableElement.transform.position = newPos;
                     break;
                 case ActionType.Scale:
                     // Scaling while keeping aspect ratio
@@ -200,11 +204,17 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             BottomRight = 3,
         }
 
-        private RectTransform _uiElementHolder;
         private float _maxWidth => BattleUiEditor.GridCellWidth * 10;
         private float _maxHeight => BattleUiEditor.GridCellHeight * 16;
         private float _minWidth => BattleUiEditor.GridCellWidth * 2;
         private float _minHeight => BattleUiEditor.GridCellHeight * 4;
+
+        private float _maxPosX => _uiElementHolder.rect.width - _movableElement.RectTransformComponent.rect.width / 2;
+        private float _maxPosY => _uiElementHolder.rect.height - _movableElement.RectTransformComponent.rect.height / 2;
+        private float _minPosX => _movableElement.RectTransformComponent.rect.width / 2;
+        private float _minPosY => _movableElement.RectTransformComponent.rect.height / 2;
+
+        private RectTransform _uiElementHolder;
 
         private BattleUiMovableElement _movableElement;
         private BattleUiMultiOrientationElement _multiOrientationElement;
@@ -214,7 +224,9 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private bool _isPointerDown = false;
         private bool _isGridToggled = false;
+
         private Coroutine _dragTimerHolder = null;
+
         private ActionType _currentAction;
 
         private void OnEnable()

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -15,21 +15,29 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         [SerializeField] private Button _flipButton;
         [SerializeField] private Button _changeOrientationButton;
 
-        public void SetInfo(BattleUiMovableElement movableElement)
+        public void SetInfo(BattleUiMovableElement movableElement, Transform uiElementHolder)
         {
             _flipButton.gameObject.SetActive(false);
             _changeOrientationButton.gameObject.SetActive(false);
 
             _movableElement = movableElement;
+            _uiElementHolder = uiElementHolder.GetComponent<RectTransform>();
+
+            SetControlButtonSize(_scaleHandleButton, 0.05f);
         }
 
-        public void SetInfo(BattleUiMultiOrientationElement multiOrientationElement)
+        public void SetInfo(BattleUiMultiOrientationElement multiOrientationElement, Transform uiElementHolder)
         {
             _flipButton.gameObject.SetActive(true);
             _changeOrientationButton.gameObject.SetActive(true);
 
             _multiOrientationElement = multiOrientationElement;
             _movableElement = multiOrientationElement;
+            _uiElementHolder = uiElementHolder.GetComponent<RectTransform>();
+
+            SetControlButtonSize(_scaleHandleButton, 0.05f);
+            SetControlButtonSize(_flipButton, 0.1f);
+            SetControlButtonSize(_changeOrientationButton, 0.1f);
         }
 
         public void OnBeginDrag(PointerEventData eventData)
@@ -65,7 +73,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         public void OnEndDrag(PointerEventData eventData)
         {
-
+            CalculateAndSetAnchors();
         }
 
         enum ActionType
@@ -75,8 +83,45 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             Scale
         }
 
+        private RectTransform _uiElementHolder;
         private BattleUiMovableElement _movableElement;
         private BattleUiMultiOrientationElement _multiOrientationElement;
         private ActionType _currentAction;
+
+        private void CalculateAndSetAnchors()
+        {
+            float holderWidth = _uiElementHolder.rect.width;
+            float holderHeight = _uiElementHolder.rect.height;
+
+            RectTransform _movableElementRect = _movableElement.GetComponent<RectTransform>();
+            float xPos = _movableElementRect.localPosition.x;
+            float yPos = _movableElementRect.localPosition.y;
+
+            float ownWidth = _movableElementRect.rect.width;
+            float ownHeight = _movableElementRect.rect.height;
+
+            float anchorXMin = (xPos - ownWidth / 2.0f) / holderWidth + 0.5f;
+            float anchorXMax = (xPos + ownWidth / 2.0f) / holderWidth + 0.5f;
+
+            float anchorYMin = (yPos - ownHeight / 2.0f) / holderHeight + 0.5f;
+            float anchorYMax = (yPos + ownHeight / 2.0f) / holderHeight + 0.5f;
+
+            Vector2 anchorMin = new(anchorXMin, anchorYMin);
+            Vector2 anchorMax = new(anchorXMax, anchorYMax);
+
+            _movableElementRect.anchorMin = anchorMin;
+            _movableElementRect.anchorMax = anchorMax;
+
+            _movableElementRect.offsetMin = Vector2.zero;
+            _movableElementRect.offsetMax = Vector2.zero;
+        }
+
+        // Is used to calculate appropiate size for the control buttons, since if they were anchored they would grow with the element when it's scaled
+        private void SetControlButtonSize(Button button, float sizeRatio)
+        {
+            float buttonWidth = _uiElementHolder.rect.width * sizeRatio;
+            Vector2 buttonSize = new Vector2(buttonWidth, buttonWidth);
+            button.GetComponent<RectTransform>().sizeDelta = buttonSize;
+        }
     }
 }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -13,12 +13,14 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
     public class BattleUiEditingComponent: MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
     {
         [SerializeField] private Button _scaleHandleButton;
-        [SerializeField] private Button _flipButton;
+        [SerializeField] private Button _flipHorizontallyButton;
+        [SerializeField] private Button _flipVerticallyButton;
         [SerializeField] private Button _changeOrientationButton;
 
         public void SetInfo(BattleUiMovableElement movableElement, Transform uiElementHolder)
         {
-            _flipButton.gameObject.SetActive(false);
+            _flipHorizontallyButton.gameObject.SetActive(false);
+            _flipVerticallyButton.gameObject.SetActive(false);
             _changeOrientationButton.gameObject.SetActive(false);
 
             _movableElement = movableElement;
@@ -32,7 +34,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         public void SetInfo(BattleUiMultiOrientationElement multiOrientationElement, Transform uiElementHolder)
         {
-            _flipButton.gameObject.SetActive(true);
+            _flipHorizontallyButton.gameObject.SetActive(true);
+            _flipVerticallyButton.gameObject.SetActive(true);
             _changeOrientationButton.gameObject.SetActive(true);
 
             _multiOrientationElement = multiOrientationElement;
@@ -40,10 +43,12 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _uiElementHolder = uiElementHolder.GetComponent<RectTransform>();
 
             SetControlButtonSize(_scaleHandleButton, 0.05f);
-            SetControlButtonSize(_flipButton, 0.1f);
+            SetControlButtonSize(_flipHorizontallyButton, 0.1f);
+            SetControlButtonSize(_flipVerticallyButton, 0.1f);
             SetControlButtonSize(_changeOrientationButton, 0.1f);
 
-            _flipButton.onClick.AddListener(FlipOrientation);
+            _flipHorizontallyButton.onClick.AddListener(FlipHorizontally);
+            _flipVerticallyButton.onClick.AddListener(FlipVertically);
             _changeOrientationButton.onClick.AddListener(ChangeOrientation);
 
             _data = multiOrientationElement.GetData();
@@ -53,7 +58,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         {
             Button selectedButton = eventData.selectedObject.GetComponent<Button>();
 
-            if (selectedButton == _flipButton || selectedButton == _changeOrientationButton)
+            if (selectedButton == _flipHorizontallyButton || selectedButton == _flipVerticallyButton || selectedButton == _changeOrientationButton)
             {
                 _currentAction = ActionType.None;
             }
@@ -110,7 +115,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private void OnDestroy()
         {
-            _flipButton.onClick.RemoveAllListeners();
+            _flipHorizontallyButton.onClick.RemoveAllListeners();
+            _flipVerticallyButton.onClick.RemoveAllListeners();
             _changeOrientationButton.onClick.RemoveAllListeners();
         }
 
@@ -182,29 +188,23 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             button.GetComponent<RectTransform>().sizeDelta = buttonSize;
         }
 
-        private void FlipOrientation()
+        private void FlipHorizontally()
         {
-            switch (_multiOrientationElement.Orientation)
-            {
-                case OrientationType.Horizontal:
-                    _data.Orientation = OrientationType.HorizontalFlipped;
-                    break;
-                case OrientationType.HorizontalFlipped:
-                    _data.Orientation = OrientationType.Horizontal;
-                    break;
-                case OrientationType.Vertical:
-                    _data.Orientation = OrientationType.VerticalFlipped;
-                    break;
-                case OrientationType.VerticalFlipped:
-                    _data.Orientation = OrientationType.Vertical;
-                    break;
-            }
+            _data.IsFlippedHorizontally = !_data.IsFlippedHorizontally;
+            _multiOrientationElement.SetData(_data);
+        }
+
+        private void FlipVertically()
+        {
+            _data.IsFlippedVertically = !_data.IsFlippedVertically;
             _multiOrientationElement.SetData(_data);
         }
 
         private void ChangeOrientation()
         {
             _data.Orientation = _multiOrientationElement.IsHorizontal ? OrientationType.Vertical : OrientationType.Horizontal;
+            _data.IsFlippedHorizontally = false; // Resetting flip statuses for new orientation
+            _data.IsFlippedVertically = false;
 
             // Calculating new aspect ratio size
             Vector2 newSize = new();

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -90,17 +90,21 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     _movableElement.RectTransformComponent.sizeDelta += new Vector2 (sizeIncreaseX, sizeIncreaseY);
 
                     // Preventing out of bounds scaling or being scaled too small
-                    float maxWidth = _uiElementHolder.rect.width / 2;
-                    float maxHeight = _uiElementHolder.rect.height / 2;
-                    float minWidth = _uiElementHolder.rect.width / 10;
-                    float minHeight = _uiElementHolder.rect.height / 10;
+                    if (_multiOrientationElement == null || _multiOrientationElement.IsHorizontal)
+                    {
+                        float clampedWidth = Mathf.Clamp(_movableElement.RectTransformComponent.rect.width, _minWidth, _maxWidth);
+                        float aspectRatio = _multiOrientationElement == null ? _movableElementAspectRatio : _multiOrientationElement.HorizontalAspectRatio;
 
-                    float clampedWidth = Mathf.Clamp(_movableElement.RectTransformComponent.rect.width, minWidth, maxWidth);
-                    //float clampedHeight = Mathf.Clamp(_movableElement.RectTransformComponent.rect.height, minHeight, maxHeight);
+                        _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, clampedWidth);
+                        _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, clampedWidth / aspectRatio);
+                    }
+                    else if (!_multiOrientationElement.IsHorizontal)
+                    {
+                        float clampedHeight = Mathf.Clamp(_movableElement.RectTransformComponent.rect.height, _minHeight, _maxHeight);
 
-                    _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, clampedWidth);
-                    //_movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, clampedHeight);
-
+                        _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, clampedHeight * _multiOrientationElement.VerticalAspectRatio);
+                        _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, clampedHeight);
+                    }
                     break;
             }
         }
@@ -119,12 +123,19 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         }
 
         private RectTransform _uiElementHolder;
+        private float _maxWidth => _uiElementHolder.rect.width / 1.5f;
+        private float _maxHeight => _uiElementHolder.rect.height / 2;
+        private float _minWidth => _uiElementHolder.rect.width / 7.5f;
+        private float _minHeight => _uiElementHolder.rect.height / 10;
+
         private BattleUiMovableElement _movableElement;
         private BattleUiMultiOrientationElement _multiOrientationElement;
         private BattleUiMovableElementData _data;
+
+        private float _movableElementAspectRatio;
+
         private ActionType _currentAction;
         private Vector2 _moveOffset;
-        private float _movableElementAspectRatio;
 
         private void OnDestroy()
         {
@@ -223,12 +234,12 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             Vector2 newSize = new();
             if (_multiOrientationElement.IsHorizontal) // If element is currently horizontal we are trying to change it to be vertical
             {
-                newSize.y = _multiOrientationElement.RectTransformComponent.rect.width;
+                newSize.y = Mathf.Clamp(_multiOrientationElement.RectTransformComponent.rect.width, _minHeight, _maxHeight);
                 newSize.x = newSize.y * _multiOrientationElement.VerticalAspectRatio;
             }
             else
             {
-                newSize.x = _multiOrientationElement.RectTransformComponent.rect.height;
+                newSize.x = Mathf.Clamp(_multiOrientationElement.RectTransformComponent.rect.height, _minWidth, _maxWidth);
                 newSize.y = newSize.x / _multiOrientationElement.HorizontalAspectRatio;
             }
 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -134,6 +134,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             {
                 case ActionType.Move:
                     Vector2 newPos = Vector2.zero;
+
                     if (_isGridToggled) // Snapping to grid while moving
                     {
                         newPos.x = Mathf.Round(eventData.position.x / BattleUiEditor.GridCellWidth) * BattleUiEditor.GridCellWidth;
@@ -150,13 +151,14 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
                     _movableElement.transform.position = newPos;
                     break;
+
                 case ActionType.Scale:
                     // Scaling while keeping aspect ratio
                     float sizeIncreaseX = (eventData.position.x - eventData.pressPosition.x) * 2;
                     float sizeIncreaseY = sizeIncreaseX / (_movableElement.RectTransformComponent.rect.width / _movableElement.RectTransformComponent.rect.height);
                     _movableElement.RectTransformComponent.sizeDelta = new Vector2(sizeIncreaseX, sizeIncreaseY);
 
-                    // Preventing out of bounds scaling or being scaled too small
+                    // Preventing being scaled too small or too big
                     if (_multiOrientationElement == null || _multiOrientationElement.IsHorizontal)
                     {
                         float clampedWidth = Mathf.Clamp(_movableElement.RectTransformComponent.rect.width, _minWidth, _maxWidth);
@@ -178,6 +180,15 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
                         _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, clampedHeight * _multiOrientationElement.VerticalAspectRatio);
                         _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, clampedHeight);
+                    }
+
+                    // Preventing Ui element from going out of editor bounds while scaling
+                    float clampedPosX = Mathf.Clamp(_movableElement.RectTransformComponent.position.x, _minPosX, _maxPosX);
+                    float clampedPosY = Mathf.Clamp(_movableElement.RectTransformComponent.position.y, _minPosY, _maxPosY);
+
+                    if (clampedPosX != _movableElement.RectTransformComponent.position.x || clampedPosY != _movableElement.RectTransformComponent.position.y)
+                    {
+                        _movableElement.RectTransformComponent.position = new Vector2(clampedPosX, clampedPosY);
                     }
                     break;
             }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -114,7 +114,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _changeOrientationButton.onClick.RemoveAllListeners();
         }
 
-        private void CalculateAndSetAnchors()
+        private void CalculateAndSetAnchors(Vector2? newSize = null)
         {
             // Saving values used in calculations to easier to read variables
             float holderWidth = _uiElementHolder.rect.width;
@@ -122,9 +122,9 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             float xPos = _movableElement.RectTransformComponent.localPosition.x;
             float yPos = _movableElement.RectTransformComponent.localPosition.y;
-
-            float ownWidth = _movableElement.RectTransformComponent.rect.width;
-            float ownHeight = _movableElement.RectTransformComponent.rect.height;
+            
+            float ownWidth = newSize == null ? _movableElement.RectTransformComponent.rect.width : newSize.Value.x;
+            float ownHeight = newSize == null ? _movableElement.RectTransformComponent.rect.height : newSize.Value.y;
 
             // Calculating anchors
             float anchorXMin = (xPos - ownWidth / 2.0f) / holderWidth + 0.5f;
@@ -205,7 +205,21 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private void ChangeOrientation()
         {
             _data.Orientation = _multiOrientationElement.IsHorizontal ? OrientationType.Vertical : OrientationType.Horizontal;
-            _multiOrientationElement.SetData(_data);
+
+            // Calculating new aspect ratio size
+            Vector2 newSize = new();
+            if (_multiOrientationElement.IsHorizontal) // If element is currently horizontal we are trying to change it to be vertical
+            {
+                newSize.y = _multiOrientationElement.RectTransformComponent.rect.width;
+                newSize.x = newSize.y * _multiOrientationElement.VerticalAspectRatio;
+            }
+            else
+            {
+                newSize.x = _multiOrientationElement.RectTransformComponent.rect.height;
+                newSize.y = newSize.x / _multiOrientationElement.HorizontalAspectRatio;
+            }
+
+            CalculateAndSetAnchors(newSize);
         }
     }
 }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -58,6 +58,11 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             else _data = _multiOrientationElement.GetData();
         }
 
+        public void ToggleGrid(bool toggle)
+        {
+            _isGridToggled = toggle;
+        }
+
         public void OnPointerDown(PointerEventData eventData)
         {
             _isPointerDown = true;
@@ -101,7 +106,18 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             switch (_currentAction)
             {
                 case ActionType.Move:
-                    _movableElement.transform.position = eventData.position;
+                    if (_isGridToggled)
+                    {
+                        Vector2 newPos = Vector2.zero;
+                        newPos.x = Mathf.Round(eventData.position.x / BattleUiEditor.GridCellWidth) * BattleUiEditor.GridCellWidth;
+                        newPos.y = Mathf.Round(eventData.position.y / BattleUiEditor.GridCellHeight) * BattleUiEditor.GridCellHeight;
+
+                        _movableElement.transform.position = newPos;
+                    }
+                    else
+                    {
+                        _movableElement.transform.position = eventData.position;
+                    }
                     break;
                 case ActionType.Scale:
                     // Scaling while keeping aspect ratio
@@ -163,6 +179,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private float _movableElementAspectRatio;
 
         private bool _isPointerDown = false;
+        private bool _isGridToggled = false;
         private Coroutine _dragTimerHolder = null;
         private ActionType _currentAction;
 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -251,18 +251,21 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private void FlipHorizontally()
         {
+            _data = _multiOrientationElement.GetData();
             _data.IsFlippedHorizontally = !_data.IsFlippedHorizontally;
             _multiOrientationElement.SetData(_data);
         }
 
         private void FlipVertically()
         {
+            _data = _multiOrientationElement.GetData();
             _data.IsFlippedVertically = !_data.IsFlippedVertically;
             _multiOrientationElement.SetData(_data);
         }
 
         private void ChangeOrientation()
         {
+            _data = _multiOrientationElement.GetData();
             _data.Orientation = _multiOrientationElement.IsHorizontal ? OrientationType.Vertical : OrientationType.Horizontal;
             _data.IsFlippedHorizontally = false; // Resetting flip statuses for new orientation
             _data.IsFlippedVertically = false;

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -84,8 +84,16 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             {
                 StopCoroutine(_dragTimerHolder);
                 _dragTimerHolder = null;
-                _dragDelayDisplay.SetActive(false);
-                ShowControls(!_scaleHandleButton.gameObject.activeSelf);
+
+                if (_dragDelayDisplay.activeSelf)
+                {
+                    ShowControls(false);
+                    _dragDelayDisplay.SetActive(false);
+                }
+                else
+                {
+                    ShowControls(!_scaleHandleButton.gameObject.activeSelf);
+                }
             }
         }
 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -19,6 +19,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         [SerializeField] private Button _flipHorizontallyButton;
         [SerializeField] private Button _flipVerticallyButton;
         [SerializeField] private Button _changeOrientationButton;
+        [SerializeField] private GameObject _dragDelayDisplay;
+        [SerializeField] private Image _dragDelayFill;
 
         public void SetInfo(BattleUiMovableElement movableElement, Transform uiElementHolder)
         {
@@ -68,7 +70,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             {
                 StopCoroutine(_dragTimerHolder);
                 _dragTimerHolder = null;
-                if (_multiOrientationElement != null) ShowControls(!_scaleHandleButton.gameObject.activeSelf);
+                _dragDelayDisplay.SetActive(false);
+                ShowControls(!_scaleHandleButton.gameObject.activeSelf);
             }
         }
 
@@ -171,7 +174,18 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private IEnumerator StartDragTimer(Action callback)
         {
-            yield return new WaitForSeconds(0.5f);
+            _dragDelayFill.fillAmount = 0;
+            _dragDelayDisplay.SetActive(true);
+
+            float timePassed = 0f;
+            while (timePassed < 0.5f)
+            {
+                _dragDelayFill.fillAmount = timePassed * 2;
+                yield return null;
+                timePassed += Time.deltaTime;
+            }
+
+            _dragDelayDisplay.SetActive(false);
             callback();
         }
 
@@ -272,6 +286,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private void ShowControls(bool show)
         {
             _scaleHandleButton.gameObject.SetActive(show);
+
+            if (_multiOrientationElement == null) show = false;
             _flipHorizontallyButton.gameObject.SetActive(show);
             _flipVerticallyButton.gameObject.SetActive(show);
             _changeOrientationButton.gameObject.SetActive(show);

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -29,8 +29,9 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             SetControlButtonSize(_scaleHandleButton, 0.05f);
 
-            _data = movableElement.GetData();
             _movableElementAspectRatio = movableElement.RectTransformComponent.rect.width / movableElement.RectTransformComponent.rect.height;
+
+            UpdateData();
         }
 
         public void SetInfo(BattleUiMultiOrientationElement multiOrientationElement, Transform uiElementHolder)
@@ -48,7 +49,13 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _flipVerticallyButton.onClick.AddListener(FlipVertically);
             _changeOrientationButton.onClick.AddListener(ChangeOrientation);
 
-            _data = multiOrientationElement.GetData();
+            UpdateData();
+        }
+
+        public void UpdateData()
+        {
+            if (_multiOrientationElement == null) _data = _movableElement.GetData();
+            else _data = _multiOrientationElement.GetData();
         }
 
         public void OnPointerDown(PointerEventData eventData)
@@ -251,21 +258,18 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private void FlipHorizontally()
         {
-            _data = _multiOrientationElement.GetData();
             _data.IsFlippedHorizontally = !_data.IsFlippedHorizontally;
             _multiOrientationElement.SetData(_data);
         }
 
         private void FlipVertically()
         {
-            _data = _multiOrientationElement.GetData();
             _data.IsFlippedVertically = !_data.IsFlippedVertically;
             _multiOrientationElement.SetData(_data);
         }
 
         private void ChangeOrientation()
         {
-            _data = _multiOrientationElement.GetData();
             _data.Orientation = _multiOrientationElement.IsHorizontal ? OrientationType.Vertical : OrientationType.Horizontal;
             _data.IsFlippedHorizontally = false; // Resetting flip statuses for new orientation
             _data.IsFlippedVertically = false;

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -88,6 +88,19 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     float sizeIncreaseX = eventData.delta.x * 2;
                     float sizeIncreaseY = sizeIncreaseX / (_movableElement.RectTransformComponent.rect.width / _movableElement.RectTransformComponent.rect.height);
                     _movableElement.RectTransformComponent.sizeDelta += new Vector2 (sizeIncreaseX, sizeIncreaseY);
+
+                    // Preventing out of bounds scaling or being scaled too small
+                    float maxWidth = _uiElementHolder.rect.width / 2;
+                    float maxHeight = _uiElementHolder.rect.height / 2;
+                    float minWidth = _uiElementHolder.rect.width / 10;
+                    float minHeight = _uiElementHolder.rect.height / 10;
+
+                    float clampedWidth = Mathf.Clamp(_movableElement.RectTransformComponent.rect.width, minWidth, maxWidth);
+                    //float clampedHeight = Mathf.Clamp(_movableElement.RectTransformComponent.rect.height, minHeight, maxHeight);
+
+                    _movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, clampedWidth);
+                    //_movableElement.RectTransformComponent.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, clampedHeight);
+
                     break;
             }
         }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -201,8 +201,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         }
 
         private RectTransform _uiElementHolder;
-        private float _maxWidth => BattleUiEditor.GridCellWidth * 14;
-        private float _maxHeight => BattleUiEditor.GridCellHeight * 20;
+        private float _maxWidth => BattleUiEditor.GridCellWidth * 10;
+        private float _maxHeight => BattleUiEditor.GridCellHeight * 16;
         private float _minWidth => BattleUiEditor.GridCellWidth * 2;
         private float _minHeight => BattleUiEditor.GridCellHeight * 4;
 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -1,0 +1,82 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+
+using Altzone.Scripts.BattleUiShared;
+
+namespace MenuUi.Scripts.Settings.BattleUiEditor
+{
+    /// <summary>
+    /// Handles the functionality for BattleUiEditingComponent prefab.
+    /// </summary>
+    public class BattleUiEditingComponent: MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+    {
+        [SerializeField] private Button _scaleHandleButton;
+        [SerializeField] private Button _flipButton;
+        [SerializeField] private Button _changeOrientationButton;
+
+        public void SetInfo(BattleUiMovableElement movableElement)
+        {
+            _flipButton.gameObject.SetActive(false);
+            _changeOrientationButton.gameObject.SetActive(false);
+
+            _movableElement = movableElement;
+        }
+
+        public void SetInfo(BattleUiMultiOrientationElement multiOrientationElement)
+        {
+            _flipButton.gameObject.SetActive(true);
+            _changeOrientationButton.gameObject.SetActive(true);
+
+            _multiOrientationElement = multiOrientationElement;
+            _movableElement = multiOrientationElement;
+        }
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            Button selectedButton = eventData.selectedObject.GetComponent<Button>();
+
+            if (selectedButton == _flipButton || selectedButton == _changeOrientationButton)
+            {
+                _currentAction = ActionType.None;
+            }
+            else if (selectedButton == _scaleHandleButton)
+            {
+                _currentAction = ActionType.Scale;
+            }
+            else
+            {
+                _currentAction = ActionType.Move;
+            }
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            switch (_currentAction)
+            {
+                case ActionType.Move:
+                    _movableElement.transform.position = eventData.position;
+                    break;
+                case ActionType.Scale:
+                    //eventData.delta
+                    break;
+            }
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+
+        }
+
+        enum ActionType
+        {
+            None,
+            Move,
+            Scale
+        }
+
+        private BattleUiMovableElement _movableElement;
+        private BattleUiMultiOrientationElement _multiOrientationElement;
+        private ActionType _currentAction;
+    }
+}

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs
@@ -165,8 +165,17 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     break;
 
                 case ActionType.Scale:
-                    // Scaling while keeping aspect ratio
-                    float sizeIncreaseX = (eventData.position.x - eventData.pressPosition.x) * 2;
+                    // Scaling while keeping aspect ratio, we have to invert scaling for the left side scale handles
+                    float sizeIncreaseX;
+                    if (_currentScaleHandleIdx == (int)CornerType.TopLeft || _currentScaleHandleIdx == (int)CornerType.BottomLeft)
+                    {
+                        sizeIncreaseX = -((eventData.position.x - eventData.pressPosition.x) * 2);
+                    }
+                    else
+                    {
+                        sizeIncreaseX = (eventData.position.x - eventData.pressPosition.x) * 2;
+                    }
+                         
                     float sizeIncreaseY = sizeIncreaseX / (_movableElement.RectTransformComponent.rect.width / _movableElement.RectTransformComponent.rect.height);
                     _movableElement.RectTransformComponent.sizeDelta = new Vector2(sizeIncreaseX, sizeIncreaseY);
 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs.meta
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditingComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23ff2b9bc1743cc439a2417e481ae6a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -84,11 +84,11 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             // Setting info to the editing component
             if (movableElement != null && multiOrientationElement == null)
             {
-                editingComponent.SetInfo(movableElement);
+                editingComponent.SetInfo(movableElement, _uiElementsHolder);
             }
             else if (multiOrientationElement != null)
             {
-                editingComponent.SetInfo(multiOrientationElement);
+                editingComponent.SetInfo(multiOrientationElement, _uiElementsHolder);
             }
             else
             {

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -314,8 +314,9 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             bool isFlippedHorizontally = false;
             bool isFlippedVertically = false;
 
-            // Rect variable so that we can do aspect ratio calculations later
-            Rect uiElementRect = new();
+            // Rect variable so that we can do aspect ratio calculations
+            Rect uiElementRect;
+            float aspectRatio = 0f;
 
             // Setting hardcoded default anchors (maybe there's a better way for this?)
             switch (uiElementType)
@@ -330,6 +331,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     anchorMax.y = 0.55f;
 
                     uiElementRect = _instantiatedTimer.GetComponent<RectTransform>().rect;
+                    aspectRatio = uiElementRect.width / uiElementRect.height;
                     break;
 
                 case BattleUiElementType.Diamonds:
@@ -340,8 +342,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
                     anchorMin.y = 0.025f;
                     anchorMax.y = 0.075f;
-
                     uiElementRect = _instantiatedDiamonds.GetComponent<RectTransform>().rect;
+                    aspectRatio = uiElementRect.width / uiElementRect.height;
                     break;
 
                 case BattleUiElementType.GiveUpButton:
@@ -354,6 +356,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     anchorMax.y = 0.075f;
 
                     uiElementRect = _instantiatedGiveUpButton.GetComponent<RectTransform>().rect;
+                    aspectRatio = uiElementRect.width / uiElementRect.height;
                     break;
 
                 case BattleUiElementType.PlayerInfo:
@@ -367,7 +370,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
                     orientation = OrientationType.Horizontal;
 
-                    uiElementRect = _instantiatedPlayerInfo.GetComponent<RectTransform>().rect;
+                    aspectRatio = GetMultiOrientationElement(BattleUiElementType.PlayerInfo).HorizontalAspectRatio;
                     break;
 
                 case BattleUiElementType.TeammateInfo:
@@ -381,13 +384,11 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
                     orientation = OrientationType.Horizontal;
 
-                    uiElementRect = _instantiatedTeammateInfo.GetComponent<RectTransform>().rect;
+                    aspectRatio = GetMultiOrientationElement(BattleUiElementType.TeammateInfo).HorizontalAspectRatio;
                     break;
             }
 
             // Fitting height to aspect ratio
-            float aspectRatio = uiElementRect.width / uiElementRect.height;
-
             float uiElementWidth = Screen.width * (anchorMax.x - anchorMin.x);
             float uiElementHeight = uiElementWidth / aspectRatio;
 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -4,6 +4,7 @@ using UnityEngine.UI;
 using TMPro;
 
 using Altzone.Scripts.BattleUiShared;
+using OrientationType = Altzone.Scripts.BattleUiShared.BattleUiMultiOrientationElement.OrientationType;
 
 namespace MenuUi.Scripts.Settings.BattleUiEditor
 {
@@ -30,17 +31,25 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         {
             gameObject.SetActive(true);
 
-            _instantiatedTimer = InstantiateBattleUiElement(_timer);
-            _instantiatedDiamonds = InstantiateBattleUiElement(_diamonds);
-            _instantiatedGiveUpButton = InstantiateBattleUiElement(_giveUpButton);
+            // Instantiating ui element prefabs
+            _instantiatedTimer = InstantiateBattleUiElement(UiElementType.Timer);
+            SetDefaultData(UiElementType.Timer);
 
-            _instantiatedPlayerInfo = InstantiateBattleUiElement(_playerInfo);
+            _instantiatedDiamonds = InstantiateBattleUiElement(UiElementType.Diamonds);
+            SetDefaultData(UiElementType.Diamonds);
+
+            _instantiatedGiveUpButton = InstantiateBattleUiElement(UiElementType.GiveUpButton);
+            SetDefaultData(UiElementType.GiveUpButton);
+
+            _instantiatedPlayerInfo = InstantiateBattleUiElement(UiElementType.PlayerInfo);
             TextMeshProUGUI playerName = _instantiatedPlayerInfo.GetComponentInChildren<TextMeshProUGUI>();
             if (playerName != null) playerName.text = "Minä";
+            SetDefaultData(UiElementType.PlayerInfo);
 
-            _instantiatedTeammateInfo = InstantiateBattleUiElement(_playerInfo);
+            _instantiatedTeammateInfo = InstantiateBattleUiElement(UiElementType.TeammateInfo);
             TextMeshProUGUI teammateName = _instantiatedTeammateInfo.GetComponentInChildren<TextMeshProUGUI>();
             if (teammateName != null) teammateName.text = "Tiimikaveri";
+            SetDefaultData(UiElementType.TeammateInfo);
         }
 
         /// <summary>
@@ -49,6 +58,15 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         public void CloseEditor()
         {
             gameObject.SetActive(false);
+        }
+
+        enum UiElementType
+        {
+            Timer,
+            PlayerInfo,
+            TeammateInfo,
+            Diamonds,
+            GiveUpButton,
         }
 
         private GameObject _instantiatedTimer;
@@ -72,8 +90,27 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _closeButton.onClick.RemoveAllListeners();
         }
 
-        private GameObject InstantiateBattleUiElement(GameObject uiElementPrefab)
+        private GameObject InstantiateBattleUiElement(UiElementType uiElementType)
         {
+            GameObject uiElementPrefab = null;
+
+            switch (uiElementType)
+            {
+                case UiElementType.Timer:
+                    uiElementPrefab = _timer;
+                    break;
+                case UiElementType.GiveUpButton:
+                    uiElementPrefab = _giveUpButton;
+                    break;
+                case UiElementType.Diamonds:
+                    uiElementPrefab = _diamonds;
+                    break;
+                case UiElementType.PlayerInfo:
+                case UiElementType.TeammateInfo:
+                    uiElementPrefab = _playerInfo;
+                    break;
+            }
+
             if (uiElementPrefab == null) return null;
             if (_editingComponent == null) return null;
 
@@ -104,6 +141,137 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             }
 
             return uiElementGameObject;
+        }
+
+        private BattleUiMovableElementData GetDefaultData(UiElementType uiElementType)
+        {
+            // Initializing variables for creating data object
+            Vector2 anchorMin = Vector2.zero;
+            Vector2 anchorMax = Vector2.zero;
+
+            OrientationType orientation = OrientationType.None;
+
+            bool isFlippedHorizontally = false;
+            bool isFlippedVertically = false;
+
+            // Rect variable so that we can do aspect ratio calculations later
+            Rect uiElementRect = new();
+
+            // Setting hardcoded default anchors (maybe there's a better way for this?)
+            switch (uiElementType)
+            {
+                case UiElementType.Timer:
+                    if (_instantiatedTimer == null) return null;
+
+                    anchorMin.x = 0.4f;
+                    anchorMax.x = 0.6f;
+
+                    anchorMin.y = 0.45f;
+                    anchorMax.y = 0.55f;
+
+                    uiElementRect = _instantiatedTimer.GetComponent<RectTransform>().rect;
+                    break;
+
+                case UiElementType.Diamonds:
+                    if (_instantiatedDiamonds == null) return null;
+
+                    anchorMin.x = 0.75f;
+                    anchorMax.x = 0.95f;
+
+                    anchorMin.y = 0.01f;
+                    anchorMax.y = 0.08f;
+
+                    uiElementRect = _instantiatedDiamonds.GetComponent<RectTransform>().rect;
+                    break;
+
+                case UiElementType.GiveUpButton:
+                    if (_instantiatedGiveUpButton == null) return null;
+
+                    anchorMin.x = 0.05f;
+                    anchorMax.x = 0.3f;
+
+                    anchorMin.y = 0.01f;
+                    anchorMax.y = 0.08f;
+
+                    uiElementRect = _instantiatedGiveUpButton.GetComponent<RectTransform>().rect;
+                    break;
+
+                case UiElementType.PlayerInfo:
+                    if (_instantiatedPlayerInfo == null) return null;
+
+                    anchorMin.x = 0.05f;
+                    anchorMax.x = 0.375f;
+
+                    anchorMin.y = 0.45f;
+                    anchorMax.y = 0.55f;
+
+                    orientation = OrientationType.Horizontal;
+
+                    uiElementRect = _instantiatedPlayerInfo.GetComponent<RectTransform>().rect;
+                    break;
+
+                case UiElementType.TeammateInfo:
+                    if (_instantiatedTeammateInfo == null) return null;
+
+                    anchorMin.x = 0.625f;
+                    anchorMax.x = 0.95f;
+
+                    anchorMin.y = 0.45f;
+                    anchorMax.y = 0.55f;
+
+                    orientation = OrientationType.Horizontal;
+
+                    uiElementRect = _instantiatedTeammateInfo.GetComponent<RectTransform>().rect;
+                    break;
+            }
+
+            // Fitting height to aspect ratio
+            float aspectRatio = uiElementRect.width / uiElementRect.height;
+
+            float uiElementWidth = Screen.width * (anchorMax.x - anchorMin.x);
+            float uiElementHeight = uiElementWidth / aspectRatio;
+
+            float yPos = (anchorMax.y + anchorMin.y) / 2 * Screen.height;
+            anchorMin.y = (yPos - uiElementHeight / 2.0f) / Screen.height;
+            anchorMax.y = (yPos + uiElementHeight / 2.0f) / Screen.height;
+
+            return new(anchorMin, anchorMax, orientation, isFlippedHorizontally, isFlippedVertically);
+        }
+
+        private void SetDefaultData(UiElementType uiElementType)
+        {
+            BattleUiMovableElementData data = GetDefaultData(uiElementType);
+            if (data == null) return;
+
+            BattleUiMovableElement movableElement = null;
+            BattleUiMultiOrientationElement multiOrientationElement = null;
+
+            switch (uiElementType)
+            {
+                case UiElementType.Timer:
+                    if (_instantiatedTimer == null) return;
+                    movableElement = _instantiatedTimer.GetComponent<BattleUiMovableElement>();
+                    break;
+                case UiElementType.GiveUpButton:
+                    if (_instantiatedGiveUpButton == null) return;
+                    movableElement = _instantiatedGiveUpButton.GetComponent<BattleUiMovableElement>();
+                    break;
+                case UiElementType.Diamonds:
+                    if (_instantiatedDiamonds == null) return;
+                    movableElement = _instantiatedDiamonds.GetComponent<BattleUiMovableElement>();
+                    break;
+                case UiElementType.PlayerInfo:
+                    if (_instantiatedPlayerInfo == null) return;
+                    multiOrientationElement = _instantiatedPlayerInfo.GetComponent<BattleUiMultiOrientationElement>();
+                    break;
+                case UiElementType.TeammateInfo:
+                    if (_instantiatedTeammateInfo == null) return;
+                    multiOrientationElement = _instantiatedTeammateInfo.GetComponent<BattleUiMultiOrientationElement>();
+                    break;
+            }
+
+            if (movableElement != null) movableElement.SetData(data);
+            else if (multiOrientationElement != null) multiOrientationElement.SetData(data);
         }
     }
 }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -151,7 +151,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _okButton.onClick.RemoveAllListeners();
             _noButton.onClick.RemoveAllListeners();
 
-            foreach (var editingComponent in GetComponentsInChildren<BattleUiEditingComponent>())
+            foreach (var editingComponent in _uiElementsHolder.GetComponentsInChildren<BattleUiEditingComponent>())
             {
                 editingComponent.OnUiElementEdited -= OnUiElementEdited;
                 editingComponent.OnUiElementSelected -= OnUiElementSelected;

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -26,6 +26,9 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         [SerializeField] private GameObject _diamonds;
         [SerializeField] private GameObject _giveUpButton;
 
+        public static float GridCellWidth => Screen.width / 20;
+        public static float GridCellHeight => Screen.height / 40;
+
         /// <summary>
         /// Open and initialize BattleUiEditor
         /// </summary>
@@ -99,6 +102,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         {
             _closeButton.onClick.RemoveAllListeners();
             _resetButton.onClick.RemoveAllListeners();
+            _gridToggle.onValueChanged.RemoveAllListeners();
         }
 
         private GameObject InstantiateBattleUiElement(UiElementType uiElementType)
@@ -150,6 +154,10 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             {
                 return null;
             }
+
+            // Setting listener for grid toggle
+            _gridToggle.onValueChanged.AddListener(editingComponent.ToggleGrid);
+            editingComponent.ToggleGrid(_gridToggle.isOn);
 
             return uiElementGameObject;
         }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -62,16 +62,27 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             if (_instantiatedPlayerInfo == null)
             {
                 _instantiatedPlayerInfo = InstantiateBattleUiElement(BattleUiElementType.PlayerInfo);
-                TextMeshProUGUI playerName = _instantiatedPlayerInfo.GetComponentInChildren<TextMeshProUGUI>();
-                if (playerName != null) playerName.text = "Minä";
+
+                BattleUiMultiOrientationElement playerInfo = GetMultiOrientationElement(BattleUiElementType.PlayerInfo);
+
+                TextMeshProUGUI playerNameHorizontal = playerInfo.HorizontalConfiguration.GetComponentInChildren<TextMeshProUGUI>();
+                TextMeshProUGUI playerNameVertical = playerInfo.VerticalConfiguration.GetComponentInChildren<TextMeshProUGUI>();
+                
+                if (playerNameHorizontal != null) playerNameHorizontal.text = PlayerText;
+                if (playerNameVertical != null) playerNameVertical.text = PlayerText;
             }
             SetData(BattleUiElementType.PlayerInfo);
 
             if (_instantiatedTeammateInfo == null)
             {
                 _instantiatedTeammateInfo = InstantiateBattleUiElement(BattleUiElementType.TeammateInfo);
-                TextMeshProUGUI teammateName = _instantiatedTeammateInfo.GetComponentInChildren<TextMeshProUGUI>();
-                if (teammateName != null) teammateName.text = "Tiimikaveri";
+
+                BattleUiMultiOrientationElement teammateInfo = GetMultiOrientationElement(BattleUiElementType.TeammateInfo);
+
+                TextMeshProUGUI teammateNameHorizontal = teammateInfo.HorizontalConfiguration.GetComponentInChildren<TextMeshProUGUI>();
+                TextMeshProUGUI teammateNameVertical = teammateInfo.VerticalConfiguration.GetComponentInChildren<TextMeshProUGUI>();
+                if (teammateNameHorizontal != null) teammateNameHorizontal.text = TeammateText;
+                if (teammateNameVertical != null) teammateNameVertical.text = TeammateText;
             }
             SetData(BattleUiElementType.TeammateInfo);
         }
@@ -103,6 +114,9 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         {
             _saveChangesPopup.SetActive(false);
         }
+
+        private const string PlayerText = "Minä";
+        private const string TeammateText = "Tiimikaveri";
 
         private GameObject _instantiatedTimer;
         private GameObject _instantiatedPlayerInfo;

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -5,6 +5,7 @@ using TMPro;
 
 using Altzone.Scripts.BattleUiShared;
 using OrientationType = Altzone.Scripts.BattleUiShared.BattleUiMultiOrientationElement.OrientationType;
+using BattleUiElementType = SettingsCarrier.BattleUiElementType;
 
 namespace MenuUi.Scripts.Settings.BattleUiEditor
 {
@@ -40,36 +41,37 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             if (_instantiatedTimer == null)
             {
-                _instantiatedTimer = InstantiateBattleUiElement(UiElementType.Timer);
-                SetDefaultData(UiElementType.Timer);
+                _instantiatedTimer = InstantiateBattleUiElement(BattleUiElementType.Timer);
+                BattleUiMovableElementData timerData = SettingsCarrier.Instance.GetBattleUiMovableElementData(BattleUiElementType.Timer);
+                SetData(BattleUiElementType.Timer);
             }
 
             if (_instantiatedDiamonds == null)
             {
-                _instantiatedDiamonds = InstantiateBattleUiElement(UiElementType.Diamonds);
-                SetDefaultData(UiElementType.Diamonds);
+                _instantiatedDiamonds = InstantiateBattleUiElement(BattleUiElementType.Diamonds);
+                SetData(BattleUiElementType.Diamonds);
             }
 
             if (_instantiatedGiveUpButton == null)
             {
-                _instantiatedGiveUpButton = InstantiateBattleUiElement(UiElementType.GiveUpButton);
-                SetDefaultData(UiElementType.GiveUpButton);
+                _instantiatedGiveUpButton = InstantiateBattleUiElement(BattleUiElementType.GiveUpButton);
+                SetData(BattleUiElementType.GiveUpButton);
             }
 
             if (_instantiatedPlayerInfo == null)
             {
-                _instantiatedPlayerInfo = InstantiateBattleUiElement(UiElementType.PlayerInfo);
+                _instantiatedPlayerInfo = InstantiateBattleUiElement(BattleUiElementType.PlayerInfo);
                 TextMeshProUGUI playerName = _instantiatedPlayerInfo.GetComponentInChildren<TextMeshProUGUI>();
                 if (playerName != null) playerName.text = "Minä";
-                SetDefaultData(UiElementType.PlayerInfo);
+                SetData(BattleUiElementType.PlayerInfo);
             }
 
             if (_instantiatedTeammateInfo == null)
             {
-                _instantiatedTeammateInfo = InstantiateBattleUiElement(UiElementType.TeammateInfo);
+                _instantiatedTeammateInfo = InstantiateBattleUiElement(BattleUiElementType.TeammateInfo);
                 TextMeshProUGUI teammateName = _instantiatedTeammateInfo.GetComponentInChildren<TextMeshProUGUI>();
                 if (teammateName != null) teammateName.text = "Tiimikaveri";
-                SetDefaultData(UiElementType.TeammateInfo);
+                SetData(BattleUiElementType.TeammateInfo);
             }
         }
 
@@ -81,15 +83,6 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             gameObject.SetActive(false);
         }
 
-        enum UiElementType
-        {
-            Timer,
-            PlayerInfo,
-            TeammateInfo,
-            Diamonds,
-            GiveUpButton,
-        }
-
         private GameObject _instantiatedTimer;
         private GameObject _instantiatedPlayerInfo;
         private GameObject _instantiatedTeammateInfo;
@@ -99,13 +92,13 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private void Awake()
         {
             _closeButton.onClick.AddListener(CloseEditor);
-            _resetButton.onClick.AddListener(()=>
+            _resetButton.onClick.AddListener(() =>
             {
-                SetDefaultData(UiElementType.Timer);
-                SetDefaultData(UiElementType.Diamonds);
-                SetDefaultData(UiElementType.GiveUpButton);
-                SetDefaultData(UiElementType.PlayerInfo);
-                SetDefaultData(UiElementType.TeammateInfo);
+                SetDefaultData(BattleUiElementType.Timer);
+                SetDefaultData(BattleUiElementType.Diamonds);
+                SetDefaultData(BattleUiElementType.GiveUpButton);
+                SetDefaultData(BattleUiElementType.PlayerInfo);
+                SetDefaultData(BattleUiElementType.TeammateInfo);
             });
         }
 
@@ -116,23 +109,41 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _gridToggle.onValueChanged.RemoveAllListeners();
         }
 
-        private GameObject InstantiateBattleUiElement(UiElementType uiElementType)
+        private void SaveChanges()
+        {
+            BattleUiMovableElementData timerData = GetMovableElement(BattleUiElementType.Timer).GetData();
+            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Timer, timerData);
+
+            BattleUiMovableElementData diamondsData = GetMovableElement(BattleUiElementType.Diamonds).GetData();
+            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Diamonds, diamondsData);
+
+            BattleUiMovableElementData giveUpButtonData = GetMovableElement(BattleUiElementType.GiveUpButton).GetData();
+            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.GiveUpButton, giveUpButtonData);
+
+            BattleUiMovableElementData playerInfoData = GetMovableElement(BattleUiElementType.PlayerInfo).GetData();
+            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.PlayerInfo, playerInfoData);
+
+            BattleUiMovableElementData teammateInfoData = GetMovableElement(BattleUiElementType.TeammateInfo).GetData();
+            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.TeammateInfo, teammateInfoData);
+        }
+
+        private GameObject InstantiateBattleUiElement(BattleUiElementType uiElementType)
         {
             GameObject uiElementPrefab = null;
 
             switch (uiElementType)
             {
-                case UiElementType.Timer:
+                case BattleUiElementType.Timer:
                     uiElementPrefab = _timer;
                     break;
-                case UiElementType.GiveUpButton:
+                case BattleUiElementType.GiveUpButton:
                     uiElementPrefab = _giveUpButton;
                     break;
-                case UiElementType.Diamonds:
+                case BattleUiElementType.Diamonds:
                     uiElementPrefab = _diamonds;
                     break;
-                case UiElementType.PlayerInfo:
-                case UiElementType.TeammateInfo:
+                case BattleUiElementType.PlayerInfo:
+                case BattleUiElementType.TeammateInfo:
                     uiElementPrefab = _playerInfo;
                     break;
             }
@@ -173,7 +184,51 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             return uiElementGameObject;
         }
 
-        private BattleUiMovableElementData GetDefaultData(UiElementType uiElementType)
+        private void SetData(BattleUiElementType uiElementType)
+        {
+            // Getting the saved data for this ui element type
+            BattleUiMovableElementData data = SettingsCarrier.Instance.GetBattleUiMovableElementData(uiElementType);
+
+            // Setting default data if saved data is null
+            if (data == null)
+            {
+                SetDefaultData(uiElementType);
+                return;
+            }
+
+            // Getting the movable or multi orientation element and editing component
+            BattleUiMovableElement movableElement = GetMovableElement(uiElementType);
+            BattleUiMultiOrientationElement multiOrientationElement = GetMultiOrientationElement(uiElementType);
+            BattleUiEditingComponent editingComponent = GetEditingComponent(uiElementType);
+
+            // Setting data to movable or multi orientation element
+            if (movableElement != null) movableElement.SetData(data);
+            else if (multiOrientationElement != null) multiOrientationElement.SetData(data);
+
+            // Updating editing component data
+            editingComponent.UpdateData();
+        }
+
+        private void SetDefaultData(BattleUiElementType uiElementType)
+        {
+            // Getting the default data for this ui element type
+            BattleUiMovableElementData data = GetDefaultData(uiElementType);
+            if (data == null) return;
+
+            // Getting the movable or multi orientation element and editing component
+            BattleUiMovableElement movableElement = GetMovableElement(uiElementType);
+            BattleUiMultiOrientationElement multiOrientationElement = GetMultiOrientationElement(uiElementType);
+            BattleUiEditingComponent editingComponent = GetEditingComponent(uiElementType);
+
+            // Setting data to movable or multi orientation element
+            if (movableElement != null) movableElement.SetData(data);
+            else if (multiOrientationElement != null) multiOrientationElement.SetData(data);
+
+            // Updating editing component data
+            editingComponent.UpdateData();
+        }
+
+        private BattleUiMovableElementData GetDefaultData(BattleUiElementType uiElementType)
         {
             // Initializing variables for creating data object
             Vector2 anchorMin = Vector2.zero;
@@ -190,7 +245,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             // Setting hardcoded default anchors (maybe there's a better way for this?)
             switch (uiElementType)
             {
-                case UiElementType.Timer:
+                case BattleUiElementType.Timer:
                     if (_instantiatedTimer == null) return null;
 
                     anchorMin.x = 0.4f;
@@ -202,7 +257,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     uiElementRect = _instantiatedTimer.GetComponent<RectTransform>().rect;
                     break;
 
-                case UiElementType.Diamonds:
+                case BattleUiElementType.Diamonds:
                     if (_instantiatedDiamonds == null) return null;
 
                     anchorMin.x = 0.75f;
@@ -214,7 +269,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     uiElementRect = _instantiatedDiamonds.GetComponent<RectTransform>().rect;
                     break;
 
-                case UiElementType.GiveUpButton:
+                case BattleUiElementType.GiveUpButton:
                     if (_instantiatedGiveUpButton == null) return null;
 
                     anchorMin.x = 0.05f;
@@ -226,7 +281,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     uiElementRect = _instantiatedGiveUpButton.GetComponent<RectTransform>().rect;
                     break;
 
-                case UiElementType.PlayerInfo:
+                case BattleUiElementType.PlayerInfo:
                     if (_instantiatedPlayerInfo == null) return null;
 
                     anchorMin.x = 0.05f;
@@ -240,7 +295,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     uiElementRect = _instantiatedPlayerInfo.GetComponent<RectTransform>().rect;
                     break;
 
-                case UiElementType.TeammateInfo:
+                case BattleUiElementType.TeammateInfo:
                     if (_instantiatedTeammateInfo == null) return null;
 
                     anchorMin.x = 0.625f;
@@ -268,52 +323,76 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             return new(anchorMin, anchorMax, orientation, isFlippedHorizontally, isFlippedVertically);
         }
 
-        private void SetDefaultData(UiElementType uiElementType)
+        private BattleUiMovableElement GetMovableElement(BattleUiElementType uiElementType)
         {
-            // Getting the default data for this ui element type
-            BattleUiMovableElementData data = GetDefaultData(uiElementType);
-            if (data == null) return;
-
-            // Getting the correct movable or multi orientation element and editing component
-            BattleUiMovableElement movableElement = null;
-            BattleUiMultiOrientationElement multiOrientationElement = null;
-            BattleUiEditingComponent editingComponent = null;
-
             switch (uiElementType)
             {
-                case UiElementType.Timer:
-                    if (_instantiatedTimer == null) return;
-                    movableElement = _instantiatedTimer.GetComponent<BattleUiMovableElement>();
-                    editingComponent = _instantiatedTimer.GetComponentInChildren<BattleUiEditingComponent>();
-                    break;
-                case UiElementType.GiveUpButton:
-                    if (_instantiatedGiveUpButton == null) return;
-                    movableElement = _instantiatedGiveUpButton.GetComponent<BattleUiMovableElement>();
-                    editingComponent = _instantiatedGiveUpButton.GetComponentInChildren<BattleUiEditingComponent>();
-                    break;
-                case UiElementType.Diamonds:
-                    if (_instantiatedDiamonds == null) return;
-                    movableElement = _instantiatedDiamonds.GetComponent<BattleUiMovableElement>();
-                    editingComponent = _instantiatedDiamonds.GetComponentInChildren<BattleUiEditingComponent>();
-                    break;
-                case UiElementType.PlayerInfo:
-                    if (_instantiatedPlayerInfo == null) return;
-                    multiOrientationElement = _instantiatedPlayerInfo.GetComponent<BattleUiMultiOrientationElement>();
-                    editingComponent = _instantiatedPlayerInfo.GetComponentInChildren<BattleUiEditingComponent>();
-                    break;
-                case UiElementType.TeammateInfo:
-                    if (_instantiatedTeammateInfo == null) return;
-                    multiOrientationElement = _instantiatedTeammateInfo.GetComponent<BattleUiMultiOrientationElement>();
-                    editingComponent = _instantiatedTeammateInfo.GetComponentInChildren<BattleUiEditingComponent>();
-                    break;
+                case BattleUiElementType.Timer:
+                    if (_instantiatedTimer == null) return null;
+                    return _instantiatedTimer.GetComponent<BattleUiMovableElement>();
+
+                case BattleUiElementType.GiveUpButton:
+                    if (_instantiatedGiveUpButton == null) return null;
+                    return _instantiatedGiveUpButton.GetComponent<BattleUiMovableElement>();
+
+                case BattleUiElementType.Diamonds:
+                    if (_instantiatedDiamonds == null) return null;
+                    return _instantiatedDiamonds.GetComponent<BattleUiMovableElement>();
+
+                case BattleUiElementType.PlayerInfo:
+                case BattleUiElementType.TeammateInfo:
+                default:
+                    return null;
             }
+        }
 
-            // Setting data to movable or multi orientation element
-            if (movableElement != null) movableElement.SetData(data);
-            else if (multiOrientationElement != null) multiOrientationElement.SetData(data);
+        private BattleUiMultiOrientationElement GetMultiOrientationElement(BattleUiElementType uiElementType)
+        {
+            switch (uiElementType)
+            {
+                case BattleUiElementType.PlayerInfo:
+                    if (_instantiatedPlayerInfo == null) return null;
+                    return _instantiatedPlayerInfo.GetComponent<BattleUiMultiOrientationElement>();
 
-            // Updating editing component data
-            editingComponent.UpdateData();
+                case BattleUiElementType.TeammateInfo:
+                    if (_instantiatedTeammateInfo == null) return null;
+                    return _instantiatedTeammateInfo.GetComponent<BattleUiMultiOrientationElement>();
+
+                case BattleUiElementType.Timer:
+                case BattleUiElementType.GiveUpButton:
+                case BattleUiElementType.Diamonds:
+                default:
+                    return null;
+            }
+        }
+
+        private BattleUiEditingComponent GetEditingComponent(BattleUiElementType uiElementType)
+        {
+            switch (uiElementType)
+            {
+                case BattleUiElementType.Timer:
+                    if (_instantiatedTimer == null) return null;
+                    return _instantiatedTimer.GetComponentInChildren<BattleUiEditingComponent>();
+
+                case BattleUiElementType.GiveUpButton:
+                    if (_instantiatedGiveUpButton == null) return null;
+                    return _instantiatedGiveUpButton.GetComponentInChildren<BattleUiEditingComponent>();
+
+                case BattleUiElementType.Diamonds:
+                    if (_instantiatedDiamonds == null) return null;
+                    return _instantiatedDiamonds.GetComponentInChildren<BattleUiEditingComponent>();
+
+                case BattleUiElementType.PlayerInfo:
+                    if (_instantiatedPlayerInfo == null) return null;
+                    return _instantiatedPlayerInfo.GetComponentInChildren<BattleUiEditingComponent>();
+
+                case BattleUiElementType.TeammateInfo:
+                    if (_instantiatedTeammateInfo == null) return null;
+                    return _instantiatedTeammateInfo.GetComponentInChildren<BattleUiEditingComponent>();
+
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -85,11 +85,20 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private void Awake()
         {
             _closeButton.onClick.AddListener(CloseEditor);
+            _resetButton.onClick.AddListener(()=>
+            {
+                SetDefaultData(UiElementType.Timer);
+                SetDefaultData(UiElementType.Diamonds);
+                SetDefaultData(UiElementType.GiveUpButton);
+                SetDefaultData(UiElementType.PlayerInfo);
+                SetDefaultData(UiElementType.TeammateInfo);
+            });
         }
 
         private void OnDestroy()
         {
             _closeButton.onClick.RemoveAllListeners();
+            _resetButton.onClick.RemoveAllListeners();
         }
 
         private GameObject InstantiateBattleUiElement(UiElementType uiElementType)
@@ -242,38 +251,50 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private void SetDefaultData(UiElementType uiElementType)
         {
+            // Getting the default data for this ui element type
             BattleUiMovableElementData data = GetDefaultData(uiElementType);
             if (data == null) return;
 
+            // Getting the correct movable or multi orientation element and editing component
             BattleUiMovableElement movableElement = null;
             BattleUiMultiOrientationElement multiOrientationElement = null;
+            BattleUiEditingComponent editingComponent = null;
 
             switch (uiElementType)
             {
                 case UiElementType.Timer:
                     if (_instantiatedTimer == null) return;
                     movableElement = _instantiatedTimer.GetComponent<BattleUiMovableElement>();
+                    editingComponent = _instantiatedTimer.GetComponentInChildren<BattleUiEditingComponent>();
                     break;
                 case UiElementType.GiveUpButton:
                     if (_instantiatedGiveUpButton == null) return;
                     movableElement = _instantiatedGiveUpButton.GetComponent<BattleUiMovableElement>();
+                    editingComponent = _instantiatedGiveUpButton.GetComponentInChildren<BattleUiEditingComponent>();
                     break;
                 case UiElementType.Diamonds:
                     if (_instantiatedDiamonds == null) return;
                     movableElement = _instantiatedDiamonds.GetComponent<BattleUiMovableElement>();
+                    editingComponent = _instantiatedDiamonds.GetComponentInChildren<BattleUiEditingComponent>();
                     break;
                 case UiElementType.PlayerInfo:
                     if (_instantiatedPlayerInfo == null) return;
                     multiOrientationElement = _instantiatedPlayerInfo.GetComponent<BattleUiMultiOrientationElement>();
+                    editingComponent = _instantiatedPlayerInfo.GetComponentInChildren<BattleUiEditingComponent>();
                     break;
                 case UiElementType.TeammateInfo:
                     if (_instantiatedTeammateInfo == null) return;
                     multiOrientationElement = _instantiatedTeammateInfo.GetComponent<BattleUiMultiOrientationElement>();
+                    editingComponent = _instantiatedTeammateInfo.GetComponentInChildren<BattleUiEditingComponent>();
                     break;
             }
 
+            // Setting data to movable or multi orientation element
             if (movableElement != null) movableElement.SetData(data);
             else if (multiOrientationElement != null) multiOrientationElement.SetData(data);
+
+            // Updating editing component data
+            editingComponent.UpdateData();
         }
     }
 }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace MenuUi.Scripts.Settings.BattleUiEditor
+{
+    /// <summary>
+    /// Handles the functionality for BattleUiEditor prefab in Settings.
+    /// </summary>
+    public class BattleUiEditor : MonoBehaviour
+    {
+    }
+}

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -7,6 +7,8 @@ using Altzone.Scripts.BattleUiShared;
 using OrientationType = Altzone.Scripts.BattleUiShared.BattleUiMultiOrientationElement.OrientationType;
 using BattleUiElementType = SettingsCarrier.BattleUiElementType;
 
+using PopupSignalBus = MenuUI.Scripts.SignalBus;
+
 namespace MenuUi.Scripts.Settings.BattleUiEditor
 {
     /// <summary>
@@ -16,6 +18,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
     {
         [Header("GameObject references")]
         [SerializeField] private Button _closeButton;
+        [SerializeField] private Button _saveButton;
         [SerializeField] private Button _resetButton;
         [SerializeField] private Toggle _gridToggle;
         [SerializeField] private Transform _uiElementsHolder;
@@ -100,6 +103,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                 SetDefaultData(BattleUiElementType.PlayerInfo);
                 SetDefaultData(BattleUiElementType.TeammateInfo);
             });
+            _saveButton.onClick.AddListener(SaveChanges);
         }
 
         private void OnDestroy()
@@ -107,6 +111,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _closeButton.onClick.RemoveAllListeners();
             _resetButton.onClick.RemoveAllListeners();
             _gridToggle.onValueChanged.RemoveAllListeners();
+            _saveButton.onClick.RemoveAllListeners();
         }
 
         private void SaveChanges()
@@ -120,11 +125,13 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             BattleUiMovableElementData giveUpButtonData = GetMovableElement(BattleUiElementType.GiveUpButton).GetData();
             SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.GiveUpButton, giveUpButtonData);
 
-            BattleUiMovableElementData playerInfoData = GetMovableElement(BattleUiElementType.PlayerInfo).GetData();
+            BattleUiMovableElementData playerInfoData = GetMultiOrientationElement(BattleUiElementType.PlayerInfo).GetData();
             SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.PlayerInfo, playerInfoData);
 
-            BattleUiMovableElementData teammateInfoData = GetMovableElement(BattleUiElementType.TeammateInfo).GetData();
+            BattleUiMovableElementData teammateInfoData = GetMultiOrientationElement(BattleUiElementType.TeammateInfo).GetData();
             SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.TeammateInfo, teammateInfoData);
+
+            PopupSignalBus.OnChangePopupInfoSignal("Muutokset on tallennettu.");
         }
 
         private GameObject InstantiateBattleUiElement(BattleUiElementType uiElementType)

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -15,6 +15,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
     {
         [Header("GameObject references")]
         [SerializeField] private Button _closeButton;
+        [SerializeField] private Button _resetButton;
+        [SerializeField] private Toggle _gridToggle;
         [SerializeField] private Transform _uiElementsHolder;
 
         [Header("BattleUi prefabs")]

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -1,6 +1,8 @@
 using UnityEngine;
 using UnityEngine.UI;
 
+using TMPro;
+
 using Altzone.Scripts.BattleUiShared;
 
 namespace MenuUi.Scripts.Settings.BattleUiEditor
@@ -29,10 +31,16 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             gameObject.SetActive(true);
 
             _instantiatedTimer = InstantiateBattleUiElement(_timer);
-            _instantiatedPlayerInfo = InstantiateBattleUiElement(_playerInfo);
-            _instantiatedTeammateInfo = InstantiateBattleUiElement(_playerInfo);
             _instantiatedDiamonds = InstantiateBattleUiElement(_diamonds);
             _instantiatedGiveUpButton = InstantiateBattleUiElement(_giveUpButton);
+
+            _instantiatedPlayerInfo = InstantiateBattleUiElement(_playerInfo);
+            TextMeshProUGUI playerName = _instantiatedPlayerInfo.GetComponentInChildren<TextMeshProUGUI>();
+            if (playerName != null) playerName.text = "Minä";
+
+            _instantiatedTeammateInfo = InstantiateBattleUiElement(_playerInfo);
+            TextMeshProUGUI teammateName = _instantiatedTeammateInfo.GetComponentInChildren<TextMeshProUGUI>();
+            if (teammateName != null) teammateName.text = "Tiimikaveri";
         }
 
         /// <summary>

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -37,24 +37,40 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             gameObject.SetActive(true);
 
             // Instantiating ui element prefabs
-            _instantiatedTimer = InstantiateBattleUiElement(UiElementType.Timer);
-            SetDefaultData(UiElementType.Timer);
 
-            _instantiatedDiamonds = InstantiateBattleUiElement(UiElementType.Diamonds);
-            SetDefaultData(UiElementType.Diamonds);
+            if (_instantiatedTimer == null)
+            {
+                _instantiatedTimer = InstantiateBattleUiElement(UiElementType.Timer);
+                SetDefaultData(UiElementType.Timer);
+            }
 
-            _instantiatedGiveUpButton = InstantiateBattleUiElement(UiElementType.GiveUpButton);
-            SetDefaultData(UiElementType.GiveUpButton);
+            if (_instantiatedDiamonds == null)
+            {
+                _instantiatedDiamonds = InstantiateBattleUiElement(UiElementType.Diamonds);
+                SetDefaultData(UiElementType.Diamonds);
+            }
 
-            _instantiatedPlayerInfo = InstantiateBattleUiElement(UiElementType.PlayerInfo);
-            TextMeshProUGUI playerName = _instantiatedPlayerInfo.GetComponentInChildren<TextMeshProUGUI>();
-            if (playerName != null) playerName.text = "Minä";
-            SetDefaultData(UiElementType.PlayerInfo);
+            if (_instantiatedGiveUpButton == null)
+            {
+                _instantiatedGiveUpButton = InstantiateBattleUiElement(UiElementType.GiveUpButton);
+                SetDefaultData(UiElementType.GiveUpButton);
+            }
 
-            _instantiatedTeammateInfo = InstantiateBattleUiElement(UiElementType.TeammateInfo);
-            TextMeshProUGUI teammateName = _instantiatedTeammateInfo.GetComponentInChildren<TextMeshProUGUI>();
-            if (teammateName != null) teammateName.text = "Tiimikaveri";
-            SetDefaultData(UiElementType.TeammateInfo);
+            if (_instantiatedPlayerInfo == null)
+            {
+                _instantiatedPlayerInfo = InstantiateBattleUiElement(UiElementType.PlayerInfo);
+                TextMeshProUGUI playerName = _instantiatedPlayerInfo.GetComponentInChildren<TextMeshProUGUI>();
+                if (playerName != null) playerName.text = "Minä";
+                SetDefaultData(UiElementType.PlayerInfo);
+            }
+
+            if (_instantiatedTeammateInfo == null)
+            {
+                _instantiatedTeammateInfo = InstantiateBattleUiElement(UiElementType.TeammateInfo);
+                TextMeshProUGUI teammateName = _instantiatedTeammateInfo.GetComponentInChildren<TextMeshProUGUI>();
+                if (teammateName != null) teammateName.text = "Tiimikaveri";
+                SetDefaultData(UiElementType.TeammateInfo);
+            }
         }
 
         /// <summary>
@@ -79,11 +95,6 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private GameObject _instantiatedTeammateInfo;
         private GameObject _instantiatedDiamonds;
         private GameObject _instantiatedGiveUpButton;
-
-        private void OnEnable()
-        {
-            OpenEditor(); // for testing only
-        }
 
         private void Awake()
         {

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -112,6 +112,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private bool _unsavedChanges = false;
 
+        private BattleUiEditingComponent _currentlySelectedEditingComponent;
+
         private void Awake()
         {
             _closeButton.onClick.AddListener(CloseEditor);
@@ -137,7 +139,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             foreach (var editingComponent in GetComponentsInChildren<BattleUiEditingComponent>())
             {
-                editingComponent.UiElementEdited -= OnUiElementEdited;
+                editingComponent.OnUiElementEdited -= OnUiElementEdited;
+                editingComponent.OnUiElementSelected -= OnUiElementSelected;
             }
         }
 
@@ -235,8 +238,9 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             _gridToggle.onValueChanged.AddListener(editingComponent.ToggleGrid);
             editingComponent.ToggleGrid(_gridToggle.isOn);
 
-            // Setting listener for editing component event
-            editingComponent.UiElementEdited += OnUiElementEdited;
+            // Setting listener for editing component events
+            editingComponent.OnUiElementEdited += OnUiElementEdited;
+            editingComponent.OnUiElementSelected += OnUiElementSelected;
 
             return uiElementGameObject;
         }
@@ -455,6 +459,16 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private void OnUiElementEdited()
         {
             _unsavedChanges = true;
+        }
+
+        private void OnUiElementSelected(BattleUiEditingComponent newSelectedEditingComponent)
+        {
+            if (_currentlySelectedEditingComponent != null && _currentlySelectedEditingComponent != newSelectedEditingComponent)
+            {
+                _currentlySelectedEditingComponent.ShowControls(false);
+            }
+
+            _currentlySelectedEditingComponent = newSelectedEditingComponent;
         }
     }
 }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -1,6 +1,8 @@
 using UnityEngine;
 using UnityEngine.UI;
 
+using Altzone.Scripts.BattleUiShared;
+
 namespace MenuUi.Scripts.Settings.BattleUiEditor
 {
     /// <summary>
@@ -10,9 +12,10 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
     {
         [Header("GameObject references")]
         [SerializeField] private Button _closeButton;
-        [SerializeField] private GameObject _uiElementsHolder;
+        [SerializeField] private Transform _uiElementsHolder;
 
         [Header("BattleUi prefabs")]
+        [SerializeField] private GameObject _editingComponent;
         [SerializeField] private GameObject _timer;
         [SerializeField] private GameObject _playerInfo;
         [SerializeField] private GameObject _diamonds;
@@ -24,6 +27,12 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         public void OpenEditor()
         {
             gameObject.SetActive(true);
+
+            _instantiatedTimer = InstantiateBattleUiElement(_timer);
+            _instantiatedPlayerInfo = InstantiateBattleUiElement(_playerInfo);
+            _instantiatedTeammateInfo = InstantiateBattleUiElement(_playerInfo);
+            _instantiatedDiamonds = InstantiateBattleUiElement(_diamonds);
+            _instantiatedGiveUpButton = InstantiateBattleUiElement(_giveUpButton);
         }
 
         /// <summary>
@@ -34,6 +43,17 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             gameObject.SetActive(false);
         }
 
+        private GameObject _instantiatedTimer;
+        private GameObject _instantiatedPlayerInfo;
+        private GameObject _instantiatedTeammateInfo;
+        private GameObject _instantiatedDiamonds;
+        private GameObject _instantiatedGiveUpButton;
+
+        private void OnEnable()
+        {
+            OpenEditor(); // for testing only
+        }
+
         private void Awake()
         {
             _closeButton.onClick.AddListener(CloseEditor);
@@ -42,6 +62,40 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private void OnDestroy()
         {
             _closeButton.onClick.RemoveAllListeners();
+        }
+
+        private GameObject InstantiateBattleUiElement(GameObject uiElementPrefab)
+        {
+            if (uiElementPrefab == null) return null;
+            if (_editingComponent == null) return null;
+
+            // Instantiating gameobjects for ui element and editing component
+            GameObject uiElementGameObject = Instantiate(uiElementPrefab, _uiElementsHolder);
+            GameObject editingComponentGameObject = Instantiate(_editingComponent, uiElementGameObject.transform);
+
+            // Getting editing component script from the editing component game object
+            BattleUiEditingComponent editingComponent = editingComponentGameObject.GetComponent<BattleUiEditingComponent>();
+            if (editingComponent == null) return null;
+
+            // Getting movable element and multi orientation script from the ui element game object
+            BattleUiMovableElement movableElement = uiElementGameObject.GetComponent<BattleUiMovableElement>();
+            BattleUiMultiOrientationElement multiOrientationElement = uiElementGameObject.GetComponent<BattleUiMultiOrientationElement>();
+
+            // Setting info to the editing component
+            if (movableElement != null && multiOrientationElement == null)
+            {
+                editingComponent.SetInfo(movableElement);
+            }
+            else if (multiOrientationElement != null)
+            {
+                editingComponent.SetInfo(multiOrientationElement);
+            }
+            else
+            {
+                return null;
+            }
+
+            return uiElementGameObject;
         }
     }
 }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace MenuUi.Scripts.Settings.BattleUiEditor
 {
@@ -7,5 +8,40 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
     /// </summary>
     public class BattleUiEditor : MonoBehaviour
     {
+        [Header("GameObject references")]
+        [SerializeField] private Button _closeButton;
+        [SerializeField] private GameObject _uiElementsHolder;
+
+        [Header("BattleUi prefabs")]
+        [SerializeField] private GameObject _timer;
+        [SerializeField] private GameObject _playerInfo;
+        [SerializeField] private GameObject _diamonds;
+        [SerializeField] private GameObject _giveUpButton;
+
+        /// <summary>
+        /// Open and initialize BattleUiEditor
+        /// </summary>
+        public void OpenEditor()
+        {
+            gameObject.SetActive(true);
+        }
+
+        /// <summary>
+        /// Close BattleUiEditor
+        /// </summary>
+        public void CloseEditor()
+        {
+            gameObject.SetActive(false);
+        }
+
+        private void Awake()
+        {
+            _closeButton.onClick.AddListener(CloseEditor);
+        }
+
+        private void OnDestroy()
+        {
+            _closeButton.onClick.RemoveAllListeners();
+        }
     }
 }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -338,8 +338,8 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     anchorMin.x = 0.75f;
                     anchorMax.x = 0.95f;
 
-                    anchorMin.y = 0.01f;
-                    anchorMax.y = 0.08f;
+                    anchorMin.y = 0.025f;
+                    anchorMax.y = 0.075f;
 
                     uiElementRect = _instantiatedDiamonds.GetComponent<RectTransform>().rect;
                     break;
@@ -348,10 +348,10 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     if (_instantiatedGiveUpButton == null) return null;
 
                     anchorMin.x = 0.05f;
-                    anchorMax.x = 0.3f;
+                    anchorMax.x = 0.25f;
 
-                    anchorMin.y = 0.01f;
-                    anchorMax.y = 0.08f;
+                    anchorMin.y = 0.025f;
+                    anchorMax.y = 0.075f;
 
                     uiElementRect = _instantiatedGiveUpButton.GetComponent<RectTransform>().rect;
                     break;
@@ -360,7 +360,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                     if (_instantiatedPlayerInfo == null) return null;
 
                     anchorMin.x = 0.05f;
-                    anchorMax.x = 0.375f;
+                    anchorMax.x = 0.35f;
 
                     anchorMin.y = 0.45f;
                     anchorMax.y = 0.55f;
@@ -373,7 +373,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                 case BattleUiElementType.TeammateInfo:
                     if (_instantiatedTeammateInfo == null) return null;
 
-                    anchorMin.x = 0.625f;
+                    anchorMin.x = 0.65f;
                     anchorMax.x = 0.95f;
 
                     anchorMin.y = 0.45f;

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -50,40 +50,30 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             // Instantiating ui element prefabs
 
-            if (_instantiatedTimer == null)
-            {
-                _instantiatedTimer = InstantiateBattleUiElement(BattleUiElementType.Timer);
-                BattleUiMovableElementData timerData = SettingsCarrier.Instance.GetBattleUiMovableElementData(BattleUiElementType.Timer);
-                SetData(BattleUiElementType.Timer);
-            }
+            if (_instantiatedTimer == null) _instantiatedTimer = InstantiateBattleUiElement(BattleUiElementType.Timer);
+            SetData(BattleUiElementType.Timer);
 
-            if (_instantiatedDiamonds == null)
-            {
-                _instantiatedDiamonds = InstantiateBattleUiElement(BattleUiElementType.Diamonds);
-                SetData(BattleUiElementType.Diamonds);
-            }
+            if (_instantiatedDiamonds == null) _instantiatedDiamonds = InstantiateBattleUiElement(BattleUiElementType.Diamonds);
+            SetData(BattleUiElementType.Diamonds);
 
-            if (_instantiatedGiveUpButton == null)
-            {
-                _instantiatedGiveUpButton = InstantiateBattleUiElement(BattleUiElementType.GiveUpButton);
-                SetData(BattleUiElementType.GiveUpButton);
-            }
+            if (_instantiatedGiveUpButton == null) _instantiatedGiveUpButton = InstantiateBattleUiElement(BattleUiElementType.GiveUpButton);
+            SetData(BattleUiElementType.GiveUpButton);
 
             if (_instantiatedPlayerInfo == null)
             {
                 _instantiatedPlayerInfo = InstantiateBattleUiElement(BattleUiElementType.PlayerInfo);
                 TextMeshProUGUI playerName = _instantiatedPlayerInfo.GetComponentInChildren<TextMeshProUGUI>();
                 if (playerName != null) playerName.text = "Minä";
-                SetData(BattleUiElementType.PlayerInfo);
             }
+            SetData(BattleUiElementType.PlayerInfo);
 
             if (_instantiatedTeammateInfo == null)
             {
                 _instantiatedTeammateInfo = InstantiateBattleUiElement(BattleUiElementType.TeammateInfo);
                 TextMeshProUGUI teammateName = _instantiatedTeammateInfo.GetComponentInChildren<TextMeshProUGUI>();
                 if (teammateName != null) teammateName.text = "Tiimikaveri";
-                SetData(BattleUiElementType.TeammateInfo);
             }
+            SetData(BattleUiElementType.TeammateInfo);
         }
 
         /// <summary>

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs.meta
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07fea859af56758409ab2d1e3c31e928
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MenuUi/Scripts/Settings/SettingsCarrier.cs
+++ b/Assets/MenuUi/Scripts/Settings/SettingsCarrier.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System;
-using System.Collections.Generic;
 using Altzone.Scripts.Model.Poco.Game;
+using Altzone.Scripts.BattleUiShared;
 
 public class SettingsCarrier : MonoBehaviour // Script for carrying settings data between scenes
 {
@@ -22,6 +22,15 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
         Small,
         Medium,
         Large
+    }
+
+    public enum BattleUiElementType
+    {
+        Timer,
+        PlayerInfo,
+        TeammateInfo,
+        Diamonds,
+        GiveUpButton,
     }
 
     // Events
@@ -117,5 +126,18 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
         _textSize = size;
         PlayerPrefs.SetInt("TextSize", (int)size);
         OnTextSizeChange?.Invoke();
+    }
+
+    public BattleUiMovableElementData GetBattleUiMovableElementData(BattleUiElementType type)
+    {
+        string json = PlayerPrefs.GetString($"BattleUi{type}", string.Empty);
+        if (string.IsNullOrEmpty(json)) return null;
+        return JsonUtility.FromJson<BattleUiMovableElementData>(json);
+    }
+
+    public void SetBattleUiMovableElementData(BattleUiElementType type, BattleUiMovableElementData data)
+    {
+        string json = JsonUtility.ToJson(data);
+        PlayerPrefs.SetString($"BattleUi{type}", json);
     }
 }


### PR DESCRIPTION
Editor for configuring Battle Ui. Not added to settings view yet to avoid possible merge conflicts, nor is the ui element data getting loaded to battle yet.

Features:
- Moving Battle Ui elements, there is a small 0.5s delay before element starts moving.
- Scaling Battle Ui elements.
- Changing orientation and flipping horizontally and vertically if the element is a multi orientation element.
- Control buttons are hidden by default but get shown by tapping on ui element.
- Grid snapping (currently grid is predefined but it should be made user configurable later). Grid can be toggled on or off.
- Resetting to default position, calculating default positions for the ui elements based on screen resolution.
- Saving and loading through SettingsCarrier.cs script.
- Popup if trying to close editor with unsaved changes.
