### PR TITLE
add correct CI builds versioning

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -22,6 +22,9 @@ jobs:
             branch: Production
 
     steps:
+      - name: Set current date as build version
+        run: echo "BUILD_VERSION=$(date +'%d.%m.%Y')" >> $GITHUB_ENV
+
       - name: Check branch match
         if: github.ref_name == matrix.branch
         run: echo "Building for branch ${{ matrix.branch }} and target ${{ matrix.targetPlatform }}"
@@ -58,6 +61,8 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           webGlCompression: Brotli
           androidExportType: 'androidAppBundle'
+          versioning: Custom
+          version: ${{ env.BUILD_VERSION }}
 
       - uses: actions/upload-artifact@v4
         if: github.ref_name == matrix.branch


### PR DESCRIPTION
Now each build version is set to be in the format DD.MM.YYYY.

Notice that builds made on the same day will have the same version.

Date is obtained from the server environment, which is UTC+0 timezone, which is 3 hours earlier than finnish