### PR TITLE
Battle/fix - On-Screen Debug Message Hotfix

### DIFF
--- a/Assets/QuantumUser/Scenes/31-QuantumBattle.unity
+++ b/Assets/QuantumUser/Scenes/31-QuantumBattle.unity
@@ -3950,6 +3950,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 33815931225985110, guid: 97e8f0ca20408d042a38f07b90b44946,
+        type: 3}
+      propertyPath: _announcementTextScaler
+      value: 
+      objectReference: {fileID: 2118663606}
     - target: {fileID: 1982871711592827336, guid: 97e8f0ca20408d042a38f07b90b44946,
         type: 3}
       propertyPath: _moveJoystickMovableElement
@@ -4097,6 +4102,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e16f983dca8ddf346ab612d4b1bce417, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2118663606 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8595071680069480649, guid: 97e8f0ca20408d042a38f07b90b44946,
+    type: 3}
+  m_PrefabInstance: {fileID: 2118663603}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 267a7639004ed724f9535653aada6aec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &2118663608 stripped


### PR DESCRIPTION
BattleUi
- Fixed missing reference to AnnouncementText text scaler that was causing on-screen debug messages to not show up.