### PR TITLE
Refactored opening stat popup and switched buttons for opening editing panel and stat popup in SelectedCharSlot

### DIFF
--- a/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
+++ b/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
@@ -37,7 +37,6 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
     // Events
     public event Action OnTextSizeChange;
     public event Action OnButtonLabelVisibilityChange;
-    public event Action<CharacterID> OnCharacterGalleryCharacterStatWindowToShowChange;
 
     // Constants
     public const string BattleArenaScaleKey = "BattleUiArenaScale";
@@ -89,22 +88,6 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
             if (_unlimitedStatUpgradeMaterials == value) return;
             _unlimitedStatUpgradeMaterials = value;
             PlayerPrefs.SetInt(UnlimitedStatUpgradeMaterialsKey, value ? 1 : 0);
-        }
-    }
-
-    // Determines which character stat window to load/show from character gallery
-    private CharacterID _characterGalleryCharacterStatWindowToShow = CharacterID.None;
-    public CharacterID CharacterGalleryCharacterStatWindowToShow
-    {
-        get => _characterGalleryCharacterStatWindowToShow;
-        set
-        {
-            if (_characterGalleryCharacterStatWindowToShow != value)
-            {
-                _characterGalleryCharacterStatWindowToShow = value;
-                OnCharacterGalleryCharacterStatWindowToShowChange?.Invoke(_characterGalleryCharacterStatWindowToShow);
-                Debug.Log("CharacterGallery value changed" + _characterGalleryCharacterStatWindowToShow);
-            }
         }
     }
 

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/CharacterInventorySlot.prefab
@@ -167,6 +167,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1e1f4a98897509e4a9efdca7eb40b686, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _characterSlot: {fileID: 4381437622224976902}
 --- !u!1 &7018444139741886887
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/SelectedCharSlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/SelectedCharSlot.prefab
@@ -721,7 +721,7 @@ RectTransform:
   m_Father: {fileID: 6762374876794546724}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.7, y: 0.95}
-  m_AnchorMax: {x: 1, y: 1.05}
+  m_AnchorMax: {x: 1.05, y: 1.05}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 1, y: 0}

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/SelectedCharSlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/SelectedCharSlot.prefab
@@ -255,7 +255,7 @@ RectTransform:
   m_Father: {fileID: 6762374876794546724}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.9}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
@@ -385,81 +385,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &1866583862207281163
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7726832314128215011}
-  - component: {fileID: 4096919905388306114}
-  - component: {fileID: 2568228964057733382}
-  m_Layer: 5
-  m_Name: SlotBackground
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7726832314128215011
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866583862207281163}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6762374876794546724}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.9}
-  m_AnchoredPosition: {x: -0.000015258789, y: 0}
-  m_SizeDelta: {x: 0.000015258789, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4096919905388306114
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866583862207281163}
-  m_CullTransparentMesh: 1
---- !u!114 &2568228964057733382
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1866583862207281163}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.14509805, g: 0.14509805, b: 0.14509805, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 776df73bddbed9848b7968a02085a428, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3359739445682050633
 GameObject:
   m_ObjectHideFlags: 0
@@ -568,7 +493,7 @@ RectTransform:
   m_Father: {fileID: 6762374876794546724}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.1, y: 0.1}
-  m_AnchorMax: {x: 0.9, y: 0.8}
+  m_AnchorMax: {x: 0.9, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -794,11 +719,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 6762374876794546724}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.91}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.7, y: 0.025}
+  m_AnchorMax: {x: 1, y: 0.15}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 1}
+  m_SizeDelta: {x: 0, y: -0.000015258789}
+  m_Pivot: {x: 1, y: 0}
 --- !u!114 &2105214007719606832
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -812,7 +737,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.6313726, b: 0, a: 1}
+  m_Color: {r: 1, g: 0.7774325, b: 0.3962264, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -915,7 +840,6 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
-  - {fileID: 7726832314128215011}
   - {fileID: 4446701218286156652}
   - {fileID: 4913961195945727584}
   - {fileID: 6740532075501184234}
@@ -973,7 +897,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.1462264, g: 0.1462264, b: 0.1462264, a: 0}
+  m_Color: {r: 0.1462264, g: 0.1462264, b: 0.1462264, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/SelectedCharSlot.prefab
+++ b/Assets/MenuUi/Prefabs/DefenceScreen/CharacterGallery/SelectedCharSlot.prefab
@@ -168,7 +168,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 38
+  m_fontSize: 26.55
   m_fontSizeBase: 28
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -186,7 +186,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 1
+  m_overflowMode: 3
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 0
@@ -695,11 +695,12 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6740532075501184234}
+  - component: {fileID: 7812831837941205522}
   - component: {fileID: 2105214007719606832}
   - component: {fileID: 3952366076128303166}
   - component: {fileID: 8189453809692650516}
   m_Layer: 5
-  m_Name: EditingPopupButton
+  m_Name: StatPopupButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -719,11 +720,24 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 6762374876794546724}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.7, y: 0.025}
-  m_AnchorMax: {x: 1, y: 0.15}
+  m_AnchorMin: {x: 0.7, y: 0.95}
+  m_AnchorMax: {x: 1, y: 1.05}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: -0.000015258789}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 1, y: 0}
+--- !u!114 &7812831837941205522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4100038017486623826}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e1f4a98897509e4a9efdca7eb40b686, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _characterSlot: {fileID: 7242292408205723005}
 --- !u!114 &2105214007719606832
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -820,7 +834,6 @@ GameObject:
   - component: {fileID: 8026849999001333827}
   - component: {fileID: 3829378240036547943}
   - component: {fileID: 4850310269340108424}
-  - component: {fileID: 379999484477294870}
   m_Layer: 5
   m_Name: SelectedCharSlot
   m_TagString: Untagged
@@ -877,7 +890,7 @@ MonoBehaviour:
   _backgroundLowerImage: {fileID: 6364127686366887402}
   _backgroundUpperImage: {fileID: 810102327897205612}
   _pieChartPreview: {fileID: 7092275817553523894}
-  _editingPopupButton: {fileID: 3952366076128303166}
+  _statPopupButton: {fileID: 3952366076128303166}
   _characterCard: {fileID: 805393309856384591}
   _hpText: {fileID: 3845305337904517040}
   _impactForceText: {fileID: 8787316134834800473}
@@ -972,18 +985,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 1
   m_AspectRatio: 0.325
---- !u!114 &379999484477294870
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4297384447084397024}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e1f4a98897509e4a9efdca7eb40b686, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &6095522071213533036
 GameObject:
   m_ObjectHideFlags: 0
@@ -1077,7 +1078,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 48
+  m_fontSize: 37.15
   m_fontSizeBase: 40
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1095,7 +1096,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 1
+  m_overflowMode: 3
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 0
@@ -1373,7 +1374,7 @@ PrefabInstance:
     - target: {fileID: 6554343735351292191, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}
       propertyPath: m_fontSize
-      value: 48
+      value: 32.1
       objectReference: {fileID: 0}
     - target: {fileID: 7548677213304090326, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}
@@ -1691,7 +1692,7 @@ PrefabInstance:
     - target: {fileID: 6554343735351292191, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}
       propertyPath: m_fontSize
-      value: 48
+      value: 32.1
       objectReference: {fileID: 0}
     - target: {fileID: 7548677213304090326, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}
@@ -1873,7 +1874,7 @@ PrefabInstance:
     - target: {fileID: 6554343735351292191, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}
       propertyPath: m_fontSize
-      value: 48
+      value: 32.1
       objectReference: {fileID: 0}
     - target: {fileID: 7548677213304090326, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}
@@ -2055,7 +2056,7 @@ PrefabInstance:
     - target: {fileID: 6554343735351292191, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}
       propertyPath: m_fontSize
-      value: 48
+      value: 32.1
       objectReference: {fileID: 0}
     - target: {fileID: 7548677213304090326, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}
@@ -2216,7 +2217,7 @@ PrefabInstance:
     - target: {fileID: 6554343735351292191, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}
       propertyPath: m_fontSize
-      value: 48
+      value: 32.1
       objectReference: {fileID: 0}
     - target: {fileID: 7548677213304090326, guid: a959795d81ed63f468822edb2ff1fb21,
         type: 3}

--- a/Assets/MenuUi/Prefabs/Windows/DefenceScreen/DefenceView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DefenceScreen/DefenceView.prefab
@@ -148,6 +148,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _view: {fileID: 417004996853790836}
   _editingPanelView: {fileID: 0}
+  _statsWindowController: {fileID: 4781772882377915832}
 --- !u!1 &2089452136527349342
 GameObject:
   m_ObjectHideFlags: 0
@@ -3194,25 +3195,70 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 4269957956424409635}
     m_Modifications:
+    - target: {fileID: 212680598732592888, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 440471220960954798, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 534685583501936687, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 611988808118557155, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 38
+      objectReference: {fileID: 0}
     - target: {fileID: 703186793058978684, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_TargetGraphic
       value: 
       objectReference: {fileID: 5238977959512526167}
+    - target: {fileID: 717891166522002745, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
     - target: {fileID: 745657963979682943, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 790643016386133842, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 904539704440893165, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 1153.032
       objectReference: {fileID: 0}
+    - target: {fileID: 943855875709506159, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 1015461107284664324, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
     - target: {fileID: 1060125106456029993, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1235236232565493620, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 1392705991178641797, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
@@ -3222,17 +3268,17 @@ PrefabInstance:
     - target: {fileID: 2047469648911103992, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2047469648911103992, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2047469648911103992, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 374.73538
       objectReference: {fileID: 0}
     - target: {fileID: 2047469648911103992, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
@@ -3242,7 +3288,7 @@ PrefabInstance:
     - target: {fileID: 2047469648911103992, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 256.9046
       objectReference: {fileID: 0}
     - target: {fileID: 2047469648911103992, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
@@ -3254,20 +3300,30 @@ PrefabInstance:
       propertyPath: _galleryView
       value: 
       objectReference: {fileID: 417004996853790836}
+    - target: {fileID: 2346953052775143624, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 2629333077055604638, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
     - target: {fileID: 2968758925973454610, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2968758925973454610, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2968758925973454610, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 374.73538
       objectReference: {fileID: 0}
     - target: {fileID: 2968758925973454610, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
@@ -3277,7 +3333,7 @@ PrefabInstance:
     - target: {fileID: 2968758925973454610, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 656.64
       objectReference: {fileID: 0}
     - target: {fileID: 2968758925973454610, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
@@ -3287,17 +3343,17 @@ PrefabInstance:
     - target: {fileID: 3304638679444693060, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3304638679444693060, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3304638679444693060, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 374.73538
       objectReference: {fileID: 0}
     - target: {fileID: 3304638679444693060, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
@@ -3307,18 +3363,48 @@ PrefabInstance:
     - target: {fileID: 3304638679444693060, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 1056.3754
       objectReference: {fileID: 0}
     - target: {fileID: 3304638679444693060, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617131550928289989, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 3694616845798506820, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953571299951615891, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 4053252466572204677, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 4067952484535672000, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_TargetGraphic
       value: 
       objectReference: {fileID: 8719790353734179563}
+    - target: {fileID: 4163653751510896223, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 38
+      objectReference: {fileID: 0}
+    - target: {fileID: 4273511634791229678, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
     - target: {fileID: 4318783152758678467, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -3329,6 +3415,21 @@ PrefabInstance:
       propertyPath: m_TargetGraphic
       value: 
       objectReference: {fileID: 9074088035071542717}
+    - target: {fileID: 4406504898292371721, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 38
+      objectReference: {fileID: 0}
+    - target: {fileID: 4735159286479575686, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 4997275491317188048, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
+      objectReference: {fileID: 0}
     - target: {fileID: 5832572210491368077, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_text
@@ -3473,6 +3574,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: SelectedCharacters
+      objectReference: {fileID: 0}
+    - target: {fileID: 8426127184364982892, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 48
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/CharacterGalleryCharacterStatWindowToShowButton.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/CharacterGalleryCharacterStatWindowToShowButton.cs
@@ -16,7 +16,7 @@ namespace MenuUi.Scripts.CharacterGallery
 
             CharacterStatWindowToShowValue = data.Id;
 
-            SettingsCarrier.Instance.CharacterGalleryCharacterStatWindowToShow = CharacterStatWindowToShowValue;
+            //SettingsCarrier.Instance.CharacterGalleryCharacterStatWindowToShow = CharacterStatWindowToShowValue;
             base.OnNaviButtonClick();
             Debug.Log("changed to " + CharacterStatWindowToShowValue);
         }

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/CharacterSlot.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/CharacterSlot.cs
@@ -12,13 +12,10 @@ namespace MenuUi.Scripts.CharacterGallery
     /// Has a reference to GalleryCharacter, and the info to GalleryCharacter is also set through SetInfo function.
     /// Inherits SlotBase for editing selected characters.
     /// </summary>
-    public class CharacterSlot : SlotBase, IGalleryCharacterData
+    public class CharacterSlot : SlotBase
     {
         [SerializeField] public GalleryCharacter Character;
 
-        private CharacterID _id;
-
-        public CharacterID Id { get => _id; }
         [HideInInspector] public bool IsLocked = false;
         public void SetInfo(Sprite sprite, Color bgColor, Color bgAltColor, string name, string className, CharacterID id)
         {

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/ModelController.cs
@@ -9,6 +9,7 @@ using Altzone.Scripts.Model.Poco.Game;
 using Altzone.Scripts.Model.Poco.Player;
 
 using MenuUi.Scripts.Signals;
+using MenuUi.Scripts.DefenceScreen.CharacterStatsWindow;
 
 namespace MenuUi.Scripts.Signals
 {
@@ -26,6 +27,13 @@ namespace MenuUi.Scripts.Signals
         public static void OnDefenceGalleryEditPanelRequestedSignal()
         {
             OnDefenceGalleryEditPanelRequested?.Invoke();
+        }
+
+        public delegate void DefenceGalleryStatPopupRequested(CharacterID characterId);
+        public static event DefenceGalleryStatPopupRequested OnDefenceGalleryStatPopupRequested;
+        public static void OnDefenceGalleryStatPopupRequestedSignal(CharacterID characterID)
+        {
+            OnDefenceGalleryStatPopupRequested?.Invoke(characterID);
         }
 
         public delegate void ReloadCharacterGalleryRequested();
@@ -54,6 +62,7 @@ namespace MenuUi.Scripts.CharacterGallery
     {
         [SerializeField] private GalleryView _view;
         [SerializeField] private GalleryView _editingPanelView;
+        [SerializeField] private StatsWindowController _statsWindowController;
 
         private PlayerData _playerData;
         private bool _reloadRequested = false;
@@ -65,6 +74,7 @@ namespace MenuUi.Scripts.CharacterGallery
             SignalBus.OnRandomSelectedCharactersRequested += SetRandomSelectedCharactersToEmptySlots;
             SignalBus.OnReloadCharacterGalleryRequested += OnReloadRequested;
             SignalBus.OnSelectedDefenceCharacterChanged += HandleCharacterSelected;
+            SignalBus.OnDefenceGalleryStatPopupRequested += _statsWindowController.OpenPopup;
         }
 
 
@@ -96,6 +106,7 @@ namespace MenuUi.Scripts.CharacterGallery
             SignalBus.OnRandomSelectedCharactersRequested -= SetRandomSelectedCharactersToEmptySlots;
             SignalBus.OnReloadCharacterGalleryRequested -= OnReloadRequested;
             SignalBus.OnSelectedDefenceCharacterChanged -= HandleCharacterSelected;
+            SignalBus.OnDefenceGalleryStatPopupRequested -= _statsWindowController.OpenPopup;
         }
 
 

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/SelectedCharSlot.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/SelectedCharSlot.cs
@@ -7,7 +7,7 @@ using MenuUi.Scripts.DefenceScreen.CharacterGallery;
 
 namespace MenuUi.Scripts.CharacterGallery
 {
-    public class SelectedCharSlot : SlotBase, IGalleryCharacterData
+    public class SelectedCharSlot : SlotBase
     {
         [SerializeField] private Image _characterImage;
         [SerializeField] private TMP_Text _className;
@@ -18,7 +18,7 @@ namespace MenuUi.Scripts.CharacterGallery
 
         [Space, SerializeField] private PieChartPreview _pieChartPreview;
 
-        [Space, SerializeField] private Button _editingPopupButton;
+        [Space, SerializeField] private Button _statPopupButton;
 
         [Space, SerializeField] private GameObject _characterCard;
         [SerializeField] private TMP_Text _hpText;
@@ -27,17 +27,14 @@ namespace MenuUi.Scripts.CharacterGallery
         [SerializeField] private TMP_Text _defenceText;
         [SerializeField] private TMP_Text _charSizeText;
 
-        private CharacterID _id;
-        public CharacterID Id => _id;
-
         private void Awake()
         {
-            if (_editingPopupButton != null) _editingPopupButton.onClick.AddListener(SignalBus.OnDefenceGalleryEditPanelRequestedSignal);
+            if (_slotButton != null) _slotButton.onClick.AddListener(SignalBus.OnDefenceGalleryEditPanelRequestedSignal);
         }
 
         private void OnDestroy()
         {
-            _editingPopupButton.onClick.RemoveAllListeners();
+            _slotButton.onClick.RemoveAllListeners();
         }
 
         public void SetInfo(CustomCharacter customCharacter, Sprite sprite, Color bgColor, Color bgAltColor, string name, string className)
@@ -60,7 +57,7 @@ namespace MenuUi.Scripts.CharacterGallery
         public void SetCharacterVisibility(bool visible)
         {
            _characterCard.SetActive(visible);
-           _slotButton.enabled = visible;
+           _statPopupButton.gameObject.SetActive(visible);
         }
     }
 }

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/SlotBase.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/SlotBase.cs
@@ -1,3 +1,4 @@
+using Altzone.Scripts.Model.Poco.Game;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -6,20 +7,21 @@ namespace MenuUi.Scripts.CharacterGallery
     /// <summary>
     /// Base class for defence gallery character slots. Has a serializefield for the slot's button and an event which gets invoked on button press.
     /// </summary>
-    public class SlotBase : MonoBehaviour
+    public class SlotBase : MonoBehaviour, IGalleryCharacterData
     {
         [SerializeField] protected Button _slotButton;
 
         public delegate void SlotPressedHandler(SlotBase slot);
         public SlotPressedHandler OnSlotPressed;
 
+        protected CharacterID _id;
+        public CharacterID Id => _id;
 
         private void Awake()
         {
             if (_slotButton == null) return;
             _slotButton.onClick.AddListener(SlotButtonPressed);
         }
-
 
         private void OnDestroy()
         {

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/StatPopUpToShowButton.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/StatPopUpToShowButton.cs
@@ -2,25 +2,20 @@ using Altzone.Scripts.Model.Poco.Game;
 using MenuUi.Scripts.DefenceScreen.CharacterStatsWindow;
 using UnityEngine.UI;
 using UnityEngine;
+using MenuUi.Scripts.Signals;
 
 namespace MenuUi.Scripts.CharacterGallery
 {
     [RequireComponent(typeof(Button))]
     public class StatPopUpToShowButton : MonoBehaviour
     {
-        private CharacterID CharacterStatWindowToShowValue;
-
-        private StatsWindowController _controller;
+        [SerializeField] SlotBase _characterSlot;
         private Button _button;
 
-        private void OnEnable()
+        private void Awake()
         {
-            if (_controller == null) _controller = FindObjectOfType<StatsWindowController>(true);
-            if (_button == null)
-            {
-                _button = GetComponent<Button>();
-                _button.onClick.AddListener(OnButtonClick);
-            }
+            _button = GetComponent<Button>();
+            _button.onClick.AddListener(OnButtonClick);
         }
 
         private void OnDestroy()
@@ -30,13 +25,7 @@ namespace MenuUi.Scripts.CharacterGallery
 
         protected void OnButtonClick()
         {
-            IGalleryCharacterData data = GetComponent<IGalleryCharacterData>();
-
-            CharacterStatWindowToShowValue = data.Id;
-
-            SettingsCarrier.Instance.CharacterGalleryCharacterStatWindowToShow = CharacterStatWindowToShowValue;
-
-            _controller.OpenPopup();
+            SignalBus.OnDefenceGalleryStatPopupRequestedSignal(_characterSlot.Id);
         }
     }
 }

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterStatsWindow/StatsWindowController.cs
@@ -34,7 +34,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
         private BaseCharacter _baseCharacter;
         private SwipeUI _swipe;
 
-        public CharacterID CurrentCharacterID { get { return _characterId; } }
+        public CharacterID CurrentCharacterID => _characterId;
 
         public event Action OnUpgradeMaterialAmountChanged;
 
@@ -50,14 +50,6 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
             _statsPanel.SetActive(false);
         }
 
-
-        private void OnEnable()
-        {
-            _characterId = SettingsCarrier.Instance.CharacterGalleryCharacterStatWindowToShow;
-            SetPlayerData();
-            SetCurrentCharacter();
-        }
-
         private void OnDisable()
         {
             ClosePopup();
@@ -68,17 +60,24 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
             _swipe.OnCurrentPageChanged -= ClosePopup;
         }
 
-        public void OpenPopup()
+        public void OpenPopup(CharacterID characterId)
         {
-            _statsUpdated = false;
-
+            // Setting visibility to popup game objects
             gameObject.SetActive(true);
             _swipeBlocker.SetActive(true);
 
+            // Initializing variables for stats window controller functionality
+            _statsUpdated = false;
+            _characterId = characterId;
+            SetPlayerData();
+            SetCurrentCharacter();
+
+            // Setting visibility to panel game objects
             if (_statsPanel != null) _statsPanel.SetActive(true);
 
             if (_infoPanel != null) _infoPanel.SetActive(false);
 
+            // Hiding filter button from gallery since it shouldn't be shown TODO: needs to be refactored
             if (_galleryView != null) _galleryView.ShowFilterButton(false);
         }
 
@@ -90,6 +89,10 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
             gameObject.SetActive(false);
             _swipeBlocker.SetActive(false);
+
+            if (_statsPanel != null) _statsPanel.SetActive(false);
+            if (_infoPanel != null) _infoPanel.SetActive(false);
+
             if (_galleryView != null) _galleryView.ShowFilterButton(true);
         }
 
@@ -139,7 +142,7 @@ namespace MenuUi.Scripts.DefenceScreen.CharacterStatsWindow
 
             // Triggering onenable functions
             ClosePopup();
-            OpenPopup();
+            OpenPopup(_characterId);
         }
 
 


### PR DESCRIPTION
- Updated the pencil button placement in SelectedCharSlot.
- Switched opening editing panel and stat popup buttons in SelectedCharSlot; slot button opens editing panel and the pencil opens stat popup.
- Removed CharacterGalleryCharacterStatWindowToShow setting from SettingsCarrier.cs.
- Updated SlotBase.cs to implement IGalleryCharacterData interface, and removed the interface implementation from SelectedCharSlot.cs and CharacterSlot.cs
- Refactored StatPopUpToShowButton.cs. Added SerializeField for SlotBase so that it can be used to get the character id.
- SignalBus event for opening stat popup in ModelController.cs. Added reference to StatWindowController, and handling it subscribing the SignalBus event.
- Updated StatWindowController.cs script's OpenPopup method to take CharacterID as a parameter.
