### PR TITLE
Updated piechart visuals and removed the 10 limit for increasing stats

### DIFF
--- a/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
@@ -46,7 +46,6 @@ namespace Altzone.Scripts.Model.Poco.Game
         public const int STATMAXCOMBINED = 50;
         public const int STATMAXLEVEL = 24;
         public const int STATMINLEVEL = 1;
-        public const int STATMAXPLAYERINCREASE = 10;
 
         public CustomCharacter(CharacterID id, int hp, int speed, int resistance, int attack, int defence)
         {

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/PieChart.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/PieChart.cs
@@ -193,7 +193,14 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
             // Modify image properties
             Image sliceImage = slice.GetComponent<Image>();
 
-            sliceImage.sprite = isBaseSlice ? _circlePatternedSprite : _circleSprite;
+            if (isBaseSlice && color != _defaultColor && color != _defaultAltColor)
+            {
+                sliceImage.sprite = _circlePatternedSprite;
+            }
+            else
+            {
+                sliceImage.sprite = _circleSprite;
+            }
 
             sliceImage.color = color;
             sliceImage.type = Image.Type.Filled;

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/PieChart.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/PieChart.cs
@@ -193,14 +193,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
             // Modify image properties
             Image sliceImage = slice.GetComponent<Image>();
 
-            if (!isBaseSlice)
-            {
-                sliceImage.sprite = _circlePatternedSprite;
-            }
-            else
-            {
-                sliceImage.sprite = _circleSprite;
-            }
+            sliceImage.sprite = isBaseSlice ? _circlePatternedSprite : _circleSprite;
 
             sliceImage.color = color;
             sliceImage.type = Image.Type.Filled;

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
@@ -579,13 +579,9 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
                 {
                     PopupSignalBus.OnChangePopupInfoSignal($"Et voi p‰ivitt‰‰ taitoa, maksimitaso on {CustomCharacter.STATMAXLEVEL}.");
                 }
-                else if (!CheckMaxPlayerIncreases())
-                {
-                    PopupSignalBus.OnChangePopupInfoSignal($"Et voi p‰ivitt‰‰ taitoja enemm‰n kuin {CustomCharacter.STATMAXPLAYERINCREASE} kertaa."); // when every characters' combined base stats are 40 remove this
-                }
             }
 
-            return statType != StatType.None && CheckCombinedLevelCap() && CheckStatLevelCap(statType) && CheckMaxPlayerIncreases();
+            return statType != StatType.None && CheckCombinedLevelCap() && CheckStatLevelCap(statType);
         }
 
 
@@ -744,20 +740,5 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
             return allowedToIncrease;
         }
-
-
-        // Check if player has increased stats for max allowed player increases
-        private bool CheckMaxPlayerIncreases()
-        {
-            if (GetStatsCombined() - GetBaseStatsCombined() < CustomCharacter.STATMAXPLAYERINCREASE)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
     }
 }


### PR DESCRIPTION
- Using the new dna patterned circle for base stats instead of updated stats.
- Removed the 10 time stat increase limit from StatsWindowController.cs and the const variable from CustomCharacter.cs