### PR TITLE
FIX/UI replaced null check with ID match in DefenceForceView

### DIFF
--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/DefenceForceView.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/DefenceForceView.cs
@@ -29,8 +29,10 @@ namespace MenuUi.Scripts.CharacterGallery
             {
                 CharacterID charID = selectedCharacters[i] == null ? CharacterID.None : selectedCharacters[i].Id;
 
-                PlayerCharacterPrototype info = PlayerCharacterPrototypes.GetCharacter(((int)charID).ToString());
-                if (info == null)
+                string lookupId = ((int)charID).ToString();
+                PlayerCharacterPrototype info = PlayerCharacterPrototypes.GetCharacter(lookupId);
+                
+                if (info.Id != lookupId)
                 {
                     _selectedCharSlots[i].SetCharacterVisibility(false);
                     continue;


### PR DESCRIPTION
GetCharacter returns a fallback: hide slot when info.Id != lookupId.