### PR TITLE
UI/defence gallery/edit/edit d gall character images and fix edit stats button

### DIFF
--- a/Assets/MenuUi/Prefabs/Windows/DefenceScreen/DefenceView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/DefenceScreen/DefenceView.prefab
@@ -4240,6 +4240,12 @@ PrefabInstance:
       propertyPath: m_fontSize
       value: 48
       objectReference: {fileID: 0}
+    - target: {fileID: 5400974564282899842, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2ccdcaed0f15de247bb4518861d2e213,
+        type: 3}
     - target: {fileID: 5832572210491368077, guid: 17dcaf24e42b9f04dbe0510400c1631d,
         type: 3}
       propertyPath: m_text
@@ -4483,6 +4489,18 @@ PrefabInstance:
       propertyPath: m_fontSize
       value: 48
       objectReference: {fileID: 0}
+    - target: {fileID: 8881767324087798334, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2ccdcaed0f15de247bb4518861d2e213,
+        type: 3}
+    - target: {fileID: 9200055310240650600, guid: 17dcaf24e42b9f04dbe0510400c1631d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2ccdcaed0f15de247bb4518861d2e213,
+        type: 3}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:

--- a/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/DefenceForceView.cs
+++ b/Assets/MenuUi/Scripts/DefenceScreen/CharacterGallery/DefenceForceView.cs
@@ -46,7 +46,7 @@ namespace MenuUi.Scripts.CharacterGallery
                 Color bgColor = _classReference.GetColor(classID);
                 Color bgAltColor = _classReference.GetAlternativeColor(classID);
 
-                _selectedCharSlots[i].SetInfo(selectedCharacters[i], info.GalleryImage,bgColor, bgAltColor, info.Name, _classReference.GetName(classID));
+                _selectedCharSlots[i].SetInfo(selectedCharacters[i], info.GalleryHeadImage,bgColor, bgAltColor, info.Name, _classReference.GetName(classID));
             }
           
         }


### PR DESCRIPTION
- Changed character slot image to show the character head instead of the full character

- Updated the prefab to use the correct head sprite (previously full body)

- Adjusted CharacterCard and SelectedCharSlot raycast targets:

             - Stat editing can now only be accessed via the StatPopupButton

             - Character selection works by clicking anywhere else on the character card