### PR TITLE
Update SkipIntroVideo setting name

### DIFF
--- a/Assets/MenuUi/Prefabs/Windows/Settings/SettingsView.prefab
+++ b/Assets/MenuUi/Prefabs/Windows/Settings/SettingsView.prefab
@@ -16237,8 +16237,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d31326f1abff33f43ad47c6f6c6ae834, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _name: skipIntroVideo
-  _type: 0
   _name: SkipIntroVideo
   _type: 4
 --- !u!1 &5704846992251268819


### PR DESCRIPTION
Changed name from skipIntroVideo to SkipIntroVideo in SettingsView.prefab to ensure the toggle value is correctly saved and restored when reopening the settings menu.