### PR TITLE
Add setting to skip intro video

### DIFF
--- a/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
+++ b/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
@@ -70,7 +70,7 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
         None,
         JukeboxSoulhomeToggle,
         JukeboxUIToggle,
-        IntroSkipToggle,
+        JukeboxBattleToggle,
     }
 
     // Events
@@ -118,8 +118,6 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
     public bool jukeboxSoulhome;
     public bool jukeboxUI;
     public bool jukeboxBattle;
-
-    public bool skipIntro;
 
     public int TextSizeSmall = 22;
     public int TextSizeMedium = 26;
@@ -328,8 +326,6 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
         jukeboxUI = PlayerPrefs.GetInt("JukeboxUI") != 0;
         jukeboxBattle = PlayerPrefs.GetInt("JukeboxBattle") != 0;
 
-        skipIntro = PlayerPrefs.GetInt("SkipIntroVideo") != 0;
-
         _battleShowDebugStatsOverlay = PlayerPrefs.GetInt(BattleShowDebugStatsOverlayKey, 1) == 1;
 
         _battleArenaScale = PlayerPrefs.GetInt(BattleArenaScaleKey, BattleArenaScaleDefault);
@@ -390,10 +386,6 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
                 jukeboxBattle = value ?? !jukeboxBattle;
                 PlayerPrefs.SetInt("JukeboxBattle", jukeboxBattle ? 1 : 0);
                 return true;
-            case SettingsType.IntroSkipToggle:
-                skipIntro = value ?? !skipIntro;
-                PlayerPrefs.SetInt("skipIntroVideo", skipIntro ? 1 : 0);
-                return true;
             default:
                 Debug.LogError($"Cannot find type: {type}. Somebody probably forgot to add it.");
                 return false;
@@ -412,8 +404,6 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
                 return jukeboxUI;
             case SettingsType.JukeboxBattleToggle:
                 return jukeboxBattle;
-            case SettingsType.IntroSkipToggle:
-                return skipIntro;
             default:
                 Debug.LogError($"Cannot find type: {type}. Somebody probably forgot to add it.");
                 return null;

--- a/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
+++ b/Assets/Altzone/Scripts/Settings/SettingsCarrier.cs
@@ -70,7 +70,7 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
         None,
         JukeboxSoulhomeToggle,
         JukeboxUIToggle,
-        JukeboxBattleToggle
+        IntroSkipToggle,
     }
 
     // Events
@@ -118,6 +118,8 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
     public bool jukeboxSoulhome;
     public bool jukeboxUI;
     public bool jukeboxBattle;
+
+    public bool skipIntro;
 
     public int TextSizeSmall = 22;
     public int TextSizeMedium = 26;
@@ -326,6 +328,8 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
         jukeboxUI = PlayerPrefs.GetInt("JukeboxUI") != 0;
         jukeboxBattle = PlayerPrefs.GetInt("JukeboxBattle") != 0;
 
+        skipIntro = PlayerPrefs.GetInt("SkipIntroVideo") != 0;
+
         _battleShowDebugStatsOverlay = PlayerPrefs.GetInt(BattleShowDebugStatsOverlayKey, 1) == 1;
 
         _battleArenaScale = PlayerPrefs.GetInt(BattleArenaScaleKey, BattleArenaScaleDefault);
@@ -386,6 +390,10 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
                 jukeboxBattle = value ?? !jukeboxBattle;
                 PlayerPrefs.SetInt("JukeboxBattle", jukeboxBattle ? 1 : 0);
                 return true;
+            case SettingsType.IntroSkipToggle:
+                skipIntro = value ?? !skipIntro;
+                PlayerPrefs.SetInt("skipIntroVideo", skipIntro ? 1 : 0);
+                return true;
             default:
                 Debug.LogError($"Cannot find type: {type}. Somebody probably forgot to add it.");
                 return false;
@@ -404,6 +412,8 @@ public class SettingsCarrier : MonoBehaviour // Script for carrying settings dat
                 return jukeboxUI;
             case SettingsType.JukeboxBattleToggle:
                 return jukeboxBattle;
+            case SettingsType.IntroSkipToggle:
+                return skipIntro;
             default:
                 Debug.LogError($"Cannot find type: {type}. Somebody probably forgot to add it.");
                 return null;

--- a/Assets/MenuUi/Prefabs/Windows/Settings/SettingsView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/Settings/SettingsView.prefab
@@ -16239,6 +16239,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _name: skipIntroVideo
   _type: 0
+  _name: SkipIntroVideo
+  _type: 4
 --- !u!1 &5704846992251268819
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/MenuUi/Scripts/Loader/GameLoader.cs
+++ b/Assets/MenuUi/Scripts/Loader/GameLoader.cs
@@ -55,7 +55,7 @@ namespace MenuUi.Scripts.Loader
         {
             if (!_videoPlaying && !_videoEnded)
             {
-                if (PlayerPrefs.GetInt("skipIntroVideo", 0) == 0)
+                if (PlayerPrefs.GetInt("SkipIntroVideo", 0) == 0)
                 {
                     //_introVideo.transform.Find("Video Player").GetComponent<VideoPlayer>().loopPointReached += CheckOver;
                     if (Application.platform is RuntimePlatform.WebGLPlayer)

--- a/Assets/MenuUi/Scripts/Loader/IntroVideoHandler.cs
+++ b/Assets/MenuUi/Scripts/Loader/IntroVideoHandler.cs
@@ -47,6 +47,19 @@ namespace MenuUi.Scripts.Loader
         {
             _player.loopPointReached += CheckOver;
             PlayIntroVideo();
+            var carrier = SettingsCarrier.Instance;
+            bool skip = carrier != null &&
+                        (carrier.GetBoolValue(SettingsCarrier.SettingsType.IntroSkipToggle) ?? false);
+
+            if (skip)
+            {
+                Debug.Log("Skip video (setting enabled)");
+                EndIntroVideo(); // tai SkipImmediately(), jos käytössä
+            }
+            else
+            {
+                PlayIntroVideo();
+            }
         }
 
         private void OnDisable()
@@ -77,6 +90,7 @@ namespace MenuUi.Scripts.Loader
             if (SceneManager.GetActiveScene().name == _menuscene.SceneName) WindowManager.Get().GoBack();
         }
 
+        
         void CheckOver(VideoPlayer vp)
         {
             EndIntroVideo();

--- a/Assets/MenuUi/Scripts/Loader/IntroVideoHandler.cs
+++ b/Assets/MenuUi/Scripts/Loader/IntroVideoHandler.cs
@@ -47,19 +47,6 @@ namespace MenuUi.Scripts.Loader
         {
             _player.loopPointReached += CheckOver;
             PlayIntroVideo();
-            var carrier = SettingsCarrier.Instance;
-            bool skip = carrier != null &&
-                        (carrier.GetBoolValue(SettingsCarrier.SettingsType.IntroSkipToggle) ?? false);
-
-            if (skip)
-            {
-                Debug.Log("Skip video (setting enabled)");
-                EndIntroVideo(); // tai SkipImmediately(), jos käytössä
-            }
-            else
-            {
-                PlayIntroVideo();
-            }
         }
 
         private void OnDisable()

--- a/Assets/MenuUi/Scripts/Settings/SettingEditor.cs
+++ b/Assets/MenuUi/Scripts/Settings/SettingEditor.cs
@@ -35,6 +35,8 @@ public class SettingEditor : MonoBehaviour
 
         //SetFPSButtons();
         SetIntroSkipToggle();
+        
+        
         SetShowButtonLabelsToggle();
 
         // Opening Battle Ui Editor if DataCarrier has a bool BattleUiEditorRequested and it's true
@@ -49,6 +51,7 @@ public class SettingEditor : MonoBehaviour
             popup.SetActive(false);
         }
     }
+
     private void Start()
     {
         _battleSettingsButton.onClick.AddListener(() => _battleEditor.OpenEditor());
@@ -57,6 +60,8 @@ public class SettingEditor : MonoBehaviour
 
         _topBarStyleButton.onClick.AddListener(() => ChangeTopbarStyle());
         _topBarStyleText.text = "Tyyli: " + carrier.TopBarStyleSetting;
+
+        _introSkipToggle.onValueChanged.AddListener(_ => SetIntroSkip());
     }
 
     public void SetFromSlider(Slider usedSlider)
@@ -106,13 +111,13 @@ public class SettingEditor : MonoBehaviour
 
     public void SetIntroSkipToggle()
     {
-        _introSkipToggle.isOn = (PlayerPrefs.GetInt("skipIntroVideo", 0) != 0);
+        _introSkipToggle.isOn = (PlayerPrefs.GetInt("SkipIntroVideo", 0) != 0);
     }
 
     public void SetIntroSkip()
     {
-        if(_introSkipToggle.isOn) PlayerPrefs.SetInt("skipIntroVideo", 1);
-        else PlayerPrefs.SetInt("skipIntroVideo", 0);
+        if(_introSkipToggle.isOn) PlayerPrefs.SetInt("SkipIntroVideo", 1);
+        else PlayerPrefs.SetInt("SkipIntroVideo", 0);
     }
 
     public void SetShowButtonLabelsToggle()


### PR DESCRIPTION
 'Skip Intro Video' toggle in  SettingsView, allowing users to bypass the intro video if enabled. IntroVideoHandler now checks this setting and skips playback accordingly.