### PR TITLE
Fixed bug that resetting default ui layout didn't trigger unsaved changes

### DIFF
--- a/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
+++ b/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
@@ -26,11 +26,12 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
 
     public enum BattleUiElementType
     {
-        Timer,
-        PlayerInfo,
-        TeammateInfo,
-        Diamonds,
-        GiveUpButton,
+        None = -1,
+        Timer = 0,
+        PlayerInfo = 1,
+        TeammateInfo = 2,
+        Diamonds = 3,
+        GiveUpButton = 4,
     }
 
     // Events
@@ -179,13 +180,18 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
 
     public BattleUiMovableElementData GetBattleUiMovableElementData(BattleUiElementType type)
     {
+        if (type == BattleUiElementType.None) return null;
+
         string json = PlayerPrefs.GetString($"BattleUi{type}", string.Empty);
         if (string.IsNullOrEmpty(json)) return null;
+
         return JsonUtility.FromJson<BattleUiMovableElementData>(json);
     }
 
     public void SetBattleUiMovableElementData(BattleUiElementType type, BattleUiMovableElementData data)
     {
+        if (type == BattleUiElementType.None) return;
+
         string json = JsonUtility.ToJson(data);
         PlayerPrefs.SetString($"BattleUi{type}", json);
     }

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -423,6 +423,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private void ResetChanges()
         {
+            _unsavedChanges = true;
             SetDefaultDataToUiElement(_instantiatedTimer);
             SetDefaultDataToUiElement(_instantiatedDiamonds);
             SetDefaultDataToUiElement(_instantiatedGiveUpButton);

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -145,6 +145,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
                 {
                     if (saveChanges == null) return;
                     if (saveChanges.Value == true) SaveChanges();
+                    else _unsavedChanges = false;
                     gameObject.SetActive(false);
                 }));
             }
@@ -394,19 +395,19 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private void SaveChanges()
         {
             BattleUiMovableElementData timerData = _instantiatedTimer.GetData();
-            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Timer, timerData);
+            if (!IsSavedDataSimilar(BattleUiElementType.Timer)) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Timer, timerData);
 
             BattleUiMovableElementData diamondsData = _instantiatedDiamonds.GetData();
-            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Diamonds, diamondsData);
+            if (!IsSavedDataSimilar(BattleUiElementType.Diamonds)) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Diamonds, diamondsData);
 
             BattleUiMovableElementData giveUpButtonData = _instantiatedGiveUpButton.GetData();
-            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.GiveUpButton, giveUpButtonData);
+            if (!IsSavedDataSimilar(BattleUiElementType.GiveUpButton)) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.GiveUpButton, giveUpButtonData);
 
             BattleUiMovableElementData playerInfoData = _instantiatedPlayerInfo.GetData();
-            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.PlayerInfo, playerInfoData);
+            if (!IsSavedDataSimilar(BattleUiElementType.PlayerInfo)) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.PlayerInfo, playerInfoData);
 
             BattleUiMovableElementData teammateInfoData = _instantiatedTeammateInfo.GetData();
-            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.TeammateInfo, teammateInfoData);
+            if (!IsSavedDataSimilar(BattleUiElementType.TeammateInfo)) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.TeammateInfo, teammateInfoData);
 
             _unsavedChanges = false;
             PopupSignalBus.OnChangePopupInfoSignal("Muutokset on tallennettu.");
@@ -429,7 +430,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             SetDefaultDataToUiElement(_instantiatedPlayerInfo);
             SetDefaultDataToUiElement(_instantiatedTeammateInfo);
 
-            if (!IsSavedDataSimilar()) _unsavedChanges = true;
+            _unsavedChanges = !IsSavedDataSimilar();
         }
 
         private bool IsSavedDataSimilar(BattleUiElementType uiElementType = BattleUiElementType.None)
@@ -824,7 +825,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private void OnUiElementEdited()
         {
-            _unsavedChanges = true;
+            _unsavedChanges = !IsSavedDataSimilar();
             _grid.RemoveLineHighlight();
         }
 

--- a/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/BattleUiEditor/BattleUiEditor.cs
@@ -394,19 +394,19 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
         private void SaveChanges()
         {
             BattleUiMovableElementData timerData = _instantiatedTimer.GetData();
-            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Timer, timerData);
+            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Timer, timerData);
 
             BattleUiMovableElementData diamondsData = _instantiatedDiamonds.GetData();
-            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Diamonds, diamondsData);
+            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.Diamonds, diamondsData);
 
             BattleUiMovableElementData giveUpButtonData = _instantiatedGiveUpButton.GetData();
-            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.GiveUpButton, giveUpButtonData);
+            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.GiveUpButton, giveUpButtonData);
 
             BattleUiMovableElementData playerInfoData = _instantiatedPlayerInfo.GetData();
-            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.PlayerInfo, playerInfoData);
+            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.PlayerInfo, playerInfoData);
 
             BattleUiMovableElementData teammateInfoData = _instantiatedTeammateInfo.GetData();
-            SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.TeammateInfo, teammateInfoData);
+            if (!IsSavedDataSimilar()) SettingsCarrier.Instance.SetBattleUiMovableElementData(BattleUiElementType.TeammateInfo, teammateInfoData);
 
             _unsavedChanges = false;
             PopupSignalBus.OnChangePopupInfoSignal("Muutokset on tallennettu.");
@@ -423,16 +423,62 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
         private void ResetChanges()
         {
-            _unsavedChanges = true;
             SetDefaultDataToUiElement(_instantiatedTimer);
             SetDefaultDataToUiElement(_instantiatedDiamonds);
             SetDefaultDataToUiElement(_instantiatedGiveUpButton);
             SetDefaultDataToUiElement(_instantiatedPlayerInfo);
             SetDefaultDataToUiElement(_instantiatedTeammateInfo);
+
+            if (!IsSavedDataSimilar()) _unsavedChanges = true;
+        }
+
+        private bool IsSavedDataSimilar(BattleUiElementType uiElementType = BattleUiElementType.None)
+        {
+            BattleUiMovableElementData savedData = SettingsCarrier.Instance.GetBattleUiMovableElementData(uiElementType);
+            BattleUiMovableElementData compareData;
+            
+            switch (uiElementType)
+            {
+                case BattleUiElementType.Timer:
+                    compareData = _instantiatedTimer.GetData();
+                    break;
+                case BattleUiElementType.Diamonds:
+                    compareData = _instantiatedDiamonds.GetData();
+                    break;
+                case BattleUiElementType.GiveUpButton:
+                    compareData = _instantiatedGiveUpButton.GetData();
+                    break;
+                case BattleUiElementType.PlayerInfo:
+                    compareData = _instantiatedPlayerInfo.GetData();
+                    break;
+                case BattleUiElementType.TeammateInfo:
+                    compareData = _instantiatedTeammateInfo.GetData();
+                    break;
+                default: // Checking if saved data is similar for every ui element
+                    // Note: if more ui elements are added change from GiveUpButton to the last element in the enum
+                    bool isSavedDataSimilar = true;
+                    for (int i = 0; i <= (int)BattleUiElementType.GiveUpButton; i++) 
+                    {
+                        isSavedDataSimilar = IsSavedDataSimilar((BattleUiElementType)i);
+                        if (!isSavedDataSimilar) break;
+                    }
+                    return isSavedDataSimilar;
+            }
+
+            if (savedData == null || compareData == null) return false;
+
+            // Compare if the data is similar
+            return savedData.IsFlippedHorizontally == compareData.IsFlippedHorizontally
+                && savedData.IsFlippedVertically == compareData.IsFlippedVertically
+                && savedData.AnchorMin == compareData.AnchorMin
+                && savedData.AnchorMax == compareData.AnchorMax
+                && savedData.Orientation == compareData.Orientation;
         }
 
         private GameObject InstantiateBattleUiElement(BattleUiElementType uiElementType)
         {
+            if (uiElementType == BattleUiElementType.None) return null;
+
             GameObject uiElementPrefab = null;
 
             switch (uiElementType)
@@ -526,6 +572,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             // Getting ui element type
             BattleUiElementType uiElementType = GetUiElementType(movableElement);
+            if (uiElementType == BattleUiElementType.None) return;
 
             // Getting the saved data for this ui element type
             BattleUiMovableElementData data = SettingsCarrier.Instance.GetBattleUiMovableElementData(uiElementType);
@@ -551,6 +598,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             // Getting ui element type
             BattleUiElementType uiElementType = GetUiElementType(multiOrientationElement);
+            if (uiElementType == BattleUiElementType.None) return;
 
             // Getting the saved data for this ui element type
             BattleUiMovableElementData data = SettingsCarrier.Instance.GetBattleUiMovableElementData(uiElementType);
@@ -576,6 +624,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             // Getting ui element type
             BattleUiElementType uiElementType = GetUiElementType(movableElement);
+            if (uiElementType == BattleUiElementType.None) return;
 
             // Getting the default data for this ui element type
             BattleUiMovableElementData data = GetDefaultDataForUiElement(uiElementType);
@@ -597,6 +646,7 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
 
             // Getting ui element type
             BattleUiElementType uiElementType = GetUiElementType(multiOrientationElement);
+            if (uiElementType == BattleUiElementType.None) return;
 
             // Getting the default data for this ui element type
             BattleUiMovableElementData data = GetDefaultDataForUiElement(uiElementType);
@@ -620,9 +670,13 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             {
                 return BattleUiElementType.GiveUpButton;
             }
-            else
+            else if (movableElement == _instantiatedDiamonds)
             {
                 return BattleUiElementType.Diamonds;
+            }
+            else
+            {
+                return BattleUiElementType.None;
             }
         }
 
@@ -632,14 +686,20 @@ namespace MenuUi.Scripts.Settings.BattleUiEditor
             {
                 return BattleUiElementType.PlayerInfo;
             }
-            else
+            else if (multiOrientationElement == _instantiatedTeammateInfo)
             {
                 return BattleUiElementType.TeammateInfo;
+            }
+            else
+            {
+                return BattleUiElementType.None;
             }
         }
 
         private BattleUiMovableElementData GetDefaultDataForUiElement(BattleUiElementType uiElementType)
         {
+            if (uiElementType == BattleUiElementType.None) return null;
+
             // Initializing variables for creating data object
             Vector2 anchorMin = Vector2.zero;
             Vector2 anchorMax = Vector2.zero;


### PR DESCRIPTION
Fixed bug in BattleUiEditor that resetting default ui layout didn't trigger unsaved changes.