### PR TITLE
Alt/feature - Battle CharacterSpec and BattleLink

### DIFF
--- a/Assets/Altzone/Editor/CustomEditors/CharacterSpecEditor.cs
+++ b/Assets/Altzone/Editor/CustomEditors/CharacterSpecEditor.cs
@@ -22,7 +22,8 @@ namespace Altzone.Editor.CustomEditors
         SerializedProperty Defence;
         SerializedProperty GalleryImage;
         SerializedProperty GalleryHeadImage;
-        SerializedProperty BattleSprite;
+        SerializedProperty BattleEntityPrototype;
+        SerializedProperty BattleUiSprite;
 
         int _prevHp = 0;
         int _prevSpeed = 0;
@@ -40,7 +41,8 @@ namespace Altzone.Editor.CustomEditors
             Defence = serializedObject.FindProperty(nameof(CharacterSpec.Defence));
             GalleryImage = serializedObject.FindProperty(nameof(CharacterSpec.GalleryImage));
             GalleryHeadImage = serializedObject.FindProperty(nameof(CharacterSpec.GalleryHeadImage));
-            BattleSprite = serializedObject.FindProperty(nameof(CharacterSpec.BattleSprite));
+            BattleEntityPrototype = serializedObject.FindProperty(nameof(CharacterSpec.BattleEntityPrototype));
+            BattleUiSprite = serializedObject.FindProperty(nameof(CharacterSpec.BattleUiSprite));
         }
         public override void OnInspectorGUI()
         {
@@ -144,7 +146,8 @@ namespace Altzone.Editor.CustomEditors
             EditorGUILayout.PropertyField(GalleryHeadImage);
 
             EditorGUILayout.Space();
-            EditorGUILayout.PropertyField(BattleSprite);
+            EditorGUILayout.PropertyField(BattleEntityPrototype);
+            EditorGUILayout.PropertyField(BattleUiSprite);
 
             EditorGUILayout.LabelField("");
         }

--- a/Assets/Altzone/Scripts/ApplicationController.cs
+++ b/Assets/Altzone/Scripts/ApplicationController.cs
@@ -41,7 +41,7 @@ namespace Altzone.Scripts
                 .ToString();
             Debug.Log(startupMessage);
 
-            AltzoneBattleLink.Int();
+            AltzoneBattleLink.Init();
 
             InstantiateGlobalGameObjects();
         }

--- a/Assets/Altzone/Scripts/ApplicationController.cs
+++ b/Assets/Altzone/Scripts/ApplicationController.cs
@@ -41,6 +41,8 @@ namespace Altzone.Scripts
                 .ToString();
             Debug.Log(startupMessage);
 
+            AltzoneBattleLink.Int();
+
             InstantiateGlobalGameObjects();
         }
 

--- a/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs
+++ b/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs
@@ -1,0 +1,20 @@
+
+using Quantum;
+
+using Battle.QSimulation.Game;
+
+public static class AltzoneBattleLink
+{
+    public static void Int()
+    {
+        BattleAltzoneLink.InitLink(
+            getCharacterPrototypeFnRef: GetCharacterPrototype
+        );
+    }
+
+    private static AssetRef<EntityPrototype> GetCharacterPrototype(int characterID)
+    {
+        // add implementation
+        return null;
+    }
+}

--- a/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs
+++ b/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs
@@ -1,18 +1,16 @@
 
+using System.Runtime.CompilerServices;
 using Quantum;
 
-using Battle.QSimulation.Game;
-
 using Altzone.Scripts.ModelV2;
+using Battle.QSimulation.Game;
 
 public static class AltzoneBattleLink
 {
-    public static void Int()
-    {
-        BattleAltzoneLink.InitLink(
-            getCharacterPrototypeFnRef: GetCharacterPrototype
-        );
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Init() => BattleAltzoneLink.InitLink(
+        getCharacterPrototypeFnRef: GetCharacterPrototype
+    );
 
     private static AssetRef<EntityPrototype> GetCharacterPrototype(int characterID)
     {

--- a/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs
+++ b/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs
@@ -17,6 +17,6 @@ public static class AltzoneBattleLink
     private static AssetRef<EntityPrototype> GetCharacterPrototype(int characterID)
     {
         PlayerCharacterPrototype info = PlayerCharacterPrototypes.GetCharacter(characterID.ToString());
-        return info != null ? info.BattleEntityPrototype: null;
+        return info != null ? info.BattleEntityPrototype : null;
     }
 }

--- a/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs
+++ b/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs
@@ -3,6 +3,8 @@ using Quantum;
 
 using Battle.QSimulation.Game;
 
+using Altzone.Scripts.ModelV2;
+
 public static class AltzoneBattleLink
 {
     public static void Int()
@@ -14,7 +16,7 @@ public static class AltzoneBattleLink
 
     private static AssetRef<EntityPrototype> GetCharacterPrototype(int characterID)
     {
-        // add implementation
-        return null;
+        PlayerCharacterPrototype info = PlayerCharacterPrototypes.GetCharacter(characterID.ToString());
+        return info != null ? info.BattleEntityPrototype: null;
     }
 }

--- a/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs.meta
+++ b/Assets/Altzone/Scripts/Battle/AltzoneBattleLink.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5fbe958418189541ab8dc7f6d054d94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Altzone/Scripts/ModelV2/Internal/CharacterSpec.cs
+++ b/Assets/Altzone/Scripts/ModelV2/Internal/CharacterSpec.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using Altzone.Scripts.Model.Poco.Game;
 using UnityEngine;
 using Object = UnityEngine.Object;
+using Quantum;
 
 namespace Altzone.Scripts.ModelV2.Internal
 {
@@ -99,7 +100,9 @@ namespace Altzone.Scripts.ModelV2.Internal
         /// Battle sprite sheet for something.
         /// TODO: add relevant doc comment here!
         /// </summary>
-        [Header("Battle Asset References")] public Sprite BattleSprite;
+        [Header("Battle Asset References")]
+        public AssetRef<EntityPrototype> BattleEntityPrototype;
+        public Sprite BattleUiSprite;
 
         #endregion
 
@@ -117,10 +120,12 @@ namespace Altzone.Scripts.ModelV2.Internal
         public override string ToString()
         {
             return $"{Id}:{ClassType}:{Name}" +
-                   $", {ResName(GalleryImage)}" +
-                   $", {ResName(BattleSprite)}";
+                   $", {UResName(GalleryImage)}" +
+                   $", {QResName(BattleEntityPrototype)}" +
+                   $", {UResName(BattleUiSprite)}";
 
-            string ResName(Object instance) => $"{(instance == null ? "null" : instance.name)}";
+            string UResName(Object instance) => $"{(instance == null ? "null" : instance.name)}";
+            string QResName<T>(AssetRef<T> instance) where T : AssetObject => $"{(instance == null ? "null" : instance.ToString())}";
         }
     }
 }

--- a/Assets/Altzone/Scripts/ModelV2/PlayerCharacterPrototype.cs
+++ b/Assets/Altzone/Scripts/ModelV2/PlayerCharacterPrototype.cs
@@ -1,5 +1,6 @@
 using Altzone.Scripts.Model.Poco.Game;
 using Altzone.Scripts.ModelV2.Internal;
+using Quantum;
 using UnityEngine;
 
 namespace Altzone.Scripts.ModelV2
@@ -29,6 +30,8 @@ namespace Altzone.Scripts.ModelV2
         public string Name => _characterSpec.Name;
         public Sprite GalleryImage => _characterSpec.GalleryImage;
         public Sprite GalleryHeadImage => _characterSpec.GalleryHeadImage;
+        public AssetRef<EntityPrototype> BattleEntityPrototype => _characterSpec.BattleEntityPrototype;
+        public Sprite BattleUiSprite => _characterSpec.BattleUiSprite;
         public string Description => _characterSpec.CharacterDescription;
         public string ShortDescription => _characterSpec.CharacterShortDescription;
 

--- a/Assets/QuantumUser/Simulation/Battle/Scripts/Game/BattleAltzoneLink.cs
+++ b/Assets/QuantumUser/Simulation/Battle/Scripts/Game/BattleAltzoneLink.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Runtime.CompilerServices;
+using Quantum;
+
+namespace Battle.QSimulation.Game
+{
+    public static class BattleAltzoneLink
+    {
+        public static void InitLink(
+            Func<int, AssetRef<EntityPrototype>> getCharacterPrototypeFnRef
+        )
+        {
+            s_getCharacterPrototypeFnRef = getCharacterPrototypeFnRef;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static AssetRef<EntityPrototype> GetCharacterPrototype(int id) => s_getCharacterPrototypeFnRef(id);
+
+        private static Func<int, AssetRef<EntityPrototype>> s_getCharacterPrototypeFnRef;
+    }
+}

--- a/Assets/QuantumUser/Simulation/Battle/Scripts/Game/BattleAltzoneLink.cs.meta
+++ b/Assets/QuantumUser/Simulation/Battle/Scripts/Game/BattleAltzoneLink.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23f33147a7bd56a468d93908ac0b2476
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Updated CharacterSpec Battle Asset References to have assets that are relevant to what is needed in Battle.
Added a way for Battle Quantum Simulation to get data from the Altzone assembly that avoids circular dependencies.

- CharacterSpec ScriptableObject
  - Removed BattleSprite
  - Added BattleEntityPrototype
  - Added BattleUiSprite

- Added AltzoneBattleLink class
  AltzoneBattleLink is in the Altzone assembly.
  AltzoneBattleLink is initialized by ApplicationController during OnApplicationStart.
  AltzoneBattleLink has private getter methods for data in the Altzone assembly. (currently just GetCharacterPrototype but more can be added as needed)
  During initialization AltzoneBattleLink sends references to the getter methods to BattleAltzoneLink.

- Added BattleAltzoneLink class
  BattleAltzoneLink is in the Battle Quantum Simulation. (Quantum assembly)
  BattleAltzoneLink has a method for receiving the getter method references from AltzoneBattleLink.
  BattleAltzoneLink stores the references and has public wrappers for calling the getter method references.
