### PR TITLE
BattlePopup bug fixes in player positioning and passing player slot and UserId info to Battle

### DIFF
--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -1010,7 +1010,7 @@ namespace Altzone.Scripts.Lobby
             yield return new WaitUntil(()=>SceneManager.GetActiveScene().name == _quantumBattleMap.Scene);
 
             DebugLogFileHandler.ContextEnter(DebugLogFileHandler.ContextID.Battle);
-            DebugLogFileHandler.FileOpen(battleID, playerSlot);
+            DebugLogFileHandler.FileOpen(battleID, (int)playerSlot);
 
             Task<bool> task = StartRunner(sessionRunnerArguments);
 

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -915,6 +915,7 @@ namespace Altzone.Scripts.Lobby
         {
             string battleID = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(BattleID);
             int playerPosition = PhotonRealtimeClient.LocalPlayer.GetCustomProperty<int>(PlayerPositionKey);
+            string userId = PhotonRealtimeClient.LocalPlayer.UserId;
 
             if (QuantumRunner.Default != null)
             {
@@ -990,6 +991,7 @@ namespace Altzone.Scripts.Lobby
             if(task.Result)
             {
                 _player.PlayerSlot = playerPosition;
+                _player.UserID = userId;
                 _runner?.Game.AddPlayer(_player);
             }
             else

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -1500,5 +1500,15 @@ namespace Altzone.Scripts.Lobby
 
             return result;
         }
+
+        public override string ToString()
+        {
+            return $"Start time: {StartTime}" +
+                 $"\nPlayerSlotUserIds: {string.Join(",", PlayerSlotUserIds)}" +
+                 $"\nPlayerSlotTypes: {string.Join(",",PlayerSlotTypes)}" +
+                 $"\nProjectileInitialEmotion: {ProjectileInitialEmotion}" +
+                 $"\nMapId: {MapId}" +
+                 $"\nPlayerCount: {PlayerCount}";  
+        }
     }
 }

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -918,6 +918,9 @@ namespace Altzone.Scripts.Lobby
         {
             Debug.Log(data.ToString());
             string battleID = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(BattleID);
+
+            // Getting the index of own user id from the player slot user id array to determine which player slot number is for local player.
+            // Adding + 1 since the player slot numbers start from 1 (1-4)
             string userId = PhotonRealtimeClient.LocalPlayer.UserId;
             int playerSlot = Array.IndexOf(data.PlayerSlotUserIds, userId) + 1;
 

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -86,8 +86,6 @@ namespace Altzone.Scripts.Lobby
         [Header("Battle Map reference")]
         [SerializeField] private BattleMapReference _battleMapReference;
 
-        private Emotion _projectileInitialEmotion = Emotion.Sorrow;
-
         private const long STARTDELAY = 6000;
 
         private QuantumRunner _runner = null;
@@ -921,10 +919,7 @@ namespace Altzone.Scripts.Lobby
             Debug.Log(data.ToString());
             string battleID = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(BattleID);
             string userId = PhotonRealtimeClient.LocalPlayer.UserId;
-            int playerPosition = Array.IndexOf(data.PlayerSlotUserIds, userId) + 1;
-
-            // Setting projectile initial emotion to a variable
-            _projectileInitialEmotion = data.ProjectileInitialEmotion;
+            int playerSlot = Array.IndexOf(data.PlayerSlotUserIds, userId) + 1;
 
             // Setting map to variable
             Map map = _battleMapReference.GetBattleMap(data.MapId).Map;
@@ -950,7 +945,7 @@ namespace Altzone.Scripts.Lobby
                     PlayerSlotTypes = data.PlayerSlotTypes,
                     PlayerSlotUserIDs = data.PlayerSlotUserIds,
                     PlayerCount = data.PlayerCount,
-                    ProjectileInitialEmotion = (BattleEmotionState)_projectileInitialEmotion
+                    ProjectileInitialEmotion = (BattleEmotionState)data.ProjectileInitialEmotion
                 }
             };
 
@@ -999,14 +994,14 @@ namespace Altzone.Scripts.Lobby
             yield return new WaitUntil(()=>SceneManager.GetActiveScene().name == _quantumBattleMap.Scene);
 
             DebugLogFileHandler.ContextEnter(DebugLogFileHandler.ContextID.Battle);
-            DebugLogFileHandler.FileOpen(battleID, playerPosition);
+            DebugLogFileHandler.FileOpen(battleID, playerSlot);
 
             Task<bool> task = StartRunner(sessionRunnerArguments);
 
             yield return new WaitUntil(() => task.IsCompleted);
             if(task.Result)
             {
-                _player.PlayerSlot = playerPosition;
+                _player.PlayerSlot = playerSlot;
                 _player.UserID = userId;
                 _runner?.Game.AddPlayer(_player);
             }
@@ -1507,8 +1502,8 @@ namespace Altzone.Scripts.Lobby
         public override string ToString()
         {
             return $"Start time: {StartTime}" +
-                 $"\nPlayerSlotUserIds: {string.Join(",", PlayerSlotUserIds)}" +
-                 $"\nPlayerSlotTypes: {string.Join(",",PlayerSlotTypes)}" +
+                 $"\nPlayerSlotUserIds: {string.Join(", ", PlayerSlotUserIds)}" +
+                 $"\nPlayerSlotTypes: {string.Join(", ",PlayerSlotTypes)}" +
                  $"\nProjectileInitialEmotion: {ProjectileInitialEmotion}" +
                  $"\nMapId: {MapId}" +
                  $"\nPlayerCount: {PlayerCount}";  

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -13,6 +13,8 @@ using Photon.Client;
 using Photon.Realtime;
 using Quantum;
 
+using Prg.Scripts.Common.PubSub;
+
 using Altzone.Scripts.Config;
 using Altzone.Scripts.Settings;
 using Altzone.Scripts.Common;
@@ -22,11 +24,10 @@ using Altzone.Scripts.ModelV2;
 using Altzone.Scripts.Battle.Photon;
 using Altzone.Scripts.Lobby.Wrappers;
 using Altzone.Scripts.AzDebug;
-using Prg.Scripts.Common.PubSub;
+using Altzone.PhotonSerializer;
 
 using Battle.QSimulation.Game;
-using static Battle.QSimulation.Game.BattleParameters;
-using Altzone.PhotonSerializer;
+using PlayerType = Battle.QSimulation.Game.BattleParameters.PlayerType;
 
 namespace Altzone.Scripts.Lobby
 {
@@ -885,7 +886,8 @@ namespace Altzone.Scripts.Lobby
                 data = new()
                 {
                     StartTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                    //PlayerSlotUserIds = player;
+                    PlayerSlotUserIds = playerUserIds,
+                    PlayerSlotTypes = playerTypes,
                     ProjectileInitialEmotion = startingEmotion,
                     MapId = mapId,
                     PlayerCount = playerCount
@@ -1477,6 +1479,7 @@ namespace Altzone.Scripts.Lobby
             byte[] bytes = new byte[0];
             Serializer.Serialize(b.StartTime, ref bytes);
             Serializer.Serialize(b.PlayerSlotUserIds, ref bytes);
+            Serializer.Serialize(b.PlayerSlotTypes.Cast<int>().ToArray(), ref bytes);
             Serializer.Serialize((int)b.ProjectileInitialEmotion, ref bytes);
             Serializer.Serialize(b.MapId, ref bytes);
             Serializer.Serialize(b.PlayerCount, ref bytes);
@@ -1490,6 +1493,7 @@ namespace Altzone.Scripts.Lobby
             int offset = 0;
             result.StartTime = Serializer.DeserializeLong(data, ref offset);
             result.PlayerSlotUserIds = Serializer.DeserializeStringArray(data, ref offset);
+            result.PlayerSlotTypes = Serializer.DeserializeIntArray(data, ref offset).Cast<PlayerType>().ToArray();
             result.ProjectileInitialEmotion = (Emotion)Serializer.DeserializeInt(data, ref offset);
             result.MapId = Serializer.DeserializeString(data, ref offset);
             result.PlayerCount = Serializer.DeserializeInt(data, ref offset);

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -918,9 +918,10 @@ namespace Altzone.Scripts.Lobby
 
         private IEnumerator StartQuantum(StartGameData data)
         {
+            Debug.Log(data.ToString());
             string battleID = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(BattleID);
             string userId = PhotonRealtimeClient.LocalPlayer.UserId;
-            int playerPosition = Array.IndexOf(data.PlayerSlotUserIds, userId);
+            int playerPosition = Array.IndexOf(data.PlayerSlotUserIds, userId) + 1;
 
             // Setting projectile initial emotion to a variable
             _projectileInitialEmotion = data.ProjectileInitialEmotion;
@@ -1311,7 +1312,9 @@ namespace Altzone.Scripts.Lobby
             switch (photonEvent.Code)
             {
                 case PhotonRealtimeClient.PhotonEvent.StartGame:
-                    StartCoroutine(StartQuantum(StartGameData.Deserialize((byte[])photonEvent.CustomData)));
+                    // For some reason sometimes in Android build the CustomData is a ByteArraySlice and causes errors, so doing a null check to the cast
+                    byte[] byteArray = photonEvent.CustomData as byte[] ?? ((ByteArraySlice)photonEvent.CustomData).Buffer;
+                    StartCoroutine(StartQuantum(StartGameData.Deserialize(byteArray)));
                     break;
                 case PhotonRealtimeClient.PhotonEvent.PlayerPositionChangeRequested:
                     int position = (int)photonEvent.CustomData;

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -932,10 +932,10 @@ namespace Altzone.Scripts.Lobby
             Debug.Log(data.ToString());
             string battleID = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(BattleID);
 
-            // Getting the index of own user id from the player slot user id array to determine which player slot number is for local player.
-            // Adding + 1 since the player slot numbers start from 1 (1-4)
+            // Getting the index of own user id from the player slot user id array to determine which player slot is for local player.
             string userId = PhotonRealtimeClient.LocalPlayer.UserId;
-            int playerSlot = Array.IndexOf(data.PlayerSlotUserIds, userId) + 1;
+            int slotIndex = Array.IndexOf(data.PlayerSlotUserIds, userId);
+            BattlePlayerSlot playerSlot = RuntimePlayer.PlayerSlots[slotIndex];
 
             // Setting map to variable
             Map map = _battleMapReference.GetBattleMap(data.MapId).Map;

--- a/Assets/MenuUi/Prefabs/UI Components/Battle Popup.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/Battle Popup.prefab
@@ -1023,7 +1023,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 55.2
+  m_fontSize: 72
   m_fontSizeBase: 55.15
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -5154,7 +5154,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 1, g: 1, b: 1, a: 1}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -5168,7 +5168,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 718369987952328105}
   m_OnClick:
     m_PersistentCalls:
@@ -5606,7 +5606,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 1, g: 1, b: 1, a: 1}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -5620,7 +5620,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 3410731086188374011}
   m_OnClick:
     m_PersistentCalls:
@@ -8383,7 +8383,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 1, g: 1, b: 1, a: 1}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -8397,7 +8397,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 2030874350614321034}
   m_OnClick:
     m_PersistentCalls:
@@ -8795,7 +8795,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 39.45
+  m_fontSize: 52.6
   m_fontSizeBase: 55.15
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -11045,7 +11045,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 45.65
+  m_fontSize: 60.9
   m_fontSizeBase: 55.15
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -11828,7 +11828,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 1, g: 1, b: 1, a: 1}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -11842,7 +11842,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 8852048676883154730}
   m_OnClick:
     m_PersistentCalls:
@@ -13078,7 +13078,7 @@ PrefabInstance:
     - target: {fileID: 4028375515925020952, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_fontSize
-      value: 41.7
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 4028375515925020952, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}

--- a/Assets/MenuUi/Scripts/Lobby/BattleButton/BattleButton.cs
+++ b/Assets/MenuUi/Scripts/Lobby/BattleButton/BattleButton.cs
@@ -42,8 +42,8 @@ namespace MenuUi.Scripts.Lobby.BattleButton
             _button = GetComponent<Button>();
             _button.onClick.AddListener(RequestBattlePopup);
 
-            // Loading selected game type from player prefs
-            _selectedGameType = (GameType)PlayerPrefs.GetInt(SelectedGameTypeKey, (int)_selectedGameType);
+            // Loading selected game type from player prefs Note: Only custom available for now
+            _selectedGameType = GameType.Custom; //(GameType)PlayerPrefs.GetInt(SelectedGameTypeKey, (int)_selectedGameType);
 
             // Instantiate game type option buttons to game type selection menu
             foreach (GameTypeInfo gameTypeInfo in _gameTypeReference.GetGameTypeInfos())

--- a/Assets/MenuUi/Scripts/Lobby/BattleButton/GameTypeOption.cs
+++ b/Assets/MenuUi/Scripts/Lobby/BattleButton/GameTypeOption.cs
@@ -63,7 +63,7 @@ namespace MenuUi.Scripts.Lobby.BattleButton
             _gameTypeInfo = info;
             SetSelected(selected);
 
-            if(info.gameType == GameType.Clan2v2)
+            if(info.gameType != GameType.Custom)
             {
                 ButtonComponent.interactable = false;
                 _settingsButton.gameObject.SetActive(false);

--- a/Assets/MenuUi/Scripts/Lobby/InLobby/InLobbyController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InLobby/InLobbyController.cs
@@ -202,6 +202,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
 
         public void CloseWindow()
         {
+            _roomSwitcher.ClosePanels();
             _popupContents.SetActive(false);
         }
 

--- a/Assets/MenuUi/Scripts/Lobby/InRoom/RoomSetupManager.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InRoom/RoomSetupManager.cs
@@ -91,6 +91,11 @@ namespace MenuUi.Scripts.Lobby.InRoom
             Spectator
         }
 
+        private void Awake()
+        {
+            LobbyManager.LobbyOnLeftRoom += OnLocalPlayerLeftRoom;
+        }
+
         private void OnEnable()
         {
             _selectedCharactersEditable.SelectedCharactersChanged += UpdateCharactersAndStatsKey;
@@ -120,6 +125,11 @@ namespace MenuUi.Scripts.Lobby.InRoom
             PhotonRealtimeClient.RemoveCallbackTarget(this);
         }
 
+        private void OnDestroy()
+        {
+            LobbyManager.LobbyOnLeftRoom -= OnLocalPlayerLeftRoom;
+        }
+
         private IEnumerator OnEnableInRoom()
         {
             yield return new WaitUntil(() => PhotonRealtimeClient.InRoom);
@@ -144,6 +154,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
                 // Updating room status and stopping coroutine
                 UpdateStatus();
+                _onEnableCoroutineHolder = null;
                 yield break;
             }
 
@@ -418,10 +429,11 @@ namespace MenuUi.Scripts.Lobby.InRoom
             _captionPlayerP4 = "Pelaaja 4";
         }
 
-        private static void SetButtonActive(Selectable selectable, bool active)
+        private static void SetButtonActive(Selectable selectable, bool active, bool interactable = true)
         {
             if (selectable == null) return;
             selectable.gameObject.SetActive(active);
+            selectable.interactable = interactable;
         }
 
         void OnPlayerEnteredRoom(LobbyPlayer newPlayer)
@@ -447,6 +459,16 @@ namespace MenuUi.Scripts.Lobby.InRoom
         void OnMasterClientSwitched(LobbyPlayer newMasterClient)
         {
             UpdateStatus();
+        }
+
+        private void OnLocalPlayerLeftRoom()
+        {
+            _firstOnEnable = true;
+
+            SetButtonActive(_buttonPlayerP1, true, false);
+            SetButtonActive(_buttonPlayerP2, true, false);
+            SetButtonActive(_buttonPlayerP3, true, false);
+            SetButtonActive(_buttonPlayerP4, true, false);
         }
     }
 }

--- a/Assets/QuantumUser/Simulation/Battle/Scripts/Game/BattleQConfig.cs
+++ b/Assets/QuantumUser/Simulation/Battle/Scripts/Game/BattleQConfig.cs
@@ -44,7 +44,28 @@ namespace Battle.QSimulation.Game
     [Serializable]
     public struct BattleParameters
     {
+        public enum PlayerType
+        {
+            None = 0,
+            Player = 1,
+            Bot = 2,
+        }
+
+        public PlayerType[] PlayerSlotTypes;
+        public string[] PlayerSlotUserIDs;
+
+        public int PlayerCount;
+
         public BattleEmotionState ProjectileInitialEmotion;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static PlayerType[] GetPlayerSlotTypes(Frame f) => f.RuntimeConfig.BattleParameters.PlayerSlotTypes;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string[] GetPlayerSlotUserIDs(Frame f) => f.RuntimeConfig.BattleParameters.PlayerSlotUserIDs;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetPlayerCount(Frame f) => f.RuntimeConfig.BattleParameters.PlayerCount;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static BattleEmotionState GetProjectileInitialEmotion(Frame f) => f.RuntimeConfig.BattleParameters.ProjectileInitialEmotion;

--- a/Assets/QuantumUser/Simulation/Battle/Scripts/Player/BattlePlayerManager.cs
+++ b/Assets/QuantumUser/Simulation/Battle/Scripts/Player/BattlePlayerManager.cs
@@ -37,7 +37,7 @@ namespace Battle.QSimulation.Player
 
             RuntimePlayer data = f.GetPlayerData(playerRef);
 
-            BattlePlayerSlot playerSlot = (BattlePlayerSlot)data.PlayerSlot;
+            BattlePlayerSlot playerSlot = data.PlayerSlot;
             BattleTeamNumber teamNumber = PlayerHandleInternal.GetTeamNumber(playerSlot);
             PlayerHandleInternal playerHandle = PlayerHandleInternal.GetPlayerHandle(playerManagerData, playerSlot);
 

--- a/Assets/QuantumUser/Simulation/RuntimePlayer.User.cs
+++ b/Assets/QuantumUser/Simulation/RuntimePlayer.User.cs
@@ -5,8 +5,10 @@
         public const int PlayerSlotCount = Constants.BATTLE_PLAYER_SLOT_COUNT;
         public const int CharacterCount = Constants.BATTLE_PLAYER_CHARACTER_COUNT;
 
+        public static readonly BattlePlayerSlot[] PlayerSlots = { BattlePlayerSlot.Slot1, BattlePlayerSlot.Slot2, BattlePlayerSlot.Slot3, BattlePlayerSlot.Slot4 };
+
         public string UserID;
-        public int PlayerSlot;
+        public BattlePlayerSlot PlayerSlot;
         public BattleCharacterBase[] Characters = new BattleCharacterBase[CharacterCount];
     }
 }

--- a/Assets/QuantumUser/Simulation/RuntimePlayer.User.cs
+++ b/Assets/QuantumUser/Simulation/RuntimePlayer.User.cs
@@ -5,6 +5,7 @@
         public const int PlayerSlotCount = Constants.BATTLE_PLAYER_SLOT_COUNT;
         public const int CharacterCount = Constants.BATTLE_PLAYER_CHARACTER_COUNT;
 
+        public string UserID;
         public int PlayerSlot;
         public BattleCharacterBase[] Characters = new BattleCharacterBase[CharacterCount];
     }


### PR DESCRIPTION
- Added UserID variable to RuntimePlayer.User.cs, passing it to battle in StartQuantum coroutine.
- Added more parameters to BattleParameters in BattleQConfig.cs; PlayerSlotTypes, PlayerSlotUserIDs and PlayerCount, also added getters. Passing those to battle in StartQuantum coroutine.
- Passing the different start game parameters with StartGameData for every client. This solves positioning bugs.
- When about to deserialize the StartGame photon event's CustomData, sometimes the data would be passed to the client as ByteArraySlice, and it caused an error and the player unable to join a game, so doing a null check in case it is a ByteArraySlice. I don't know why it happens but it happened in Bluestacks Android build.
- Disabled Collector2v2 game type for now.
- Fixed bug that the initial projectile emotion and map id was only assigned for master client. Passing them in StartGameData and setting them to variables in StartQuantum coroutine.

Marked pull request as draft since I will work on these 2 bugs tomorrow:
- Sometimes null reference error when trying to create a custom room. (Error is pasted to the issue) Couldn't trigger this so maybe it's not an issue anymore?
- Sometimes even though player joined the room their UserId doesn't update before the game starts so the game starts with 4 players but the newest player isn't in any position. -> Solved, it was because the player didn't yet reserve a position before the game started, also the player might've had a old position in custom properties which overrided another player's position.
- I will also do more testing to discover more bugs: Fixed a bug with the first position of the room being unable to be entered, if entered a room 2nd time. Fixed bug that RoomSetupManager OnEnableInRoom coroutine was stopped the 2nd time when entering a room.