### PR TITLE
make CI/CD pipeline to use common GH actions runner

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   buildWebGL:
     name: Build WebGL
-    runs-on: [self-hosted, unity]
+    runs-on: [self-hosted, gh-runner-common]
 
     steps:
       - name: Set current date as build version

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -2,9 +2,7 @@ name: Build project
 
 on:
   schedule:
-    - cron: '0 3 * * *'
-    - cron: '0 10 * * *'
-    - cron: '0 15 * * *'
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
CI/CD pipeline now uses organization common GitHub runner. Current runner in use will be removed in future from the infra server

Closes #1658 issue