### PR TITLE
add Assets/Photon/Quantum/PackageResources to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ Doc/Doxygen/Battle/doc-test/*
 !Doc/Doxygen/Battle/doc-test/.dox
 Assets/Plugins/Android/mainTemplate.gradle.backup*
 Assets/Altzone/Graphics/DefenceCharacterBattleGraphics/DefenceCharacterBattleGraphicsNew/BattlePlayer303.png
+
+Assets/Photon/Quantum/PackageResources
+Assets/Photon/Quantum/PackageResources.meta


### PR DESCRIPTION
Folder Assets\Photon\Quantum\PackageResources should not be in version control at all.
I can not change that (how it is imported to UNITY or how Photon Quantum might create these).

Only thing I can do is hide them as they just create noise to version control changes.