### PR TITLE
Jukebox playlist fetching is now handled through MQTT.

### DIFF
--- a/Assets/Altzone/Scripts/Audio/JukeboxManager.cs
+++ b/Assets/Altzone/Scripts/Audio/JukeboxManager.cs
@@ -437,29 +437,6 @@ namespace Altzone.Scripts.Audio
             return tracks.Find(track => track.Id == musicTrackId);
         }
 
-        /// <summary>
-        /// Used to update clan playlist.
-        /// </summary>
-        /// <returns></returns>
-        private IEnumerator ServerPlaylistFetchLoop()
-        {
-            bool? success = null;
-            float timer = 0f;
-
-            while (timer < _playlistServerFetchFrequency)
-            {
-                yield return null;
-                timer += Time.deltaTime;
-            }
-
-            StartCoroutine(UpdateLocalClanPlaylist((successData) => success = successData));
-
-            yield return new WaitUntil(() => (success != null));
-
-            if (success != null && !success.Value) yield break;
-
-            _playlistServerFetchCoroutine = StartCoroutine(ServerPlaylistFetchLoop());
-        }
         #endregion
 
         #region Playback

--- a/Assets/Altzone/Scripts/Audio/JukeboxManager.cs
+++ b/Assets/Altzone/Scripts/Audio/JukeboxManager.cs
@@ -48,6 +48,10 @@ namespace Altzone.Scripts.Audio
             All
         }
 
+        ServerPlaylist _serverPlaylistData = null;
+
+        public ServerPlaylist ServerCurrentPlaylist => _serverPlaylistData;
+
         private Playlist _currentPlaylist = null;
         public Playlist CurrentPlaylist {  get { return _currentPlaylist; } }
 
@@ -140,16 +144,13 @@ namespace Altzone.Scripts.Audio
 
             _currentPlaylist = new Playlist("Klaani", PlaylistType.Clan);
 
-            ServerPlaylist playlistData = null;
             bool? success = null;
 
-            StartCoroutine(UpdateLocalClanPlaylist((successData) => success = successData, (serverPlaylistData) => playlistData = serverPlaylistData));
+            StartCoroutine(UpdateLocalClanPlaylist((successData) => success = successData));
 
             yield return new WaitUntil(() => (success != null));
 
             if (!success.Value) yield break;
-
-            UpdateQueueContents(playlistData);
 
             _musicTrackFavorites = GetFavoriteDatas();
             _playlistReady = true;
@@ -278,9 +279,9 @@ namespace Altzone.Scripts.Audio
             playlistData(serverPlaylist);
         }
 
-        private void UpdateLocalClanPlaylist() { StartCoroutine(UpdateLocalClanPlaylist(null, null)); }
+        private void UpdateLocalClanPlaylist() { StartCoroutine(UpdateLocalClanPlaylist(null)); }
 
-        private IEnumerator UpdateLocalClanPlaylist(System.Action<bool> successCallback, System.Action<ServerPlaylist> serverPlaylistCallback)
+        private IEnumerator UpdateLocalClanPlaylist(System.Action<bool> successCallback)
         {
             ServerPlaylist serverPlaylistData = null;
             bool? timeout = null;
@@ -305,15 +306,16 @@ namespace Altzone.Scripts.Audio
                 yield break;
             }
 
-            UpdateQueueContents(serverPlaylistData);
+            _serverPlaylistData = serverPlaylistData;
+
+            UpdateQueueContents();
             OnQueueChange?.Invoke();
-            StartCoroutine(PlayServerTrack(serverPlaylistData.currentSong));
+            StartCoroutine(PlayServerTrack());
 
             _serverOperationAvailable = true;
 
             _playlistServerFetchCoroutine = StartCoroutine(ServerPlaylistFetchLoop());
 
-            serverPlaylistCallback?.Invoke(serverPlaylistData);
             successCallback?.Invoke(true);
         }
 
@@ -393,7 +395,7 @@ namespace Altzone.Scripts.Audio
                 timer += Time.deltaTime;
             }
 
-            StartCoroutine(UpdateLocalClanPlaylist((successData) => success = successData, null));
+            StartCoroutine(UpdateLocalClanPlaylist((successData) => success = successData));
 
             yield return new WaitUntil(() => (success != null));
 
@@ -404,11 +406,11 @@ namespace Altzone.Scripts.Audio
         #endregion
 
         #region Playback
-        private IEnumerator PlayServerTrack(ServerCurrentSong serverCurrentSong)
+        private IEnumerator PlayServerTrack()
         {
-            yield return new WaitUntil(() => _currentPlaylist != null);
+            yield return new WaitUntil(() => _currentPlaylist != null || _serverPlaylistData != null);
 
-            if (serverCurrentSong == null)
+            if (_serverPlaylistData.currentSong == null)
             {
                 _currentTrackQueueData = null;
 
@@ -422,6 +424,7 @@ namespace Altzone.Scripts.Audio
 
                 yield break;
             }
+            ServerCurrentSong serverCurrentSong = _serverPlaylistData.currentSong;
 
             System.DateTime gmtTime = System.DateTimeOffset.FromUnixTimeMilliseconds(serverCurrentSong.startedAt).DateTime;
             System.DateTime localTime = gmtTime.ToLocalTime();
@@ -826,10 +829,10 @@ namespace Altzone.Scripts.Audio
         /// <summary>
         /// Update local track queue contents with server playlist.
         /// </summary>
-        /// <param name="serverPlaylist"></param>
-        public void UpdateQueueContents(ServerPlaylist serverPlaylist)
+        public void UpdateQueueContents()
         {
             _trackQueue.Clear();
+            ServerPlaylist serverPlaylist = _serverPlaylistData;
 
             for (int i = 0; i < serverPlaylist.songQueue.Count; i++)
             {

--- a/Assets/Altzone/Scripts/Audio/JukeboxManager.cs
+++ b/Assets/Altzone/Scripts/Audio/JukeboxManager.cs
@@ -1,6 +1,8 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Altzone.Scripts.Model.Poco.Player;
+using Altzone.Scripts.MQTT;
 using Altzone.Scripts.ReferenceSheets;
 using UnityEngine;
 
@@ -48,7 +50,7 @@ namespace Altzone.Scripts.Audio
             All
         }
 
-        ServerPlaylist _serverPlaylistData = null;
+        private ServerPlaylist _serverPlaylistData = null;
 
         public ServerPlaylist ServerCurrentPlaylist => _serverPlaylistData;
 
@@ -136,6 +138,12 @@ namespace Altzone.Scripts.Audio
 
         private void Start() { StartCoroutine(Setup()); }
 
+        private void OnDestroy()
+        {
+            MQTTManager.OnJukeboxPlaylistUpdated -= UpdateLocalClanPlaylist;
+            MQTTManager.OnJukeboxSongUpdated -= UpdateLocalClanSong;
+        }
+
         private IEnumerator Setup()
         {
             StartCoroutine(GetPlayerData());
@@ -157,7 +165,9 @@ namespace Altzone.Scripts.Audio
 
             OnQueueChange?.Invoke();
 
-            _playlistServerFetchCoroutine = StartCoroutine(ServerPlaylistFetchLoop());
+            //_playlistServerFetchCoroutine = StartCoroutine(ServerPlaylistFetchLoop());
+            MQTTManager.OnJukeboxPlaylistUpdated += UpdateLocalClanPlaylist;
+            MQTTManager.OnJukeboxSongUpdated += UpdateLocalClanSong;
         }
 
         private IEnumerator GetPlayerData()
@@ -279,7 +289,7 @@ namespace Altzone.Scripts.Audio
             playlistData(serverPlaylist);
         }
 
-        private void UpdateLocalClanPlaylist() { StartCoroutine(UpdateLocalClanPlaylist(null)); }
+        private void UpdateLocalClanPlaylist() { StartCoroutine(UpdateLocalClanPlaylist(successCallback: null)); }
 
         private IEnumerator UpdateLocalClanPlaylist(System.Action<bool> successCallback)
         {
@@ -314,9 +324,56 @@ namespace Altzone.Scripts.Audio
 
             _serverOperationAvailable = true;
 
-            _playlistServerFetchCoroutine = StartCoroutine(ServerPlaylistFetchLoop());
+            //_playlistServerFetchCoroutine = StartCoroutine(ServerPlaylistFetchLoop());
 
             successCallback?.Invoke(true);
+        }
+
+        private void UpdateLocalClanPlaylist(MQTTJukeBoxPlaylist list) => StartCoroutine(UpdateLocalClanPlaylistCoroutine(list));
+
+        private IEnumerator UpdateLocalClanPlaylistCoroutine(MQTTJukeBoxPlaylist list)
+        {
+            yield return new WaitUntil(() =>_serverOperationAvailable == true);
+
+            if (list == null)
+            {
+                yield break;
+            }
+
+            _serverPlaylistData = new(list);
+
+            UpdateQueueContents();
+            OnQueueChange?.Invoke();
+            StartCoroutine(PlayServerTrack());
+        }
+
+        private void UpdateLocalClanSong(MQTTCurrentSong song) => StartCoroutine(UpdateLocalClanSongCoroutine(song));
+
+
+        private IEnumerator UpdateLocalClanSongCoroutine(MQTTCurrentSong song)
+        {
+            yield return new WaitUntil(() => _serverOperationAvailable == true);
+
+            if (song == null)
+            {
+                yield break;
+            }
+
+            foreach (var data in _serverPlaylistData.songQueue)
+            {
+                if (data.songId.Equals(song.songId))
+                {
+                    _serverPlaylistData.currentSong = new(data,song);
+                    _serverPlaylistData.songQueue.Remove(data);
+
+                }
+            }
+
+            _serverPlaylistData.currentSong = new(song);
+
+            UpdateQueueContents();
+            OnQueueChange?.Invoke();
+            StartCoroutine(PlayServerTrack());
         }
 
         private IEnumerator DeleteTrackFromServer(System.Action<bool> successCallback, string trackUniqueId, string trackName)
@@ -832,6 +889,7 @@ namespace Altzone.Scripts.Audio
         public void UpdateQueueContents()
         {
             _trackQueue.Clear();
+            if (_serverPlaylistData == null)  return;
             ServerPlaylist serverPlaylist = _serverPlaylistData;
 
             for (int i = 0; i < serverPlaylist.songQueue.Count; i++)

--- a/Assets/Altzone/Scripts/Audio/JukeboxManager.cs
+++ b/Assets/Altzone/Scripts/Audio/JukeboxManager.cs
@@ -33,6 +33,9 @@ namespace Altzone.Scripts.Audio
         private bool _jukeboxMuted = false;
         public bool JukeboxMuted { get {  return _jukeboxMuted; } }
 
+        private bool _jukeboxDisabled = false;
+        public bool JukeboxDisabled { get { return _jukeboxDisabled; } }
+
         private float _musicElapsedTime = 0f;
         #endregion
 
@@ -165,7 +168,6 @@ namespace Altzone.Scripts.Audio
 
             OnQueueChange?.Invoke();
 
-            //_playlistServerFetchCoroutine = StartCoroutine(ServerPlaylistFetchLoop());
             MQTTManager.OnJukeboxPlaylistUpdated += UpdateLocalClanPlaylist;
             MQTTManager.OnJukeboxSongUpdated += UpdateLocalClanSong;
         }
@@ -324,8 +326,6 @@ namespace Altzone.Scripts.Audio
 
             _serverOperationAvailable = true;
 
-            //_playlistServerFetchCoroutine = StartCoroutine(ServerPlaylistFetchLoop());
-
             successCallback?.Invoke(true);
         }
 
@@ -444,6 +444,8 @@ namespace Altzone.Scripts.Audio
         {
             yield return new WaitUntil(() => _currentPlaylist != null || _serverPlaylistData != null);
 
+            if(_jukeboxDisabled) yield break; 
+
             if (_serverPlaylistData.currentSong == null)
             {
                 _currentTrackQueueData = null;
@@ -517,7 +519,7 @@ namespace Altzone.Scripts.Audio
         /// <returns>Track name that is playing.</returns>
         public string PlayTrack(TrackQueueData trackQueueData, bool forcePlay)
         {
-            if (!forcePlay && PlayTrackBlockingCheck(trackQueueData) || _trackPreviewActive) return null;
+            if (!forcePlay && PlayTrackBlockingCheck(trackQueueData) || _trackPreviewActive || _jukeboxDisabled) return null;
 
             string trackName = "";
 
@@ -586,6 +588,29 @@ namespace Altzone.Scripts.Audio
             return (muteActivation ? _jukeboxMuted : _playbackPaused);
         }
 
+        public void DisableJukeBox()
+        {
+            if (JukeboxDisabled) return;
+            _jukeboxDisabled = true;
+            if (JukeboxMuted) return;
+            if (_serverPlaylistData.currentSong != null) AudioManager.Instance.PlayFallBackTrack();
+        }
+
+        public void EnableJukeBox()
+        {
+            _jukeboxDisabled = false;
+
+            if (!_playbackPaused && !_jukeboxMuted)
+            {
+                if (_currentTrackQueueData != null)
+                    ContinueTrack(false);
+                else
+                    PlayTrack();
+            }
+            else
+                AudioManager.Instance.PlayFallBackTrack();
+        }
+
         /// <summary>
         /// Continues the current music track.
         /// </summary>
@@ -620,7 +645,7 @@ namespace Altzone.Scripts.Audio
 
             OnSetSongInfo?.Invoke(_currentTrackQueueData.MusicTrack);
 
-            if (!_jukeboxMuted)
+            if (!_jukeboxMuted || !_jukeboxDisabled)
                 return AudioManager.Instance.ContinueMusic(AudioCategoryType.Jukebox, _currentTrackQueueData.MusicTrack,
                     MusicHandler.MusicSwitchType.CrossFade, _musicElapsedTime, forcePlay);
 

--- a/Assets/Altzone/Scripts/Audio/ServerCurrentSong.cs
+++ b/Assets/Altzone/Scripts/Audio/ServerCurrentSong.cs
@@ -1,7 +1,42 @@
-﻿public class ServerCurrentSong
+﻿using Altzone.Scripts.MQTT;
+
+public class ServerCurrentSong
 {
     public string id;
     public string songId;
     public string playerId;
     public long startedAt;
+
+    [Newtonsoft.Json.JsonConstructor]
+    public ServerCurrentSong(string id, string songId, string playerId, long startedAt)
+    {
+        this.id = id;
+        this.songId = songId;
+        this.playerId = playerId;
+        this.startedAt = startedAt;
+    }
+
+    public ServerCurrentSong(MQTTJukeBoxSong song)
+    {
+        id = song.id;
+        songId = song.songId;
+        playerId = song.playerId;
+        startedAt = song.startedAt;
+    }
+
+    public ServerCurrentSong(ServerSong songFromList, MQTTCurrentSong newsong)
+    {
+        id = songFromList.id;
+        songId = songFromList.songId;
+        playerId = songFromList.playerId;
+        startedAt = newsong.startedAt;
+    }
+
+    public ServerCurrentSong(MQTTCurrentSong song)
+    {
+        id = null;
+        songId = song.songId;
+        playerId = null;
+        startedAt = song.startedAt;
+    }
 }

--- a/Assets/Altzone/Scripts/Audio/ServerPlaylist.cs
+++ b/Assets/Altzone/Scripts/Audio/ServerPlaylist.cs
@@ -17,8 +17,8 @@ public class ServerPlaylist
 
     public ServerPlaylist(MQTTJukeBoxPlaylist mqttPlaylist)
     {
-        currentSong = new(mqttPlaylist.currentSong);
+        currentSong = mqttPlaylist.currentSong != null ? new(mqttPlaylist.currentSong) : null;
 
-        songQueue = mqttPlaylist.songQueue.Select(x => new ServerSong(x)).ToList();
+        songQueue = mqttPlaylist.currentSong != null ? mqttPlaylist.songQueue.Select(x => new ServerSong(x)).ToList() : null;
     }
 }

--- a/Assets/Altzone/Scripts/Audio/ServerPlaylist.cs
+++ b/Assets/Altzone/Scripts/Audio/ServerPlaylist.cs
@@ -1,7 +1,24 @@
 using System.Collections.Generic;
+using System.Linq;
+using Altzone.Scripts.MQTT;
+using Newtonsoft.Json;
 
 public class ServerPlaylist
 {
     public ServerCurrentSong currentSong { get; set; }
     public List<ServerSong> songQueue { get; set; }
+
+    [Newtonsoft.Json.JsonConstructor]
+    public ServerPlaylist(ServerCurrentSong song, List<ServerSong> queue)
+    {
+        currentSong = song;
+        songQueue = queue;
+    }
+
+    public ServerPlaylist(MQTTJukeBoxPlaylist mqttPlaylist)
+    {
+        currentSong = new(mqttPlaylist.currentSong);
+
+        songQueue = mqttPlaylist.songQueue.Select(x => new ServerSong(x)).ToList();
+    }
 }

--- a/Assets/Altzone/Scripts/Audio/ServerSong.cs
+++ b/Assets/Altzone/Scripts/Audio/ServerSong.cs
@@ -1,4 +1,6 @@
-﻿public class ServerSong
+﻿using Altzone.Scripts.MQTT;
+
+public class ServerSong
 {
     public string id;
     public string songId;
@@ -20,6 +22,14 @@
         songId = serverCurrentSong.songId;
         playerId = serverCurrentSong.playerId;
         songDurationSeconds = -1;
+    }
+
+    public ServerSong(MQTTJukeBoxQueue song)
+    {
+        id = song.id;
+        songId = song.songId;
+        playerId = song.playerId;
+        songDurationSeconds = song.songDurationSeconds;
     }
 }
 

--- a/Assets/Altzone/Scripts/MQTT/MQTTJukebox.cs
+++ b/Assets/Altzone/Scripts/MQTT/MQTTJukebox.cs
@@ -16,9 +16,9 @@ namespace Altzone.Scripts.MQTT
     {
         public string id { get; set; }
         public string songId { get; set; }
-        public float songDurationSeconds { get; set; }
+        public int songDurationSeconds { get; set; }
         public string playerId { get; set; }
-        public float startedAt { get; set; }
+        public long startedAt { get; set; }
     }
 
     [Serializable]
@@ -26,7 +26,7 @@ namespace Altzone.Scripts.MQTT
     {
         public string id { get; set; }
         public string songId { get; set; }
-        public float songDurationSeconds { get; set; }
+        public int songDurationSeconds { get; set; }
         public string playerId { get; set; }
     }
 
@@ -34,6 +34,6 @@ namespace Altzone.Scripts.MQTT
     public class MQTTCurrentSong
     {
         public string songId { get; set; }
-        public float startedAt { get; set; }
+        public long startedAt { get; set; }
     }
 }

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -6600,6 +6600,7 @@ namespace Altzone.Scripts.Lobby
 
         public static void CloseRunner()
         {
+            JukeboxManager.Instance.DisableJukeBox();
             AudioManager.Instance.StopMusic();
             QuantumRunner.ShutdownAll();
             DebugLogFileHandler.ContextEnter(DebugLogFileHandler.ContextID.MenuUI);

--- a/Assets/MenuUi/Prefabs/Windows/BattleStory/BattleStartHandler.cs
+++ b/Assets/MenuUi/Prefabs/Windows/BattleStory/BattleStartHandler.cs
@@ -34,6 +34,7 @@ public class BattleStartHandler : MonoBehaviour
 
     private void OnEnable()
     {
+        JukeboxManager.Instance.DisableJukeBox();
         AudioManager.Instance.StopMusic(); //This should have a short sfx clip playing while the battle starts.
         OverlayPanelCheck.Instance.ToggleOverlay(false);
         LobbyManager.OnStartTimeSet += StartTimer;

--- a/Assets/MenuUi/Scripts/MainMenu/MainMenuController.cs
+++ b/Assets/MenuUi/Scripts/MainMenu/MainMenuController.cs
@@ -48,8 +48,9 @@ namespace MenuUi.Scripts.MainMenu
             OverlayPanelCheck.Instance?.ToggleOverlay(true);
 
             AudioManager.Instance?.PlayMusic(AudioCategoryType.MainMenu);
+            if(JukeboxManager.Instance.JukeboxDisabled) JukeboxManager.Instance?.EnableJukeBox();
 
-            if(!LobbyManager.IsActive) LobbyManager.Instance.Activate();
+            if (!LobbyManager.IsActive) LobbyManager.Instance.Activate();
             if (LobbyManager.Instance.RunnerActive) LobbyManager.CloseRunner();
 
             StartCoroutine(EnableChooseTask());

--- a/Assets/QuantumUser/View/Battle/Scripts/Audio/BattleAudioViewController.cs
+++ b/Assets/QuantumUser/View/Battle/Scripts/Audio/BattleAudioViewController.cs
@@ -30,6 +30,7 @@ namespace Battle.View.Audio
         public static void PlayMusic()
         {
             AudioManager.Instance.PlayMusic(AudioCategoryType.Battle, MusicHandler.MusicSwitchType.Immediate, forcePlay: true);
+            JukeboxManager.Instance.EnableJukeBox();
         }
 
         /// <summary>


### PR DESCRIPTION
This makes the playlist update immediately when changes happen and no longer unnecessarily fetches data from server every few seconds.
Also fixed a bug that caused music to start playing seemingly randomly during match start and match end screens.