### PR TITLE
Battle/fix - Character rotate direction

### DIFF
--- a/Assets/QuantumUser/View/Battle/Scripts/Player/BattlePlayerInput.cs
+++ b/Assets/QuantumUser/View/Battle/Scripts/Player/BattlePlayerInput.cs
@@ -266,6 +266,8 @@ namespace Battle.View.Player
                     break;
             }
 
+            if (BattleGameViewController.LocalPlayerTeam == BattleTeamNumber.TeamBeta) rotationInputInfo.RotationValue *= -1;
+
             return rotationInputInfo;
         }
 


### PR DESCRIPTION
Player characters no longer rotate incorrectly for team beta.

BattlePlayerInput:
  - Flips rotation direction if the local player is in team beta