### PR TITLE
Battle/feature - Setting for debug stats overlay

### DIFF
--- a/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
+++ b/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
@@ -40,6 +40,7 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
     public event Action<CharacterID> OnCharacterGalleryCharacterStatWindowToShowChange;
 
     // Constants
+    public const string BattleShowDebugStatsOverlayKey = "BattleStatsOverlay";
     public const string BattleArenaScaleKey = "BattleUiArenaScale";
     public const string BattleArenaPosXKey = "BattleUiPosX";
     public const string BattleArenaPosYKey = "BattleUiPosY";
@@ -91,6 +92,18 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
                 OnCharacterGalleryCharacterStatWindowToShowChange?.Invoke(_characterGalleryCharacterStatWindowToShow);
                 Debug.Log("CharacterGallery value changed" + _characterGalleryCharacterStatWindowToShow);
             }
+        }
+    }
+
+    private bool _battleShowDebugStatsOverlay;
+    public bool BattleShowDebugStatsOverlay
+    {
+        get => _battleShowDebugStatsOverlay;
+        set
+        {
+            if (_battleShowDebugStatsOverlay == value) return;
+            _battleShowDebugStatsOverlay = value;
+            PlayerPrefs.SetInt(BattleShowDebugStatsOverlayKey, value ? 1 : 0);
         }
     }
 
@@ -156,6 +169,8 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
         menuVolume = PlayerPrefs.GetFloat("MenuVolume", 1);
         musicVolume = PlayerPrefs.GetFloat("MusicVolume", 1);
         soundVolume = PlayerPrefs.GetFloat("SoundVolume", 1);
+
+        _battleShowDebugStatsOverlay = PlayerPrefs.GetInt(BattleShowDebugStatsOverlayKey, 0) == 1;
 
         _battleArenaScale = PlayerPrefs.GetInt(BattleArenaScaleKey, BattleArenaScaleDefault);
         _battleArenaPosX = PlayerPrefs.GetInt(BattleArenaPosXKey, BattleArenaPosXDefault);

--- a/Assets/QuantumUser/View/Battle/Scripts/Game/BattleGameViewController.cs
+++ b/Assets/QuantumUser/View/Battle/Scripts/Game/BattleGameViewController.cs
@@ -241,6 +241,7 @@ namespace Battle.View.Game
 
         private void QEventDebugOnUpdateStatsOverlay(EventBattleDebugUpdateStatsOverlay e)
         {
+            if (!SettingsCarrier.Instance.BattleShowDebugStatsOverlay) return;
             _uiController.DebugStatsOverlayHandler.SetShow(true);
             _uiController.DebugStatsOverlayHandler.SetStats(e.Character);
         }


### PR DESCRIPTION
- Added setting for BattleShowDebugStatsOverlay to SettingsCarrier.cs. By default it's false.
- Checking for the setting in BattleGameViewController.cs before showing stats overlay.