### PR TITLE
Fixed battle popup selected character class colors

### DIFF
--- a/Assets/MenuUi/Prefabs/UI Components/Battle Popup/BattlePopupSelectedCharacter.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/Battle Popup/BattlePopupSelectedCharacter.prefab
@@ -32,6 +32,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 8835253624458372228}
+  - {fileID: 4661047007768976170}
   - {fileID: 3813463039263476049}
   - {fileID: 1497434569553465059}
   - {fileID: 1851524540821749159}
@@ -63,8 +65,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _spriteImage: {fileID: 2980416419759435658}
-  _backgroundImage: {fileID: 1698316617930894126}
-  _backgroundDetailsImage: {fileID: 0}
+  _bordersBackgroundImage: {fileID: 1698316617930894126}
+  _upperBackgroundImage: {fileID: 5836939434433138973}
+  _lowerBackgroundImage: {fileID: 4589846820146580298}
   _piechartPreview: {fileID: 599868788555485942}
   _selectionDropdown: {fileID: 1844653283393957054}
   _selectionDropdownContent: {fileID: 2420914945809431188}
@@ -190,6 +193,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1844653283393957054}
   m_CullTransparentMesh: 1
+--- !u!1 &3301462512797615254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4661047007768976170}
+  - component: {fileID: 5708044809592833863}
+  - component: {fileID: 4589846820146580298}
+  m_Layer: 5
+  m_Name: LowerBackground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4661047007768976170
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3301462512797615254}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8755021714922067558}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5708044809592833863
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3301462512797615254}
+  m_CullTransparentMesh: 1
+--- !u!114 &4589846820146580298
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3301462512797615254}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 025f84cc8494e344b9b6cee7f38a9032, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8132852156446877540
 GameObject:
   m_ObjectHideFlags: 0
@@ -258,6 +336,81 @@ MonoBehaviour:
   m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8617346764155059060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8835253624458372228}
+  - component: {fileID: 8844493286808534704}
+  - component: {fileID: 5836939434433138973}
+  m_Layer: 5
+  m_Name: UpperBackground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8835253624458372228
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8617346764155059060}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8755021714922067558}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8844493286808534704
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8617346764155059060}
+  m_CullTransparentMesh: 1
+--- !u!114 &5836939434433138973
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8617346764155059060}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a9d59ff05e7b74d4892bceafcf19c795, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1

--- a/Assets/MenuUi/Scripts/Lobby/SelectedCharacters/BattlePopupSelectedCharacter.cs
+++ b/Assets/MenuUi/Scripts/Lobby/SelectedCharacters/BattlePopupSelectedCharacter.cs
@@ -19,7 +19,9 @@ namespace MenuUi.Scripts.Lobby.SelectedCharacters
     {
         [Header("Character slot references")]
         [SerializeField] private Image _spriteImage;
-        [SerializeField] private Image _backgroundImage;
+        [SerializeField] private Image _bordersBackgroundImage;
+        [SerializeField] private Image _upperBackgroundImage;
+        [SerializeField] private Image _lowerBackgroundImage;
         [SerializeField] private PieChartPreview _piechartPreview;
 
         [Header("Dropdown references")]
@@ -65,7 +67,8 @@ namespace MenuUi.Scripts.Lobby.SelectedCharacters
             _spriteImage.enabled = true;
 
             CharacterClassID charClassID = CustomCharacter.GetClassID(charID);
-            _backgroundImage.color = _classColorReference.GetColor(charClassID);
+            _upperBackgroundImage.color = _classColorReference.GetAlternativeColor(charClassID);
+            _lowerBackgroundImage.color = _classColorReference.GetColor(charClassID);
 
             _characterId = charID;
 
@@ -107,7 +110,8 @@ namespace MenuUi.Scripts.Lobby.SelectedCharacters
         public void SetEmpty(bool isEditable, int slotIdx)
         {
             _spriteImage.enabled = false;
-            _backgroundImage.color = Color.white;
+            _upperBackgroundImage.color = Color.white;
+            _lowerBackgroundImage.color = Color.white;
             _piechartPreview.gameObject.SetActive(false);
             _characterId =CharacterID.None;
             _slotIdx = slotIdx;
@@ -204,10 +208,17 @@ namespace MenuUi.Scripts.Lobby.SelectedCharacters
 
             GameObject dropdownButton = new();
 
-            // Background image
-            Image backgroundImage = dropdownButton.AddComponent<Image>();
-            backgroundImage.sprite = _backgroundImage.sprite;
-            backgroundImage.color = _classColorReference.GetColor(charClassID);
+            // Background images
+            Image bordersBackgroundImage = dropdownButton.AddComponent<Image>();
+            bordersBackgroundImage.sprite = _bordersBackgroundImage.sprite;
+
+            Image upperBackgroundImage = AddImageChildToParent(dropdownButton.transform);
+            upperBackgroundImage.sprite = _upperBackgroundImage.sprite;
+            upperBackgroundImage.color = _classColorReference.GetAlternativeColor(charClassID);
+
+            Image lowerBackgroundImage = AddImageChildToParent(dropdownButton.transform);
+            lowerBackgroundImage.sprite = _lowerBackgroundImage.sprite;
+            lowerBackgroundImage.color = _classColorReference.GetColor(charClassID);
 
             // Button component
             Button button = dropdownButton.AddComponent<Button>();
@@ -218,19 +229,26 @@ namespace MenuUi.Scripts.Lobby.SelectedCharacters
             });
 
             // Sprite image
-            GameObject gallerySprite = new();
-            Image spriteImage = gallerySprite.AddComponent<Image>();
+            Image spriteImage = AddImageChildToParent(dropdownButton.transform);
             spriteImage.preserveAspect = true;
             spriteImage.sprite = charInfo.GalleryImage;
-            gallerySprite.transform.SetParent(dropdownButton.transform, false);
-
-            RectTransform spriteRect = gallerySprite.GetComponent<RectTransform>();
-            spriteRect.sizeDelta = Vector2.zero;
-            spriteRect.anchorMin = Vector2.zero;
-            spriteRect.anchorMax = Vector2.one;
 
             // Adding dropdown button to dropdown contents
             dropdownButton.transform.SetParent(_selectionDropdownContent, false);
+        }
+
+        private Image AddImageChildToParent(Transform parent)
+        {
+            GameObject image = new();
+            Image imageComponent = image.AddComponent<Image>();
+            image.transform.SetParent(parent, false);
+
+            RectTransform rectTransform = image.GetComponent<RectTransform>();
+            rectTransform.sizeDelta = Vector2.zero;
+            rectTransform.anchorMin = Vector2.zero;
+            rectTransform.anchorMax = Vector2.one;
+
+            return imageComponent;
         }
     }
 }

--- a/Assets/MenuUi/Scripts/Lobby/SelectedCharacters/BattlePopupSelectedCharacter.cs
+++ b/Assets/MenuUi/Scripts/Lobby/SelectedCharacters/BattlePopupSelectedCharacter.cs
@@ -142,6 +142,12 @@ namespace MenuUi.Scripts.Lobby.SelectedCharacters
 
         private void OpenSelectionDropdown()
         {
+            if (_selectionDropdownContent.childCount > 0)
+            {
+                _selectionDropdown.SetActive(true);
+                return;
+            }
+
             StartCoroutine(GetPlayerData(playerData =>
             {
                 var characters = playerData.CustomCharacters.GroupBy(x => x.Id).Select(x => x.First()).ToList(); // ensuring no duplicate characters are shown
@@ -168,14 +174,6 @@ namespace MenuUi.Scripts.Lobby.SelectedCharacters
             if (_selectionDropdown.activeSelf)
             {
                 _selectionDropdown.SetActive(false);
-                for (int i = 0; i < _selectionDropdownContent.childCount; i++)
-                {
-                    Transform dropdownButton = _selectionDropdownContent.GetChild(i);
-                    Button buttonComponent = dropdownButton.GetComponent<Button>();
-                    buttonComponent.onClick.RemoveAllListeners();
-
-                    Destroy(dropdownButton.gameObject);
-                }
                 _dropdownScrollRect.VerticalNormalizedPosition = 1;
             }
         }


### PR DESCRIPTION
- Fixed battle popup selected character class background being invisible, implemented the new background art.
- Updated the script to not destroy character buttons when the dropdown is closed. I think it's better to keep them in memory so that new gameobjects aren't created every time the dropdown is opened.