### PR TITLE
remove prg.debug dependency (revert baack to normal UNITY debug logging)

### DIFF
--- a/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
+++ b/Assets/Altzone/Scripts/Model/Poco/Game/CustomCharacter.cs
@@ -4,10 +4,9 @@ using System.Diagnostics.CodeAnalysis;
 using Altzone.Scripts.Config;
 using Altzone.Scripts.Model.Poco.Player;
 using Newtonsoft.Json;
-using Prg;
 using UnityEngine;
 using UnityEngine.Assertions;
-using Debug = Prg.Debug;
+using Debug = UnityEngine.Debug;
 
 namespace Altzone.Scripts.Model.Poco.Game
 {

--- a/Assets/MenuUi/Scripts/SoulHome/FurnitureHandling.cs
+++ b/Assets/MenuUi/Scripts/SoulHome/FurnitureHandling.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Altzone.Scripts.Model.Poco.Game;
 using UnityEngine;
 using UnityEngine.Rendering;
-using Debug = Prg.Debug;
 
 namespace MenuUI.Scripts.SoulHome
 {

--- a/Assets/MenuUi/Scripts/SoulHome/RoomData.cs
+++ b/Assets/MenuUi/Scripts/SoulHome/RoomData.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Altzone.Scripts.Model.Poco.Game;
 using UnityEngine;
 using UnityEngine.Rendering;
-using Debug = Prg.Debug;
 
 namespace MenuUI.Scripts.SoulHome
 {
@@ -294,7 +293,7 @@ namespace MenuUI.Scripts.SoulHome
             {
                 _ladder.gameObject.SetActive(true);
                 _ladder.GetComponent<SortingGroup>().sortingOrder = 20;
-                
+
                 foreach(Transform rowTransform in _wallBackFurniturePoints)
                 {
                     rowTransform.GetChild(1).GetComponent<FurnitureSlot>().Ladder = true;
@@ -341,7 +340,7 @@ namespace MenuUI.Scripts.SoulHome
                     }
                 }
             }
-            
+
             _walkableSlots.Clear();
 
             foreach (GridNode node in _grid)
@@ -381,7 +380,7 @@ namespace MenuUI.Scripts.SoulHome
         }
 
         // Add a penalty to tiles to the right or left of furniture, and double penalty if there is furniture to the left and the right,
-        // and also add a penalty to the bottom-right corner + 1 node to the left, and bottom-left corner and 1 node from that to the right, 
+        // and also add a penalty to the bottom-right corner + 1 node to the left, and bottom-left corner and 1 node from that to the right,
         // so the avatar only goes there if there is no other way (makes clipping with furniture less likely, and avatar only chooses to "slip"
         // through the corner of the furniture if there is absolutely no other way to the end position)
         private void CalculatePenalties()

--- a/Assets/Prg/Scripts/Common/PubSub/Hub.cs
+++ b/Assets/Prg/Scripts/Common/PubSub/Hub.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace Prg.Scripts.Common.PubSub
 {

--- a/Assets/Prg/Scripts/Common/Unity/Localization/Localizer.cs
+++ b/Assets/Prg/Scripts/Common/Unity/Localization/Localizer.cs
@@ -9,6 +9,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.UI;
+using Debug = UnityEngine.Debug;
 
 namespace Prg.Scripts.Common.Unity.Localization
 {

--- a/Assets/Prg/WebRequests.cs
+++ b/Assets/Prg/WebRequests.cs
@@ -2,9 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
-using Prg;
+using UnityEngine;
 using UnityEngine.Networking;
-using static Prg.Debug;
 
 
 /// <summary>


### PR DESCRIPTION
I removed dependency to **Prg.Debug** from these files that are actively in use.
There is more files that use it, but they are not in use so I did not want to touch them as it is separate issue (to remove them from the project).

I tried to prevent tabs but failed.
There is some noise where tabs are repalces by spaces.