### PR TITLE
Cleanup old code by jari

### DIFF
--- a/Assets/Altzone/Scripts/Config/ScriptableObjects/LocalDevConfig.cs
+++ b/Assets/Altzone/Scripts/Config/ScriptableObjects/LocalDevConfig.cs
@@ -1,5 +1,3 @@
-using System;
-using Prg.Scripts.Common.Util;
 using UnityEngine;
 
 namespace Altzone.Scripts.Config.ScriptableObjects
@@ -16,28 +14,8 @@ namespace Altzone.Scripts.Config.ScriptableObjects
     public class LocalDevConfig : ScriptableObject
     {
         /// <summary>
-        /// Use local Photon version to keep all rooms "invisible" for other developers
-        /// </summary>
-        [Header("Photon Settings")] public string _photonVersionOverride;
-
-        /// <summary>
-        /// Reference to <c>LoggerConfig</c> to use.
-        /// </summary>
-        [Header("Development Settings")] public LoggerConfig _loggerConfig;
-
-        /// <summary>
         /// Override Application.targetFrameRate for Game View in UNITY Editor, default value is -1 to use.
         /// </summary>
         [Header("Editor Settings"), Range(-1, 999)] public int _targetFrameRateOverride = -1;
-
-        /// <summary>
-        /// List of classes that use Debug.Log calls, just for your information :-)
-        /// </summary>
-        [Header("Classes Seen"), TextArea(5, 20), Tooltip("List of classes using Debug.Log in last run")] public string _loggedTypes;
-
-        public void SetLoggedDebugTypes(string lines)
-        {
-            _loggedTypes = lines;
-        }
     }
 }

--- a/Assets/Prg/Debug.cs
+++ b/Assets/Prg/Debug.cs
@@ -287,11 +287,11 @@ public static class Debug
 
     private static string GetPrefix(MemberInfo method, string memberName = null)
     {
-        var className = method.ReflectedType?.Name ?? nameof(Debug);
+        var className = method.ReflectedType?.Name ?? nameof(UnityEngine.Debug);
         if (className.StartsWith("<"))
         {
             // For anonymous types we try its parent type.
-            className = method.ReflectedType?.DeclaringType?.Name ?? nameof(Debug);
+            className = method.ReflectedType?.DeclaringType?.Name ?? nameof(UnityEngine.Debug);
         }
         var methodName = method.Name;
         if (methodName.StartsWith("<"))


### PR DESCRIPTION
Cleanup code (dependencies) to prepare for more old code refactoring and deletion.

Most propably LocalDevConfig could be deleted but ApplicationController uses it to set frame rate in Editor.
I think nobody cares if this "feature" is removed as well!