### PR TITLE
Battle/test - Speed Override

### DIFF
--- a/Assets/QuantumUser/Simulation/Battle/Scripts/Player/BattlePlayerManager.cs
+++ b/Assets/QuantumUser/Simulation/Battle/Scripts/Player/BattlePlayerManager.cs
@@ -6,7 +6,7 @@
 /// The manager handles initializing players that are present in the game, as well as spawning and despawning player characters.<br/>
 /// This script also contains the public and private PlayerHandle structs.
 
-//#define DEBUG_PLAYER_STAT_OVERRIDE
+#define DEBUG_PLAYER_STAT_OVERRIDE
 
 using System.Runtime.CompilerServices;
 using UnityEngine;
@@ -374,11 +374,26 @@ namespace Battle.QSimulation.Player
                         };
 
 #if DEBUG_PLAYER_STAT_OVERRIDE
-                        playerData.Stats.Hp            = FP.FromString("3.0");
-                        playerData.Stats.Speed         = FP.FromString("20.0");
-                        playerData.Stats.CharacterSize = FP.FromString("1.0");
-                        playerData.Stats.Attack        = FP.FromString("1.0");
-                        playerData.Stats.Defence       = FP.FromString("1.0");
+                        //playerData.Stats.Hp            = FP.FromString("3.0");
+                        //playerData.Stats.Speed         = FP.FromString("20.0");
+                        //playerData.Stats.CharacterSize = FP.FromString("1.0");
+                        //playerData.Stats.Attack        = FP.FromString("1.0");
+                        //playerData.Stats.Defence       = FP.FromString("1.0");
+
+                        switch (data.Characters[playerCharacterNumber].Id)
+                        {
+                            case 101:
+                                playerData.Stats.Speed = FP.FromString("20.0");
+                                break;
+                            case 301:
+                                playerData.Stats.Speed = FP.FromString("16.0");
+                                break;
+                            case 401:
+                                playerData.Stats.Speed = FP.FromString("18.0");
+                                break;
+                            default:
+                                break;
+                        }
 #endif
                         playerData.CurrentHp = playerData.Stats.Hp;
                         playerData.CurrentDefence = playerData.Stats.Defence;


### PR DESCRIPTION
Testing different movement speeds speeds by overriding three specific characters speed stats.

BattlePlayerManager:
  - Enabled DEBUG_PLAYER_STAT_OVERRIDE
  - The speeds of characters 101, 301 and 401 are overridden to 20, 16 and 18 respectively