### PR TITLE
Add SwipeBlockOverlay to block swipe when popups are open

### DIFF
--- a/Assets/MenuUi/Prefabs/Windows/Settings/SettingsView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/Settings/SettingsView.prefab
@@ -586,8 +586,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 270, y: -192.97162}
-  m_SizeDelta: {x: 500, y: 68.38774}
+  m_AnchoredPosition: {x: 270, y: -191.61917}
+  m_SizeDelta: {x: 500, y: 67.486115}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &297278080638712010
 GameObject:
@@ -940,8 +940,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 270, y: -504.0626}
-  m_SizeDelta: {x: 500, y: 68.38774}
+  m_AnchoredPosition: {x: 270, y: -499.10364}
+  m_SizeDelta: {x: 500, y: 67.486115}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &6971227397291781352
 MonoBehaviour:
@@ -1375,7 +1375,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0.1, y: 1}
   m_AnchoredPosition: {x: 8.5, y: 0}
-  m_SizeDelta: {x: 18.387741, y: 0}
+  m_SizeDelta: {x: 17.486115, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3627581513947218192
 CanvasRenderer:
@@ -1659,6 +1659,141 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 2
   m_AspectRatio: 1
+--- !u!1 &626282381641368589
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8978845654060921024}
+  - component: {fileID: 7487737653758036197}
+  - component: {fileID: 5298800245710761278}
+  - component: {fileID: 7231111034778839778}
+  - component: {fileID: 4907923288995357588}
+  m_Layer: 5
+  m_Name: SwipeBlockOverlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &8978845654060921024
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626282381641368589}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 867626076711261357}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7487737653758036197
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626282381641368589}
+  m_CullTransparentMesh: 1
+--- !u!114 &5298800245710761278
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626282381641368589}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7231111034778839778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626282381641368589}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 5298800245710761278}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &4907923288995357588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 626282381641368589}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cabc7ab297e9ab44a96e83ec36e516df, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _blockType: 0
+  _swipe: {fileID: 0}
 --- !u!1 &736018762690062112
 GameObject:
   m_ObjectHideFlags: 0
@@ -2004,8 +2139,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 270, y: -89.38887}
-  m_SizeDelta: {x: 500, y: 138.77774}
+  m_AnchoredPosition: {x: 270, y: -88.93806}
+  m_SizeDelta: {x: 500, y: 137.87611}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &665516673779566630
 CanvasRenderer:
@@ -4308,8 +4443,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 270, y: -435.67484}
-  m_SizeDelta: {x: 500, y: 68.38774}
+  m_AnchoredPosition: {x: 270, y: -431.6175}
+  m_SizeDelta: {x: 500, y: 67.486115}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &6435122514672627496
 MonoBehaviour:
@@ -5030,7 +5165,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0.1, y: 1}
   m_AnchoredPosition: {x: 8.5, y: 0}
-  m_SizeDelta: {x: 18.387741, y: 0}
+  m_SizeDelta: {x: 17.486115, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2527125093335172565
 CanvasRenderer:
@@ -5171,8 +5306,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 270, y: -661.9531}
-  m_SizeDelta: {x: 500, y: 110.61774}
+  m_AnchoredPosition: {x: 270, y: -655.1908}
+  m_SizeDelta: {x: 500, y: 109.71611}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &750208965385642730
 CanvasRenderer:
@@ -5997,7 +6132,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 29.15
+  m_fontSize: 28.75
   m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -7235,7 +7370,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0.1, y: 1}
   m_AnchoredPosition: {x: 8.5, y: 0}
-  m_SizeDelta: {x: 18.387741, y: 0}
+  m_SizeDelta: {x: 17.486115, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4869714347618483920
 CanvasRenderer:
@@ -14014,7 +14149,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 29.15
+  m_fontSize: 28.75
   m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -14973,6 +15108,7 @@ MonoBehaviour:
   _closeButtons:
   - {fileID: 6450549574574219563}
   - {fileID: 2541976446447670012}
+  _swipeBlockOverlay: {fileID: 626282381641368589}
 --- !u!114 &7019136095634686499
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -17248,8 +17384,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 270, y: -751.4558}
-  m_SizeDelta: {x: 500, y: 68.38774}
+  m_AnchoredPosition: {x: 270, y: -743.79193}
+  m_SizeDelta: {x: 500, y: 67.486115}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2471068837817712015
 MonoBehaviour:
@@ -17907,6 +18043,7 @@ MonoBehaviour:
   _closeButtons:
   - {fileID: 1448790578392374114}
   - {fileID: 5907402319670386933}
+  _swipeBlockOverlay: {fileID: 626282381641368589}
 --- !u!1 &6205201353159723468
 GameObject:
   m_ObjectHideFlags: 0
@@ -20103,7 +20240,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 34.19387, y: 0}
+  m_SizeDelta: {x: 33.743057, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2649199131336212750
 CanvasRenderer:
@@ -21368,7 +21505,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "Ohita introvideo\nk\xE4ynnistyksess\xE4"
+  m_text: Kolikot
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 60e82e4f80e646e498eed795d845cfe2, type: 2}
   m_sharedMaterial: {fileID: 6181749917240489737, guid: 60e82e4f80e646e498eed795d845cfe2,
@@ -21396,7 +21533,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 23.9
+  m_fontSize: 36
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -21748,8 +21885,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 270, y: -261.35934}
-  m_SizeDelta: {x: 500, y: 68.38774}
+  m_AnchoredPosition: {x: 270, y: -259.1053}
+  m_SizeDelta: {x: 500, y: 67.486115}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &7759716167226140731
 GameObject:
@@ -24896,7 +25033,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: kolikot
+  m_text: LeaderBoard
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 60e82e4f80e646e498eed795d845cfe2, type: 2}
   m_sharedMaterial: {fileID: 6181749917240489737, guid: 60e82e4f80e646e498eed795d845cfe2,
@@ -25129,8 +25266,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 270, y: -348.5171}
-  m_SizeDelta: {x: 500, y: 105.92774}
+  m_AnchoredPosition: {x: 270, y: -345.3614}
+  m_SizeDelta: {x: 500, y: 105.026115}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4164492618138396309
 CanvasRenderer:
@@ -25270,8 +25407,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 270, y: -572.4503}
-  m_SizeDelta: {x: 500, y: 68.38774}
+  m_AnchoredPosition: {x: 270, y: -566.5897}
+  m_SizeDelta: {x: 500, y: 67.486115}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &3816882072646446653
 MonoBehaviour:
@@ -25649,7 +25786,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 34.19387, y: 0}
+  m_SizeDelta: {x: 33.743057, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8706805615211207724
 CanvasRenderer:
@@ -26308,6 +26445,7 @@ MonoBehaviour:
   _closeButtons:
   - {fileID: 1881642727661124735}
   - {fileID: 2041114877952976699}
+  _swipeBlockOverlay: {fileID: 626282381641368589}
 --- !u!114 &4011332388976535709
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -26637,6 +26775,7 @@ MonoBehaviour:
   _closeButtons:
   - {fileID: 1288982967449279087}
   - {fileID: 1726257769989847522}
+  _swipeBlockOverlay: {fileID: 626282381641368589}
 --- !u!1 &9178331493335486026
 GameObject:
   m_ObjectHideFlags: 0
@@ -27029,7 +27168,7 @@ PrefabInstance:
     - target: {fileID: 2641932565321544379, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.94188035
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2665311521893521844, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -27110,12 +27249,12 @@ PrefabInstance:
     - target: {fileID: 3472046463813142143, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.86688036
+      value: 0.923
       objectReference: {fileID: 0}
     - target: {fileID: 3472046463813142143, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.1975
+      value: 0.2045
       objectReference: {fileID: 0}
     - target: {fileID: 3482542752552871026, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -27787,7 +27926,7 @@ PrefabInstance:
     - target: {fileID: 7827142668286818857, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.1975
+      value: 0.2045
       objectReference: {fileID: 0}
     - target: {fileID: 8020515439083824472, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -27897,12 +28036,12 @@ PrefabInstance:
     - target: {fileID: 9009743781400064838, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.94188035
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9009743781400064838, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.86688036
+      value: 0.923
       objectReference: {fileID: 0}
     - target: {fileID: 9055697728720554350, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
@@ -27930,7 +28069,8 @@ PrefabInstance:
       propertyPath: m_VerticalAlignment
       value: 1024
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 2988449535024697909, guid: 57890b7dbec8a984abb7d8148eefe9f6, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 1100066851907345866, guid: 57890b7dbec8a984abb7d8148eefe9f6,
@@ -27941,6 +28081,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 6251713821646766710}
+    - targetCorrespondingSourceObject: {fileID: 3161658419340045711, guid: 57890b7dbec8a984abb7d8148eefe9f6,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8978845654060921024}
     - targetCorrespondingSourceObject: {fileID: 3161658419340045711, guid: 57890b7dbec8a984abb7d8148eefe9f6,
         type: 3}
       insertIndex: -1
@@ -28421,7 +28565,7 @@ PrefabInstance:
     - target: {fileID: 2522924568871388016, guid: 36168b4a92b6679449c8fc40f06c0cf9,
         type: 3}
       propertyPath: m_Value
-      value: 0.5
+      value: 0.50000006
       objectReference: {fileID: 0}
     - target: {fileID: 2522924569201874204, guid: 36168b4a92b6679449c8fc40f06c0cf9,
         type: 3}

--- a/Assets/MenuUi/Scripts/Settings/SettingsPopup.cs
+++ b/Assets/MenuUi/Scripts/Settings/SettingsPopup.cs
@@ -5,24 +5,51 @@ using UnityEngine.UI;
 
 public class SettingsPopup : MonoBehaviour
 {
-    [SerializeField] private Button[] _closeButtons;        // background button is huge invisible button behind the popup to close it if clicked outside
-
+    [SerializeField] private Button[] _closeButtons;   // esim. se näkymätön taustabuttoni
+    [SerializeField] private GameObject _swipeBlockOverlay; // se SwipeBlockOverlay-objekti
 
     private void Start()
     {
-        foreach (Button _button in _closeButtons)
+        foreach (Button button in _closeButtons)
         {
-            _button.onClick.AddListener(() => ClosePopup());
+            button.onClick.AddListener(ClosePopup);
         }
     }
 
     public void OpenPopup()
     {
         gameObject.SetActive(true);
+
+        if (_swipeBlockOverlay != null)
+        {
+            _swipeBlockOverlay.SetActive(true);
+        }
     }
 
     public void ClosePopup()
     {
         gameObject.SetActive(false);
+
+        if (_swipeBlockOverlay != null)
+        {
+            // tarkista onko vielä muita popuppeja aktiivisena
+            bool anyPopupOpen = false;
+
+            // käy läpi saman parentin kaikki SettingsPopupit
+            var siblings = GetComponentsInParent<Transform>(true)[0].GetComponentsInChildren<SettingsPopup>(true);
+            foreach (var popup in siblings)
+            {
+                if (popup.gameObject.activeSelf)
+                {
+                    anyPopupOpen = true;
+                    break;
+                }
+            }
+
+            if (!anyPopupOpen)
+            {
+                _swipeBlockOverlay.SetActive(false);
+            }
+        }
     }
 }


### PR DESCRIPTION
- Added SwipeBlockOverlay (invisible UI element) with SwipeBlocker script to intercept drag gestures and prevent SwipeUI navigation.
- Updated SettingsPopup script to activate the overlay when opening a popup and deactivate it when all popups are closed.
- Ensures swipe navigation is disabled while popups are active, preventing accidental page swipes behind dialogs.