### PR TITLE
Battle/fix - Remove placeholder teammate player info

### DIFF
--- a/Assets/QuantumUser/View/Battle/Scripts/Game/BattleGameViewController.cs
+++ b/Assets/QuantumUser/View/Battle/Scripts/Game/BattleGameViewController.cs
@@ -181,6 +181,7 @@ namespace Battle.View.Game
                     new float[3] { (float)localPlayerData.Characters[0].Stats.Defence, (float)localPlayerData.Characters[1].Stats.Defence, (float)localPlayerData.Characters[2].Stats.Defence },
                     SettingsCarrier.Instance.GetBattleUiMovableElementData(BattleUiElementType.PlayerInfo)
                 );
+                _uiController.PlayerInfoHandler.SetShowPlayer(true);
 
                 // Setting local teammate info
                 if (localTeammateData != null)
@@ -192,16 +193,7 @@ namespace Battle.View.Game
                         new float[3] { (float)localTeammateData.Characters[0].Stats.Defence, (float)localTeammateData.Characters[1].Stats.Defence, (float)localTeammateData.Characters[2].Stats.Defence },
                         SettingsCarrier.Instance.GetBattleUiMovableElementData(BattleUiElementType.TeammateInfo)
                     );
-                }
-                else
-                {
-                    _uiController.PlayerInfoHandler.SetInfo(
-                        PlayerType.LocalTeammate,
-                        "Tiimiläinen",
-                        new int[3] { 101, 201, 301 },
-                        new float[3] { 0, 0, 0 },
-                        SettingsCarrier.Instance.GetBattleUiMovableElementData(BattleUiElementType.TeammateInfo)
-                    );
+                    _uiController.PlayerInfoHandler.SetShowTeammate(true);
                 }
             }
 

--- a/Assets/QuantumUser/View/Battle/Scripts/UI/BattleUiPlayerInfoHandler.cs
+++ b/Assets/QuantumUser/View/Battle/Scripts/UI/BattleUiPlayerInfoHandler.cs
@@ -21,14 +21,29 @@ namespace Battle.View.UI
             LocalTeammate,
         }
 
-        public bool IsVisible => _localPlayerMultiOrientationElement.gameObject.activeSelf;
+        public bool IsVisible => _isVisible;
+        public bool IsVisiblePlayer => _isVisiblePlayer;
+        public bool IsVisibleTeammate => _isVisibleTeammate;
         public BattleUiMultiOrientationElement LocalPlayerMultiOrientationElement => _localPlayerMultiOrientationElement;
         public BattleUiMultiOrientationElement LocalTeammateMultiOrientationElement => _localTeammateMultiOrientationElement;
 
         public void SetShow(bool show)
         {
-            _localPlayerMultiOrientationElement.gameObject.SetActive(show);
-            _localTeammateMultiOrientationElement.gameObject.SetActive(show);
+            _isVisible = show;
+            _localPlayerMultiOrientationElement   .gameObject.SetActive(_isVisible && _isVisiblePlayer);
+            _localTeammateMultiOrientationElement .gameObject.SetActive(_isVisible && _isVisibleTeammate);
+        }
+
+        public void SetShowPlayer(bool show)
+        {
+            _isVisiblePlayer = show;
+            _localPlayerMultiOrientationElement.gameObject.SetActive(_isVisible && _isVisiblePlayer);
+        }
+
+        public void SetShowTeammate(bool show)
+        {
+            _isVisibleTeammate = show;
+            _localTeammateMultiOrientationElement.gameObject.SetActive(_isVisible && _isVisibleTeammate);
         }
 
         public void SetInfo(PlayerType playerType, string playerName, int[] characterIds, float[] characterDefenceNumbers, BattleUiMovableElementData data)
@@ -104,5 +119,9 @@ namespace Battle.View.UI
                 return _localTeammateMultiOrientationElement.GetActiveGameObject().GetComponent<BattleUiPlayerInfoComponent>();
             }
         }
+
+        private bool _isVisible         = false;
+        private bool _isVisiblePlayer   = false;
+        private bool _isVisibleTeammate = false;
     }
 }


### PR DESCRIPTION
Now when you don't have a teammate it no longer shows you empty teammate template in the UI.
With SetShowPlayer and SetShowTeammate we can now set them active separately.

BattleUiPlayerInfoHandler
- Deleted template for empty teammate
- Disabled teammate player info when there is no teammate

BattleGameViewController
- Added private booleans
- Modified SetShow so it can set both active
- Added SetShowPlayer and SetShowTeammate