### PR TITLE
Fixed a few jukebox bugs

### DIFF
--- a/Assets/MenuUi/Scripts/Jukebox/JukeBoxSoulhomeHandler.cs
+++ b/Assets/MenuUi/Scripts/Jukebox/JukeBoxSoulhomeHandler.cs
@@ -101,6 +101,7 @@ public class JukeBoxSoulhomeHandler : MonoBehaviour
         JukeboxManager.Instance.OnStopJukeboxVisuals += StopJukeboxVisuals;
         JukeboxManager.Instance.OnClearJukeboxVisuals += ClearJukeboxVisuals;
         //JukeboxManager.Instance.OnSetPlayButtonImages += SetPlayButtonStates;
+        JukeboxManager.Instance.OnJukeboxMute += SetMuteImage;
 
         if (JukeboxManager.Instance.CurrentTrackQueueData != null)
             SetSongInfo(JukeboxManager.Instance.CurrentTrackQueueData.MusicTrack);
@@ -114,6 +115,7 @@ public class JukeBoxSoulhomeHandler : MonoBehaviour
         JukeboxManager.Instance.OnStopJukeboxVisuals -= StopJukeboxVisuals;
         JukeboxManager.Instance.OnClearJukeboxVisuals -= ClearJukeboxVisuals;
         //JukeboxManager.Instance.OnSetPlayButtonImages -= SetPlayButtonStates;
+        JukeboxManager.Instance.OnJukeboxMute -= SetMuteImage;
 
         StopJukeboxVisuals();
     }


### PR DESCRIPTION
- Fixed a bug where pressing mute button would play the last clan playlist track even though the playlist was empty.
- Fixed a bug when mute was on and music preview started playing it would keep playing it indefinitely.
- Made a failsafe state if JukeboxManager loaded before AudioManager.