### PR TITLE
Profile data saving fix and connection to leaderboard

### DIFF
--- a/Assets/Altzone/Scripts/Model/Poco/Clan/ClanMember.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Clan/ClanMember.cs
@@ -13,6 +13,7 @@ namespace Altzone.Scripts.Model.Poco.Clan
         [ForeignKey(nameof(PlayerData)), Mandatory] public string PlayerDataId;
         [ForeignKey(nameof(RaidRoom)), Optional] public string RaidRoomId;
         public ClanMemberRole Role;
+        private ServerPlayer _player;
 
         private int _leaderBoardWins = 0;
         private int _leaderBoardCoins = 0;
@@ -26,6 +27,12 @@ namespace Altzone.Scripts.Model.Poco.Clan
         {
             _id = player._id;
             _name = player.name;
+            _player = player;
+        }
+
+        public PlayerData GetPlayerData()
+        {
+            return new(_player, true);
         }
 
         public void Update(int wins, int coins)

--- a/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
@@ -141,24 +141,24 @@ namespace Altzone.Scripts.Model.Poco.Player
             UniqueIdentifier = uniqueIdentifier;
         }
 
-        public PlayerData(ServerPlayer player)
+        public PlayerData(ServerPlayer player, bool limited = false)
         {
             Assert.IsTrue(player._id.IsPrimaryKey());
             Assert.IsTrue(player.clan_id.IsNullOEmptyOrNonWhiteSpace());
             //Assert.IsTrue(player.currentCustomCharacterId >= 0);
             Assert.IsTrue(player.name.IsMandatory());
-            Assert.IsTrue(player.backpackCapacity >= 0);
+            if (!limited) Assert.IsTrue(player.backpackCapacity >= 0);
             Assert.IsTrue(player.uniqueIdentifier.IsMandatory());
             Id = player._id;
             ClanId = player.clan_id ?? string.Empty;
             SelectedCharacterId = (int)(player.currentAvatarId == null ? 0 : player.currentAvatarId);
-            SelectedCharacterIds = (player?.battleCharacter_ids == null || player.battleCharacter_ids.Length < 3) ? new string[3] {"0","0","0"} : player.battleCharacter_ids;
+            if(!limited)SelectedCharacterIds = (player?.battleCharacter_ids == null || player.battleCharacter_ids.Length < 3) ? new string[3] {"0","0","0"} : player.battleCharacter_ids;
             Name = player.name;
-            BackpackCapacity = player.backpackCapacity;
+            if (!limited) BackpackCapacity = player.backpackCapacity;
             UniqueIdentifier = player.uniqueIdentifier;
             points = player.points;
             stats = player.gameStatistics;
-            Task = player.DailyTask != null ? new(player.DailyTask): null;
+            if (!limited) Task = player.DailyTask != null ? new(player.DailyTask): null;
         }
 
         public void UpdatePlayerData(ServerPlayer player)

--- a/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Player/PlayerData.cs
@@ -68,6 +68,10 @@ namespace Altzone.Scripts.Model.Poco.Player
         public List<PlayerVoteData> playerVotes = new List<PlayerVoteData>();
 
         public ServerGameStatistics stats = null;
+
+        public string ChosenMotto = null;
+        public string FavoriteDefenceID = null;
+
         /// <summary>
         /// Unique string to identify this player across devices and systems.
         /// </summary>

--- a/Assets/MenuUi/Prefabs/Leaderboard/LeaderboardPlayerActivityItem.prefab
+++ b/Assets/MenuUi/Prefabs/Leaderboard/LeaderboardPlayerActivityItem.prefab
@@ -224,6 +224,8 @@ GameObject:
   - component: {fileID: 2519015727964769259}
   - component: {fileID: 9188896772049500079}
   - component: {fileID: 5731231893955110458}
+  - component: {fileID: 2880526593071471378}
+  - component: {fileID: 6945124994884593517}
   m_Layer: 5
   m_Name: LeaderboardPlayerActivityItem
   m_TagString: Untagged
@@ -313,6 +315,65 @@ MonoBehaviour:
   _nameText: {fileID: 8825604220182762085}
   _coinsText: {fileID: 6191827188570660342}
   _clanHeart: {fileID: 1709619670028437936}
+  <OpenProfileButton>k__BackingField: {fileID: 2880526593071471378}
+--- !u!114 &2880526593071471378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3281663084631502013}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 9188896772049500079}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &6945124994884593517
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3281663084631502013}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 337dca1768bd6a44a9fe3bfb30afa666, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _naviTarget: {fileID: 11400000, guid: e159432f6bd8572419fea7a32165e31b, type: 2}
+  _isCurrentPopOutWindow: 0
 --- !u!1 &5375524824018107496
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/Leaderboard/LeaderboardPlayerWinsItem.prefab
+++ b/Assets/MenuUi/Prefabs/Leaderboard/LeaderboardPlayerWinsItem.prefab
@@ -149,6 +149,8 @@ GameObject:
   - component: {fileID: 1597823337199040676}
   - component: {fileID: 6905070578077349040}
   - component: {fileID: 4621702329782291870}
+  - component: {fileID: 4330713747197579326}
+  - component: {fileID: 4733782203718501551}
   m_Layer: 5
   m_Name: LeaderboardPlayerWinsItem
   m_TagString: Untagged
@@ -237,6 +239,65 @@ MonoBehaviour:
   _nameText: {fileID: 1437532963947543663}
   _winsText: {fileID: 5482741490182790832}
   _clanHeart: {fileID: 6253194504039477938}
+  <OpenProfileButton>k__BackingField: {fileID: 4330713747197579326}
+--- !u!114 &4330713747197579326
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4620648385292652003}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6905070578077349040}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &4733782203718501551
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4620648385292652003}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 337dca1768bd6a44a9fe3bfb30afa666, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _naviTarget: {fileID: 11400000, guid: e159432f6bd8572419fea7a32165e31b, type: 2}
+  _isCurrentPopOutWindow: 0
 --- !u!1 &5403608456972220549
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/Windows/HomeScreen/ProfiiliView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/HomeScreen/ProfiiliView.prefab
@@ -2253,7 +2253,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.6}
   m_AnchorMax: {x: 1, y: 0.875}
-  m_AnchoredPosition: {x: 15, y: 0.000030517578}
+  m_AnchoredPosition: {x: 15, y: 0}
   m_SizeDelta: {x: -30, y: 0.00008535385}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4703821774740086374
@@ -4281,7 +4281,6 @@ MonoBehaviour:
   _LosesText: {fileID: 2723808183462104539}
   _WinsText: {fileID: 3874926736005044309}
   _CarbonText: {fileID: 6354010782697853409}
-  _LoreInputField: {fileID: 0}
   _answerOptionPrefab: {fileID: 7096046977997727650, guid: 0d211df1f8ed0f04da32fdf396b0b623,
     type: 3}
   _mottoOptionsPopup: {fileID: 994349298486276067}
@@ -4295,6 +4294,9 @@ MonoBehaviour:
   _openMottoOptions: {fileID: 6763859444021365781}
   _openFavoriteDefenceSelection: {fileID: 6351976437230096604}
   _closePopupAreaButton: {fileID: 3963435832654689240}
+  _playStyleButtons:
+  - {fileID: 1789862274210685803}
+  - {fileID: 4638413136516349032}
   _ClanURLButton: {fileID: 4306818100801534888}
   _saveEditsButton: {fileID: 2955943204991639641}
   _addFriendButton: {fileID: 8953335287255744339}
@@ -5516,7 +5518,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 29.35
+  m_fontSize: 30.75
   m_fontSizeBase: 40
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -9694,6 +9696,11 @@ PrefabInstance:
       propertyPath: m_fontSize
       value: 24.1
       objectReference: {fileID: 0}
+    - target: {fileID: 2047688902295938898, guid: 2c4d02b28f79a164daa59e12d72bc229,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2139964531247244469, guid: 2c4d02b28f79a164daa59e12d72bc229,
         type: 3}
       propertyPath: m_Pivot.y
@@ -10734,7 +10741,7 @@ PrefabInstance:
     - target: {fileID: 142879347403563673, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_fontSize
-      value: 44.35
+      value: 42.7
       objectReference: {fileID: 0}
     - target: {fileID: 217236838875629824, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -10941,17 +10948,17 @@ PrefabInstance:
     - target: {fileID: 2544346663654659494, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_fontSize
-      value: 29.95
+      value: 28.9
       objectReference: {fileID: 0}
     - target: {fileID: 2641932565321544379, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.94188035
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2665311521893521844, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_fontSize
-      value: 44.5
+      value: 42.9
       objectReference: {fileID: 0}
     - target: {fileID: 2822583859474931625, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -11016,12 +11023,12 @@ PrefabInstance:
     - target: {fileID: 3472046463813142143, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.86688036
+      value: 0.9236
       objectReference: {fileID: 0}
     - target: {fileID: 3472046463813142143, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.1975
+      value: 0.2024
       objectReference: {fileID: 0}
     - target: {fileID: 3482542752552871026, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -11722,7 +11729,7 @@ PrefabInstance:
     - target: {fileID: 7827142668286818857, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.1975
+      value: 0.2024
       objectReference: {fileID: 0}
     - target: {fileID: 8176312792972380284, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -11807,12 +11814,12 @@ PrefabInstance:
     - target: {fileID: 9009743781400064838, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.94188035
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9009743781400064838, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.86688036
+      value: 0.9236
       objectReference: {fileID: 0}
     - target: {fileID: 9092838377446531208, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}

--- a/Assets/MenuUi/Prefabs/Windows/HomeScreen/ProfiiliView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/HomeScreen/ProfiiliView.prefab
@@ -2245,6 +2245,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 8925412973318677917}
   - {fileID: 7983338394954758628}
   - {fileID: 97842429925712859}
   - {fileID: 132131741065000167}
@@ -4291,6 +4292,7 @@ MonoBehaviour:
   _characterOptionsContent: {fileID: 4765153253163608207}
   _characterOptionPrefab: {fileID: 7096046977997727650, guid: 015d262b10fcaf74ebe269354fb7d60e,
     type: 3}
+  _characterSelectionMessage: {fileID: 6362232812138138065}
   _openMottoOptions: {fileID: 6763859444021365781}
   _openFavoriteDefenceSelection: {fileID: 6351976437230096604}
   _closePopupAreaButton: {fileID: 3963435832654689240}
@@ -5518,7 +5520,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 30.75
+  m_fontSize: 30.15
   m_fontSizeBase: 40
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -7863,6 +7865,143 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 1
+--- !u!1 &7298336846252301587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8925412973318677917}
+  - component: {fileID: 6236844229335223503}
+  - component: {fileID: 6362232812138138065}
+  m_Layer: 5
+  m_Name: SelectionMessageText (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8925412973318677917
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7298336846252301587}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7989077206744786339}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.4}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.00009918213}
+  m_SizeDelta: {x: 0, y: -0.00019836}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6236844229335223503
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7298336846252301587}
+  m_CullTransparentMesh: 1
+--- !u!114 &6362232812138138065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7298336846252301587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
+  m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 36
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7300649654047243665
 GameObject:
   m_ObjectHideFlags: 0
@@ -10741,7 +10880,7 @@ PrefabInstance:
     - target: {fileID: 142879347403563673, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_fontSize
-      value: 42.7
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 217236838875629824, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -10948,7 +11087,7 @@ PrefabInstance:
     - target: {fileID: 2544346663654659494, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_fontSize
-      value: 28.9
+      value: 28.45
       objectReference: {fileID: 0}
     - target: {fileID: 2641932565321544379, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -10958,7 +11097,7 @@ PrefabInstance:
     - target: {fileID: 2665311521893521844, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_fontSize
-      value: 42.9
+      value: 42.25
       objectReference: {fileID: 0}
     - target: {fileID: 2822583859474931625, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}

--- a/Assets/MenuUi/Prefabs/Windows/HomeScreen/Stats.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/HomeScreen/Stats.prefab
@@ -1596,9 +1596,9 @@ MonoBehaviour:
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_PressedColor: {r: 0.9607844, g: 0.9607844, b: 0.9607844, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 0.9607844, g: 0.9607844, b: 0.9607844, a: 1}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:

--- a/Assets/MenuUi/Prefabs/Windows/PlayerStats/LeaderboardView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/PlayerStats/LeaderboardView.prefab
@@ -341,6 +341,141 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &256164687398405964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5456677163595504497}
+  - component: {fileID: 5027931037772900528}
+  - component: {fileID: 6785551593977336990}
+  - component: {fileID: 6866483560132152795}
+  - component: {fileID: 8640320822821257797}
+  m_Layer: 5
+  m_Name: OpenPlayerButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5456677163595504497
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256164687398405964}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6550146919712428675}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -0.000061035156, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5027931037772900528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256164687398405964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8640320822821257797}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &6785551593977336990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256164687398405964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 337dca1768bd6a44a9fe3bfb30afa666, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _naviTarget: {fileID: 11400000, guid: e159432f6bd8572419fea7a32165e31b, type: 2}
+  _isCurrentPopOutWindow: 0
+--- !u!222 &6866483560132152795
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256164687398405964}
+  m_CullTransparentMesh: 1
+--- !u!114 &8640320822821257797
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256164687398405964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &430296265085231316
 GameObject:
   m_ObjectHideFlags: 0
@@ -2038,6 +2173,7 @@ RectTransform:
   - {fileID: 2406276986342314829}
   - {fileID: 907816173248040720}
   - {fileID: 7456149375855742357}
+  - {fileID: 4753405646933464062}
   m_Father: {fileID: 2209971332152043480}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.32, y: 0}
@@ -2169,6 +2305,141 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: 4cb47eb99076cbc49b8fd084cd768826, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2480367316739761053
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4753405646933464062}
+  - component: {fileID: 1163980604408810595}
+  - component: {fileID: 3016327879029915935}
+  - component: {fileID: 2410310467951144064}
+  - component: {fileID: 6919563412306917413}
+  m_Layer: 5
+  m_Name: OpenPlayerButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4753405646933464062
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2480367316739761053}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2380170615588361721}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1163980604408810595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2480367316739761053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6919563412306917413}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &3016327879029915935
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2480367316739761053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 337dca1768bd6a44a9fe3bfb30afa666, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _naviTarget: {fileID: 11400000, guid: e159432f6bd8572419fea7a32165e31b, type: 2}
+  _isCurrentPopOutWindow: 0
+--- !u!222 &2410310467951144064
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2480367316739761053}
+  m_CullTransparentMesh: 1
+--- !u!114 &6919563412306917413
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2480367316739761053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -4357,6 +4628,7 @@ RectTransform:
   - {fileID: 6941287798181155609}
   - {fileID: 7848239465675557058}
   - {fileID: 92165644333460720}
+  - {fileID: 1550255003819234484}
   m_Father: {fileID: 2209971332152043480}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -4730,6 +5002,7 @@ RectTransform:
   - {fileID: 8573816646307368717}
   - {fileID: 527452455321293495}
   - {fileID: 5062496185622176596}
+  - {fileID: 5456677163595504497}
   m_Father: {fileID: 2209971332152043480}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.71, y: 0}
@@ -5169,6 +5442,141 @@ MonoBehaviour:
       m_Calls: []
   m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4264269823175884689
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1550255003819234484}
+  - component: {fileID: 812871163293777034}
+  - component: {fileID: 2425174215929093357}
+  - component: {fileID: 2206896256811346881}
+  - component: {fileID: 7908375439560707182}
+  m_Layer: 5
+  m_Name: OpenPlayerButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1550255003819234484
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4264269823175884689}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2161350180764445429}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &812871163293777034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4264269823175884689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7908375439560707182}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2425174215929093357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4264269823175884689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 337dca1768bd6a44a9fe3bfb30afa666, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _naviTarget: {fileID: 11400000, guid: e159432f6bd8572419fea7a32165e31b, type: 2}
+  _isCurrentPopOutWindow: 0
+--- !u!222 &2206896256811346881
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4264269823175884689}
+  m_CullTransparentMesh: 1
+--- !u!114 &7908375439560707182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4264269823175884689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -10525,24 +10933,35 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47490c57df55bd548adff4c0f2229203, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _playerProfileButtons:
+  - {fileID: 4264269823175884689}
+  - {fileID: 2480367316739761053}
+  - {fileID: 256164687398405964}
+  _clanProfileButtons:
+  - {fileID: 5110117561641146733}
+  - {fileID: 3419825462653813941}
+  - {fileID: 4709326288554947215}
   _firstName: {fileID: 4309767811935280806}
   _firstPoints: {fileID: 2703652073698042699}
   _firstClanHeart: {fileID: 5564705606055241412}
   _firstClanHeartPlayer: {fileID: 7592428591864747152}
   _firstAvatarHead: {fileID: 7360935508527971584}
   <FirstOpenClanProfileButton>k__BackingField: {fileID: 6818251390931208265}
+  <FirstOpenPlayerProfileButton>k__BackingField: {fileID: 1163980604408810595}
   _secondName: {fileID: 9195379478113814116}
   _secondPoints: {fileID: 6664724612702036673}
   _secondClanHeart: {fileID: 867354241666836112}
   _secondClanHeartPlayer: {fileID: 9221444745018899322}
   _secondAvatarHead: {fileID: 6566852773246358277}
   <SecondOpenClanProfileButton>k__BackingField: {fileID: 1115279988320692753}
+  <SecondOpenPlayerProfileButton>k__BackingField: {fileID: 812871163293777034}
   _thirdName: {fileID: 2317710593634464254}
   _thirdPoints: {fileID: 5887167636141540924}
   _thirdClanHeart: {fileID: 1918901502220892804}
   _thirdClanHeartPlayer: {fileID: 5625986905651303461}
   _thirdAvatarHead: {fileID: 3188014570817743996}
   <ThirdOpenClanProfileButton>k__BackingField: {fileID: 8876666602069788495}
+  <ThirdOpenPlayerProfileButton>k__BackingField: {fileID: 5027931037772900528}
 --- !u!1 &7377492228285397043
 GameObject:
   m_ObjectHideFlags: 0
@@ -13418,10 +13837,60 @@ PrefabInstance:
       propertyPath: m_fontSize
       value: 42.9
       objectReference: {fileID: 0}
+    - target: {fileID: 238256686529316341, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 351381219934476030, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 351381219934476030, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 351381219934476030, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 351381219934476030, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 454137004331519346, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 534851206385820570, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_fontSize
-      value: 31
+      value: 28.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 668928474750791978, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 887840839647906052, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 988107141080270557, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1202927817492883387, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1498605224896170927, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
@@ -13431,6 +13900,11 @@ PrefabInstance:
     - target: {fileID: 1498605224896170927, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1574091165673386512, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1595777600247209436, guid: e41290d0959bdfe47b62024b1a7a3c44,
@@ -13443,20 +13917,130 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -1
       objectReference: {fileID: 0}
+    - target: {fileID: 1671811254354871571, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2218432846418422772, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2235068869896540795, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_fontSize
       value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 2298189892219336953, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2477003514160165043, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2501123970339904624, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2657921023226793592, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2727182031199687845, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 42.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3005394014881265771, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3009603512980926658, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3124640018725359746, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3347562999960549725, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3452581593634017370, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_fontSize
       value: 35.8
       objectReference: {fileID: 0}
+    - target: {fileID: 3476238485458081761, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3817575405982014914, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3872833548716069313, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4157435021258434962, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4162271009348586078, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4191235192382201070, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4335743718415998625, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4419744792767982754, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4432322589454936928, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_fontSize
       value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482654205759618232, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4525487868207707556, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801358333382125668, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5121922535685081116, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
@@ -13468,20 +14052,55 @@ PrefabInstance:
       propertyPath: m_Value
       value: 1.000012
       objectReference: {fileID: 0}
+    - target: {fileID: 5182675393013953107, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5584544043235329587, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593457544635998475, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5759620484407943366, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_fontSize
       value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 5839737063007643555, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6016632658432163293, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_fontSize
       value: 28
       objectReference: {fileID: 0}
+    - target: {fileID: 6150616040324677184, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6175919415710551228, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6221160951982613882, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_Name
       value: UIOverlayPanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490595044015969972, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6645719920315919770, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
@@ -13491,6 +14110,26 @@ PrefabInstance:
     - target: {fileID: 6853548187239314907, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6874875501156775734, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7039820359420640014, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7043193773727190041, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7048076992167296156, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7141936146467267303, guid: e41290d0959bdfe47b62024b1a7a3c44,
@@ -13503,6 +14142,16 @@ PrefabInstance:
       propertyPath: m_ActiveFontFeatures.Array.data[0]
       value: 1801810542
       objectReference: {fileID: 0}
+    - target: {fileID: 7297197238351598591, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7337703267853003909, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7397605467378155027, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_fontSize
@@ -13512,6 +14161,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_ActiveFontFeatures.Array.data[0]
       value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 7416820097986064510, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7486934642797737969, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7584895158970224139, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
@@ -13544,6 +14203,26 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 5e1c9ce07e75b0349a0457bfb0046cd0,
         type: 3}
+    - target: {fileID: 8060401964950094792, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8100700787637544904, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8304232023194842160, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8460042963550306715, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8476621660179101015, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_Pivot.x
@@ -13652,6 +14331,26 @@ PrefabInstance:
     - target: {fileID: 8533230917277494904, guid: e41290d0959bdfe47b62024b1a7a3c44,
         type: 3}
       propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8789393652271096271, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8844189568690890044, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8896212905483880756, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8949745129488991392, guid: e41290d0959bdfe47b62024b1a7a3c44,
+        type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/Assets/MenuUi/Scripts/Leaderboard/LeaderboardActivityItem.cs
+++ b/Assets/MenuUi/Scripts/Leaderboard/LeaderboardActivityItem.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class LeaderboardActivityItem : MonoBehaviour
 {
@@ -9,6 +10,7 @@ public class LeaderboardActivityItem : MonoBehaviour
     [SerializeField] private TextMeshProUGUI _nameText;
     [SerializeField] private TextMeshProUGUI _coinsText;
     [SerializeField] private ClanHeartColorSetter _clanHeart;
+    [field: SerializeField] public Button OpenProfileButton { get; private set; }
 
     public void Initialize(int rank, string name, int coins)
     {

--- a/Assets/MenuUi/Scripts/Leaderboard/LeaderboardPodium.cs
+++ b/Assets/MenuUi/Scripts/Leaderboard/LeaderboardPodium.cs
@@ -41,18 +41,34 @@ public class LeaderboardPodium : MonoBehaviour
 
     private bool _isClanView = false;
 
-    public void InitilializePodium(int rank, string name, int points, ClanData clanData, ServerClan serverClan, PlayerData playerData)
+    public void InitilializePodium(int rank, string name, int points, ClanData clanData, ServerClan serverClan)
     {
         switch (rank)
         {
             case 1:
-                InitializeFirstPlace(name, points, clanData, serverClan, playerData);
+                InitializeFirstPlace(name, points, clanData, serverClan, null);
                 break;
             case 2:
-                InitializeSecondPlace(name, points, clanData, serverClan, playerData);
+                InitializeSecondPlace(name, points, clanData, serverClan, null);
                 break;
             case 3:
-                InitializeThirdPlace(name, points, clanData, serverClan, playerData);
+                InitializeThirdPlace(name, points, clanData, serverClan, null);
+                break;
+        }
+    }
+
+    public void InitilializePodium(int rank, string name, int points, PlayerData playerData)
+    {
+        switch (rank)
+        {
+            case 1:
+                InitializeFirstPlace(name, points, null, null, playerData);
+                break;
+            case 2:
+                InitializeSecondPlace(name, points, null, null, playerData);
+                break;
+            case 3:
+                InitializeThirdPlace(name, points, null, null, playerData);
                 break;
         }
     }

--- a/Assets/MenuUi/Scripts/Leaderboard/LeaderboardPodium.cs
+++ b/Assets/MenuUi/Scripts/Leaderboard/LeaderboardPodium.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Altzone.Scripts.Model.Poco.Clan;
+using Altzone.Scripts.Model.Poco.Player;
 using MenuUi.Scripts.Window;
 using TMPro;
 using UnityEngine;
@@ -8,6 +9,9 @@ using UnityEngine.UI;
 
 public class LeaderboardPodium : MonoBehaviour
 {
+    [SerializeField] private GameObject[] _playerProfileButtons;
+    [SerializeField] private GameObject[] _clanProfileButtons;
+
     [Header("First place")]
     [SerializeField] private TextMeshProUGUI _firstName;
     [SerializeField] private TextMeshProUGUI _firstPoints;
@@ -15,6 +19,7 @@ public class LeaderboardPodium : MonoBehaviour
     [SerializeField] private GameObject _firstClanHeartPlayer;
     [SerializeField] private GameObject _firstAvatarHead;
     [field: SerializeField] public Button FirstOpenClanProfileButton { get; private set; }
+    [field: SerializeField] public Button FirstOpenPlayerProfileButton { get; private set; }
 
     [Header("Second place")]
     [SerializeField] private TextMeshProUGUI _secondName;
@@ -23,6 +28,7 @@ public class LeaderboardPodium : MonoBehaviour
     [SerializeField] private GameObject _secondClanHeartPlayer;
     [SerializeField] private GameObject _secondAvatarHead;
     [field: SerializeField] public Button SecondOpenClanProfileButton { get; private set; }
+    [field: SerializeField] public Button SecondOpenPlayerProfileButton { get; private set; }
 
     [Header("Third place")]
     [SerializeField] private TextMeshProUGUI _thirdName;
@@ -31,26 +37,27 @@ public class LeaderboardPodium : MonoBehaviour
     [SerializeField] private GameObject _thirdClanHeartPlayer;
     [SerializeField] private GameObject _thirdAvatarHead;
     [field: SerializeField] public Button ThirdOpenClanProfileButton { get; private set; }
+    [field: SerializeField] public Button ThirdOpenPlayerProfileButton { get; private set; }
 
     private bool _isClanView = false;
 
-    public void InitilializePodium(int rank, string name, int points, ClanData clanData, ServerClan serverClan)
+    public void InitilializePodium(int rank, string name, int points, ClanData clanData, ServerClan serverClan, PlayerData playerData)
     {
-        switch(rank)
+        switch (rank)
         {
             case 1:
-                InitializeFirstPlace(name, points, clanData, serverClan);
+                InitializeFirstPlace(name, points, clanData, serverClan, playerData);
                 break;
             case 2:
-                InitializeSecondPlace(name, points, clanData, serverClan);
+                InitializeSecondPlace(name, points, clanData, serverClan, playerData);
                 break;
             case 3:
-                InitializeThirdPlace(name, points, clanData, serverClan);
+                InitializeThirdPlace(name, points, clanData, serverClan, playerData);
                 break;
         }
     }
 
-    private void InitializeFirstPlace(string firstName, int firstPoints, ClanData clanData, ServerClan serverClan)
+    private void InitializeFirstPlace(string firstName, int firstPoints, ClanData clanData, ServerClan serverClan, PlayerData playerData)
     {
         _firstName.text = firstName;
         _firstPoints.text = firstPoints.ToString();
@@ -67,10 +74,20 @@ public class LeaderboardPodium : MonoBehaviour
                 DataCarrier.AddData(DataCarrier.ClanListing, serverClan);
             });
         }
-            
+        else
+        {
+            if (playerData != null)
+            {
+                FirstOpenPlayerProfileButton.onClick.AddListener(() =>
+                {
+                    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
+                });
+            }
+
+        }
     }
 
-    private void InitializeSecondPlace(string secondName, int secondPoints, ClanData clanData, ServerClan serverClan)
+    private void InitializeSecondPlace(string secondName, int secondPoints, ClanData clanData, ServerClan serverClan, PlayerData playerData)
     {
         _secondName.text = secondName;
         _secondPoints.text = secondPoints.ToString();
@@ -87,9 +104,19 @@ public class LeaderboardPodium : MonoBehaviour
                 DataCarrier.AddData(DataCarrier.ClanListing, serverClan);
             });
         }
+        else
+        {
+            if (playerData != null)
+            {
+                SecondOpenPlayerProfileButton.onClick.AddListener(() =>
+                {
+                    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
+                });
+            }
+        }
     }
 
-    private void InitializeThirdPlace(string thirdName, int thirdPoints, ClanData clanData, ServerClan serverClan)
+    private void InitializeThirdPlace(string thirdName, int thirdPoints, ClanData clanData, ServerClan serverClan, PlayerData playerData)
     {
         _thirdName.text = thirdName;
         _thirdPoints.text = thirdPoints.ToString();
@@ -106,45 +133,69 @@ public class LeaderboardPodium : MonoBehaviour
                 DataCarrier.AddData(DataCarrier.ClanListing, serverClan);
             });
         }
+        else
+        {
+            if (playerData != null)
+            {
+                ThirdOpenPlayerProfileButton.onClick.AddListener(() =>
+                {
+                    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
+                });
+            }
+        }
     }
 
     public void SetPlayerView()
     {
         _isClanView = false;
 
-        FirstOpenClanProfileButton.interactable = false;
         _firstClanHeart.SetActive(false);
         _firstAvatarHead.SetActive(true);
         _firstClanHeartPlayer.SetActive(true);
 
-        SecondOpenClanProfileButton.interactable = false;
         _secondClanHeart.SetActive(false);
         _secondAvatarHead.SetActive(true);
         _secondClanHeartPlayer.SetActive(true);
 
-        ThirdOpenClanProfileButton.interactable = false;
         _thirdClanHeart.SetActive(false);
         _thirdAvatarHead.SetActive(true);
         _thirdClanHeartPlayer.SetActive(true);
+
+        foreach (GameObject button in _clanProfileButtons)
+        {
+            button.SetActive(false);
+        }
+
+        foreach (GameObject button in _playerProfileButtons)
+        {
+            button.SetActive(true);
+        }
     }
 
     public void SetClanView()
     {
-        _isClanView= true;
+        _isClanView = true;
 
         _firstAvatarHead.SetActive(false);
         _firstClanHeartPlayer.SetActive(false);
         _firstClanHeart.SetActive(true);
-        FirstOpenClanProfileButton.interactable = true;
 
         _secondAvatarHead.SetActive(false);
         _secondClanHeartPlayer.SetActive(false);
         _secondClanHeart.SetActive(true);
-        SecondOpenClanProfileButton.interactable = true;
 
         _thirdAvatarHead.SetActive(false);
         _thirdClanHeartPlayer.SetActive(false);
         _thirdClanHeart.SetActive(true);
-        ThirdOpenClanProfileButton.interactable = true;
+
+        foreach (GameObject button in _clanProfileButtons)
+        {
+            button.SetActive(true);
+        }
+
+        foreach (GameObject button in _playerProfileButtons)
+        {
+            button.SetActive(false);
+        }
     }
 }

--- a/Assets/MenuUi/Scripts/Leaderboard/LeaderboardView.cs
+++ b/Assets/MenuUi/Scripts/Leaderboard/LeaderboardView.cs
@@ -129,7 +129,7 @@ public class LeaderboardView : MonoBehaviour
                             {
                                 if (rank < 4)
                                 {
-                                    _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, null, null, ranking.Clan);
+                                    _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, ranking.Clan);
                                 }
                                 else
                                 {
@@ -155,7 +155,7 @@ public class LeaderboardView : MonoBehaviour
                             {
                                 if (rank < 4)
                                 {
-                                    _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, null, null, ranking.Clan);
+                                    _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, ranking.Clan);
                                 }
                                 else
                                 {
@@ -192,7 +192,7 @@ public class LeaderboardView : MonoBehaviour
 
                             if (rank < 4)
                             {
-                                _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, clanData, serverClan, null);
+                                _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, clanData, serverClan);
                             }
                             else
                             {
@@ -231,7 +231,7 @@ public class LeaderboardView : MonoBehaviour
 
                             if (rank < 4)
                             {
-                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardWins, null, null, playerData);
+                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardWins, playerData);
                             }
                             else
                             {
@@ -257,7 +257,7 @@ public class LeaderboardView : MonoBehaviour
                             {
                                 if (rank < 4)
                                 {
-                                    _podium.InitilializePodium(rank, "", 0, null, null, null);
+                                    _podium.InitilializePodium(rank, "", 0, null);
                                 }
                                 else
                                 {
@@ -280,7 +280,7 @@ public class LeaderboardView : MonoBehaviour
 
                             if (rank < 4)
                             {
-                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardCoins, null, null, playerData);
+                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardCoins, playerData);
                             }
                             else
                             {
@@ -306,7 +306,7 @@ public class LeaderboardView : MonoBehaviour
                             {
                                 if (rank < 4)
                                 {
-                                    _podium.InitilializePodium(rank, "", 0, null, null, null);
+                                    _podium.InitilializePodium(rank, "", 0, null);
                                 }
                                 else
                                 {
@@ -328,7 +328,7 @@ public class LeaderboardView : MonoBehaviour
                     {
                         if (i < 4)
                         {
-                            _podium.InitilializePodium(i, "", 0, null, null, null);
+                            _podium.InitilializePodium(i, "", 0, null);
                         }
                         else
                         {
@@ -349,7 +349,7 @@ public class LeaderboardView : MonoBehaviour
                     {
                         if (i < 4)
                         {
-                            _podium.InitilializePodium(i, "", 0, null, null, null);
+                            _podium.InitilializePodium(i, "", 0, null);
                         }
                         else
                         {

--- a/Assets/MenuUi/Scripts/Leaderboard/LeaderboardView.cs
+++ b/Assets/MenuUi/Scripts/Leaderboard/LeaderboardView.cs
@@ -227,20 +227,22 @@ public class LeaderboardView : MonoBehaviour
                         int rank = 1;
                         foreach (ClanMember player in clanData.Members)
                         {
+                            PlayerData playerData = player.GetPlayerData();
+
                             if (rank < 4)
                             {
-                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardWins, null, null, null);
+                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardWins, null, null, playerData);
                             }
                             else
                             {
                                 LeaderboardWinsItem item = Instantiate(_playerWinsItemPrefab, parent: _winsContent).GetComponent<LeaderboardWinsItem>();
                                 item.Initialize(rank, player.Name, player.LeaderBoardWins);
 
-                                // View player profile button
-                                //item.OpenProfileButton.onClick.AddListener(() =>
-                                //{
-                                //    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
-                                //});
+                                //View player profile button
+                                item.OpenProfileButton.onClick.AddListener(() =>
+                                {
+                                    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
+                                });
                             }
 
                             rank++;
@@ -274,9 +276,11 @@ public class LeaderboardView : MonoBehaviour
                         int rank = 1;
                         foreach (ClanMember player in clanData.Members)
                         {
+                            PlayerData playerData = player.GetPlayerData();
+
                             if (rank < 4)
                             {
-                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardCoins, null, null, null);
+                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardCoins, null, null, playerData);
                             }
                             else
                             {
@@ -284,10 +288,10 @@ public class LeaderboardView : MonoBehaviour
                                 item.Initialize(rank, player.Name, player.LeaderBoardCoins);
 
                                 // View player profile button
-                                //item.OpenProfileButton.onClick.AddListener(() =>
-                                //{
-                                //    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
-                                //});
+                                item.OpenProfileButton.onClick.AddListener(() =>
+                                {
+                                    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
+                                });
                             }
 
                             rank++;

--- a/Assets/MenuUi/Scripts/Leaderboard/LeaderboardView.cs
+++ b/Assets/MenuUi/Scripts/Leaderboard/LeaderboardView.cs
@@ -2,6 +2,7 @@
 using System;
 using Altzone.Scripts;
 using Altzone.Scripts.Model.Poco.Clan;
+using Altzone.Scripts.Model.Poco.Player;
 using MenuUi.Scripts.TabLine;
 using MenuUi.Scripts.Window;
 using UnityEngine;
@@ -128,12 +129,18 @@ public class LeaderboardView : MonoBehaviour
                             {
                                 if (rank < 4)
                                 {
-                                    _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, null, null);
+                                    _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, null, null, ranking.Clan);
                                 }
                                 else
                                 {
                                     LeaderboardWinsItem item = Instantiate(_playerWinsItemPrefab, parent: _winsContent).GetComponent<LeaderboardWinsItem>();
                                     item.Initialize(rank, ranking.Clan.Name, ranking.Points);
+
+                                    // View player profile button
+                                    item.OpenProfileButton.onClick.AddListener(() =>
+                                    {
+                                        DataCarrier.AddData(DataCarrier.PlayerProfile, ranking.Clan);
+                                    });
                                 }
 
                                 rank++;
@@ -148,12 +155,18 @@ public class LeaderboardView : MonoBehaviour
                             {
                                 if (rank < 4)
                                 {
-                                    _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, null, null);
+                                    _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, null, null, ranking.Clan);
                                 }
                                 else
                                 {
                                     LeaderboardActivityItem item = Instantiate(_playerActivityItemPrefab, parent: _activityContent).GetComponent<LeaderboardActivityItem>();
                                     item.Initialize(rank, ranking.Clan.Name, ranking.Points);
+
+                                    // View player profile button
+                                    item.OpenProfileButton.onClick.AddListener(() =>
+                                    {
+                                        DataCarrier.AddData(DataCarrier.PlayerProfile, ranking.Clan);
+                                    });
                                 }
 
                                 rank++;
@@ -179,7 +192,7 @@ public class LeaderboardView : MonoBehaviour
 
                             if (rank < 4)
                             {
-                                _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, clanData, serverClan);
+                                _podium.InitilializePodium(rank, ranking.Clan.Name, ranking.Points, clanData, serverClan, null);
                             }
                             else
                             {
@@ -216,12 +229,18 @@ public class LeaderboardView : MonoBehaviour
                         {
                             if (rank < 4)
                             {
-                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardWins, null, null);
+                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardWins, null, null, null);
                             }
                             else
                             {
                                 LeaderboardWinsItem item = Instantiate(_playerWinsItemPrefab, parent: _winsContent).GetComponent<LeaderboardWinsItem>();
                                 item.Initialize(rank, player.Name, player.LeaderBoardWins);
+
+                                // View player profile button
+                                //item.OpenProfileButton.onClick.AddListener(() =>
+                                //{
+                                //    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
+                                //});
                             }
 
                             rank++;
@@ -236,7 +255,7 @@ public class LeaderboardView : MonoBehaviour
                             {
                                 if (rank < 4)
                                 {
-                                    _podium.InitilializePodium(rank, "", 0, null, null);
+                                    _podium.InitilializePodium(rank, "", 0, null, null, null);
                                 }
                                 else
                                 {
@@ -257,12 +276,18 @@ public class LeaderboardView : MonoBehaviour
                         {
                             if (rank < 4)
                             {
-                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardCoins, null, null);
+                                _podium.InitilializePodium(rank, player.Name, player.LeaderBoardCoins, null, null, null);
                             }
                             else
                             {
                                 LeaderboardActivityItem item = Instantiate(_playerActivityItemPrefab, parent: _activityContent).GetComponent<LeaderboardActivityItem>();
                                 item.Initialize(rank, player.Name, player.LeaderBoardCoins);
+
+                                // View player profile button
+                                //item.OpenProfileButton.onClick.AddListener(() =>
+                                //{
+                                //    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
+                                //});
                             }
 
                             rank++;
@@ -277,7 +302,7 @@ public class LeaderboardView : MonoBehaviour
                             {
                                 if (rank < 4)
                                 {
-                                    _podium.InitilializePodium(rank, "", 0, null, null);
+                                    _podium.InitilializePodium(rank, "", 0, null, null, null);
                                 }
                                 else
                                 {
@@ -299,12 +324,18 @@ public class LeaderboardView : MonoBehaviour
                     {
                         if (i < 4)
                         {
-                            _podium.InitilializePodium(i, "", 0, null, null);
+                            _podium.InitilializePodium(i, "", 0, null, null, null);
                         }
                         else
                         {
                             LeaderboardWinsItem item = Instantiate(_playerWinsItemPrefab, parent: _winsContent).GetComponent<LeaderboardWinsItem>();
                             item.Initialize(i, "", 0);
+
+                            // View player profile button
+                            //item.OpenProfileButton.onClick.AddListener(() =>
+                            //{
+                            //    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
+                            //});
                         }
                     }
                 }
@@ -314,12 +345,18 @@ public class LeaderboardView : MonoBehaviour
                     {
                         if (i < 4)
                         {
-                            _podium.InitilializePodium(i, "", 0, null, null);
+                            _podium.InitilializePodium(i, "", 0, null, null, null);
                         }
                         else
                         {
                             LeaderboardActivityItem item = Instantiate(_playerActivityItemPrefab, parent: _activityContent).GetComponent<LeaderboardActivityItem>();
                             item.Initialize(i, "", 0);
+
+                            // View player profile button
+                            //item.OpenProfileButton.onClick.AddListener(() =>
+                            //{
+                            //    DataCarrier.AddData(DataCarrier.PlayerProfile, playerData);
+                            //});
                         }
                     }
                 }

--- a/Assets/MenuUi/Scripts/Leaderboard/LeaderboardWinsItem.cs
+++ b/Assets/MenuUi/Scripts/Leaderboard/LeaderboardWinsItem.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class LeaderboardWinsItem : MonoBehaviour
 {
@@ -9,6 +10,7 @@ public class LeaderboardWinsItem : MonoBehaviour
     [SerializeField] private TextMeshProUGUI _nameText;
     [SerializeField] private TextMeshProUGUI _winsText;
     [SerializeField] private ClanHeartColorSetter _clanHeart;
+    [field: SerializeField] public Button OpenProfileButton { get; private set; }
 
     public void Initialize(int rank, string name, int wins)
     {

--- a/Assets/MenuUi/Scripts/PlayerProfile/ProfileMenu.cs
+++ b/Assets/MenuUi/Scripts/PlayerProfile/ProfileMenu.cs
@@ -50,6 +50,7 @@ public class ProfileMenu : AltMonoBehaviour
     [SerializeField] private GameObject _characterOptionsPopup;
     [SerializeField] private Transform _characterOptionsContent;
     [SerializeField] private GameObject _characterOptionPrefab;
+    [SerializeField] private TextMeshProUGUI _characterSelectionMessage;
 
     [Header("Buttons")]
     [SerializeField] private Button _openMottoOptions;
@@ -95,8 +96,8 @@ public class ProfileMenu : AltMonoBehaviour
 
     private ServerPlayer _player;
 
-    private const string MottoDefault = "Paina tästä valitaksesi...";
-    private const string MottoDefaultOther = "Ei valittu";
+    private const string SelectionMessageDefault = "Paina tästä valitaksesi...";
+    private const string SelectionMessageDefaultOther = "Ei valittu";
 
     private string _tempFavoriteDefenceID;
 
@@ -219,6 +220,14 @@ public class ProfileMenu : AltMonoBehaviour
             {
                 _tempFavoriteDefenceID = character.Id;
                 _favoriteCharacterImage.sprite = character.GalleryImage;
+
+                //Show image
+                Image image = _favoriteCharacterImage;
+                var tempColor = image.color;
+                tempColor.a = 1f;
+                image.color = tempColor;
+                _characterSelectionMessage.text = "";
+
                 _characterOptionsPopup.SetActive(false);
                 _closePopupAreaButton.SetActive(false);
             });
@@ -311,27 +320,52 @@ public class ProfileMenu : AltMonoBehaviour
             CharacterClassID defenceClass = (CharacterClassID)((_playerData.SelectedCharacterId / 100) * 100);
             _DefenceClassText.text = defenceClass.ToString();
 
-            if (_playerData.ChosenMotto != null || _MottoText.text == "")
-            {
-                _MottoText.text = _playerData.ChosenMotto;
-            }
-            else
+            if (_playerData.ChosenMotto == null || _MottoText.text == "")
             {
                 if (_otherPlayerProfile)
                 {
-                    _MottoText.text = MottoDefaultOther;
+                    _MottoText.text = SelectionMessageDefaultOther;
                 }
                 else
                 {
-                    _MottoText.text = MottoDefault;
-                }
+                    _MottoText.text = SelectionMessageDefault;
+                } 
+            }
+            else
+            {
+                _MottoText.text = _playerData.ChosenMotto;
             }
 
             PlayerCharacterPrototype favoriteDefence = PlayerCharacterPrototypes.GetCharacter(_playerData.FavoriteDefenceID);
+            Image image = _favoriteCharacterImage;
+            var tempColor = image.color;
             if (favoriteDefence != null)
             {
-                _tempFavoriteDefenceID = _playerData.FavoriteDefenceID;
+                //Show image
+                tempColor.a = 1f;
+                image.color = tempColor;
+                _characterSelectionMessage.text = "";
+
+                if (!_otherPlayerProfile)
+                {
+                    _tempFavoriteDefenceID = _playerData.FavoriteDefenceID;
+                }
                 _favoriteCharacterImage.sprite = favoriteDefence.GalleryImage;
+            }
+            else
+            {
+                // Hide image
+                tempColor.a = 0f;
+                image.color = tempColor;
+
+                if (_otherPlayerProfile)
+                {
+                    _characterSelectionMessage.text = SelectionMessageDefaultOther;
+                }
+                else
+                {
+                    _characterSelectionMessage.text = SelectionMessageDefault;
+                }
             }
 
             store.GetClanData(_playerData.ClanId, clan =>
@@ -363,7 +397,6 @@ public class ProfileMenu : AltMonoBehaviour
     /// <summary>
     /// Disables editing when viewing other player's profile
     /// </summary>
-    /// <param name="otherPlayer"></param>
     private void ToggleProfileViewMode()
     {
         if (_otherPlayerProfile)
@@ -371,23 +404,33 @@ public class ProfileMenu : AltMonoBehaviour
             _openFavoriteDefenceSelection.interactable = false;
             _openMottoOptions.interactable = false;
             _saveEditsButton.gameObject.SetActive(false);
-            foreach(GameObject button in _playStyleButtons)
+            foreach (GameObject button in _playStyleButtons)
             {
                 button.SetActive(false);
             }
         }
         else
         {
-            _openFavoriteDefenceSelection.interactable = true;
-            _openMottoOptions.interactable = true;
-            if(_saveEditsButton != null)
+            if (_openFavoriteDefenceSelection != null)
+            {
+                _openFavoriteDefenceSelection.interactable = true;
+            }
+
+            if (_openMottoOptions != null)
+            {
+                _openMottoOptions.interactable = true;
+            }
+
+            if (_saveEditsButton != null)
             {
                 _saveEditsButton.gameObject.SetActive(true);
             }
-
             foreach (GameObject button in _playStyleButtons)
             {
-                button.SetActive(true);
+                if (button != null)
+                {
+                    button.SetActive(true);
+                } 
             }
         }
     }

--- a/Assets/MenuUi/Scripts/PlayerProfile/ProfileMenu.cs
+++ b/Assets/MenuUi/Scripts/PlayerProfile/ProfileMenu.cs
@@ -166,6 +166,7 @@ public class ProfileMenu : AltMonoBehaviour
     {
         _characterOptionsPopup.SetActive(false);
         _closePopupAreaButton.SetActive(false);
+        ServerManager.OnLogInStatusChanged -= SetPlayerProfileValues;
     }
 
     private void Reset()

--- a/Assets/MenuUi/Scripts/PlayerProfile/ProfileMenu.cs
+++ b/Assets/MenuUi/Scripts/PlayerProfile/ProfileMenu.cs
@@ -380,7 +380,11 @@ public class ProfileMenu : AltMonoBehaviour
         {
             _openFavoriteDefenceSelection.interactable = true;
             _openMottoOptions.interactable = true;
-            _saveEditsButton.gameObject.SetActive(true);
+            if(_saveEditsButton != null)
+            {
+                _saveEditsButton.gameObject.SetActive(true);
+            }
+
             foreach (GameObject button in _playStyleButtons)
             {
                 button.SetActive(true);

--- a/Assets/MenuUi/Scripts/PlayerProfile/ProfileMenu.cs
+++ b/Assets/MenuUi/Scripts/PlayerProfile/ProfileMenu.cs
@@ -17,6 +17,7 @@ using UnityEngine.EventSystems;
 using Altzone.Scripts.ReferenceSheets;
 using Altzone.Scripts.Model.Poco.Game;
 using Altzone.Scripts.ModelV2;
+using System.Data;
 
 public class ProfileMenu : AltMonoBehaviour
 {
@@ -261,69 +262,81 @@ public class ProfileMenu : AltMonoBehaviour
     /// </summary>
     private void SetPlayerProfileValues(bool isLoggedIn)
     {
-        if (isLoggedIn)
+        PlayerData player = DataCarrier.GetData<PlayerData>(DataCarrier.PlayerProfile);
+        var store = Storefront.Get();
+
+        if (player != null)
         {
-            //_BattleCharacter.AddComponent(typeof(Image));
-            //Img = Resources.Load<Sprite>(playerData.BattleCharacter.Name);
-            //_BattleCharacter.GetComponent<Image>().sprite = Img;
-            var store = Storefront.Get();
-            store.GetPlayerData(GameConfig.Get().PlayerSettings.PlayerGuid, p =>
-            {
-                if (p == null)
-                {
-                    Debug.LogError("Pelaajatietojen haku epäonnistui.");
-                    return;
-                }
-
-                _playerData = p;
-                _playerNameText.text = _playerData.Name;
-                _playerNameInputField.text = _playerData.Name;
-
-                _activityText.text = _playerData.points.ToString();
-                _WinsText.text = _playerData.stats.wonBattles.ToString();
-
-                CharacterClassID defenceClass = (CharacterClassID)((_playerData.SelectedCharacterId / 100) * 100);
-                _DefenceClassText.text = defenceClass.ToString();
-
-                _MottoText.text = _playerData.ChosenMotto;
-                if (_MottoText.text == "")
-                {
-                    _MottoText.text = MottoDefault;
-                }
-
-                PlayerCharacterPrototype favoriteDefence = PlayerCharacterPrototypes.GetCharacter(_playerData.FavoriteDefenceID);
-                if (favoriteDefence != null)
-                {
-                    _tempFavoriteDefenceID = _playerData.FavoriteDefenceID;
-                    _favoriteCharacterImage.sprite = favoriteDefence.GalleryImage;
-                }
-
-                store.GetClanData(_playerData.ClanId, clan =>
-                {
-                    if (clan == null)
-                    {
-                        _rolesErrorMessage.text = "Klaania ei löydetty.";
-                        Debug.LogError("Klaanitietojen haku epäonnistui.");
-                        return;
-                    }
-
-                    _clanData = clan;
-                    _playerClanNameText.text = _clanData.Name;
-                    _rolesErrorMessage.text = "Rooleja ei voitu hakea.";
-
-                    _clanID = _playerData.ClanId;
-                    _url = "https://altzone.fi/clans/" + _playerData.ClanId;
-                });
-            });
-
-            updateTime();
+            _playerData = player;
         }
         else
         {
-            Reset();
-        }
-    }
+            if (isLoggedIn)
+            {
+                store.GetPlayerData(GameConfig.Get().PlayerSettings.PlayerGuid, p =>
+                {
+                    if (p == null)
+                    {
+                        Debug.LogError("Pelaajatietojen haku epäonnistui.");
+                        return;
+                    }
 
+                    _playerData = p;
+                });
+            }
+            else
+            {
+                Reset();
+            }
+        }
+
+        _playerNameText.text = _playerData.Name;
+        _playerNameInputField.text = _playerData.Name;
+
+        _activityText.text = _playerData.points.ToString();
+        if (_playerData.stats != null)
+        {
+            _WinsText.text = _playerData.stats.wonBattles.ToString();
+        }
+
+        CharacterClassID defenceClass = (CharacterClassID)((_playerData.SelectedCharacterId / 100) * 100);
+        _DefenceClassText.text = defenceClass.ToString();
+
+        if (_playerData.ChosenMotto != null || _MottoText.text == "")
+        {
+            _MottoText.text = _playerData.ChosenMotto;
+        }
+        else
+        {
+            _MottoText.text = MottoDefault;
+        }
+
+        PlayerCharacterPrototype favoriteDefence = PlayerCharacterPrototypes.GetCharacter(_playerData.FavoriteDefenceID);
+        if (favoriteDefence != null)
+        {
+            _tempFavoriteDefenceID = _playerData.FavoriteDefenceID;
+            _favoriteCharacterImage.sprite = favoriteDefence.GalleryImage;
+        }
+
+        store.GetClanData(_playerData.ClanId, clan =>
+            {
+                if (clan == null)
+                {
+                    _rolesErrorMessage.text = "Klaania ei löydetty.";
+                    Debug.LogError("Klaanitietojen haku epäonnistui.");
+                    return;
+                }
+
+                _clanData = clan;
+                _playerClanNameText.text = _clanData.Name;
+                _rolesErrorMessage.text = "Rooleja ei voitu hakea.";
+
+                _clanID = _playerData.ClanId;
+                _url = "https://altzone.fi/clans/" + _playerData.ClanId;
+            });
+
+        updateTime();
+    }
 
     private void SaveMinutes()
     {

--- a/Assets/MenuUi/Scripts/Window/DataCarrier.cs
+++ b/Assets/MenuUi/Scripts/Window/DataCarrier.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Altzone.Scripts.Model.Poco.Clan;
+using Altzone.Scripts.Model.Poco.Player;
 using UnityEngine;
 
 namespace MenuUi.Scripts.Window
@@ -8,9 +9,11 @@ namespace MenuUi.Scripts.Window
     public class DataCarrier : MonoBehaviour
     {
         public const string ClanListing = "cl";
+        public const string PlayerProfile = "pp";
 
         public static DataCarrier Instance { get; private set; }
         public ServerClan clanToView;
+        public PlayerData playerToView;
 
         private static Dictionary<string, object> s_datastorage = new();
 
@@ -26,6 +29,7 @@ namespace MenuUi.Scripts.Window
                 DontDestroyOnLoad(this);
             }
             clanToView = null;
+            playerToView = null;
         }
 
         public static void AddData<T>(string key, T value) where T : class


### PR DESCRIPTION
- fixed the local data saving to right location
- Connected the profile to leaderboard; now when clicking the a player's ranking, the profile of that player is opened
- Added default message to favorite defence; when the defence is not chosen a message is now shown instead of the random defence sprite set in editor