### PR TITLE
Battle/fix - On Screen Debug Messages

### DIFF
--- a/Assets/QuantumUser/View/Battle/Scripts/UI/Handler/BattleUiDebugConsoleHandler.cs
+++ b/Assets/QuantumUser/View/Battle/Scripts/UI/Handler/BattleUiDebugConsoleHandler.cs
@@ -220,7 +220,7 @@ namespace Battle.View.UI
 
             int newIndex = (_entriesStartingIndex + _entriesCount - 1) % _entriesMax;
 
-            int endOfFirstLineIndex = message.IndexOf('\n', 0, _entryMessageLengthMax);
+            int endOfFirstLineIndex = message.IndexOf('\n', 0, Mathf.Min(_entryMessageLengthMax, message.Length));
 
             int messageShortLength = endOfFirstLineIndex > -1 ? endOfFirstLineIndex : _entryMessageLengthMax;
 


### PR DESCRIPTION
Prevents ArgumentOutOfRangeException when messages are shorter than _entryMessageLengthMax.
Fixed AddLog method by clamping the search length when using IndexOf on message. 

BattleUiDebugConsoleHandler.cs
 - Fixed IndexOf in AddLog method