### PR TITLE
UI/matchmaking/feature/flipper test startup

### DIFF
--- a/Assets/Altzone/Scripts/Photon/GameTypeEnum.cs
+++ b/Assets/Altzone/Scripts/Photon/GameTypeEnum.cs
@@ -19,5 +19,35 @@ namespace Altzone.Scripts.Lobby
         BattleTestFlipperGame = 1,
         Raid = 10,
     }
+    public static class CustomGameModeExtension
+    {
+        public static string GetString(this GameType gameMode)
+        {
+            return SettingsCarrier.Instance.Language switch
+            {
+                SettingsCarrier.LanguageType.English => gameMode switch
+                {
+                    GameType.BattlePingPong => "Basegame",
+                    GameType.BattleTestFlipperGame => "Flipper test",
+                    GameType.Raid => "Raid",
+                    _ => ""
+                },
+                SettingsCarrier.LanguageType.Finnish => gameMode switch
+                {
+                    GameType.BattlePingPong => "Peruspeli",
+                    GameType.BattleTestFlipperGame => "Flipper testi",
+                    GameType.Raid => "Ryöstö",
+                    _ => ""
+                },
+                _ => gameMode switch
+                {
+                    GameType.BattlePingPong => "Peruspeli",
+                    GameType.BattleTestFlipperGame => "Flipper testi",
+                    GameType.Raid => "Ryöstö",
+                    _ => ""
+                },
+            };
+        }
+    }
 }
 

--- a/Assets/Altzone/Scripts/Photon/GameTypeEnum.cs
+++ b/Assets/Altzone/Scripts/Photon/GameTypeEnum.cs
@@ -3,14 +3,20 @@ namespace Altzone.Scripts.Lobby
     /// <summary>
     /// Used for determining battle popup game type.
     /// </summary>
-    public enum GameType
+    public enum MatchmakingType
     {
         None = -1,
         Custom = 0,
         Random2v2 = 1,
         Clan2v2 = 2,
         FriendLobby = 3,
-        TestFlipperGame = 4,
+    }
+
+    public enum GameType
+    {
+        None = -1,
+        BattlePingPong = 0,
+        BattleTestFlipperGame = 1,
         Raid = 10,
     }
 }

--- a/Assets/Altzone/Scripts/Photon/LobbyManager.cs
+++ b/Assets/Altzone/Scripts/Photon/LobbyManager.cs
@@ -120,7 +120,7 @@ namespace Altzone.Scripts.Lobby
         private Coroutine _reserveFreePositionHolder = null;
         private Coroutine _requestPositionChangeHolder = null;
         private Coroutine _matchmakingHolder = null;
-        private GameType _currentMatchmakingGameType = GameType.Random2v2;
+        private MatchmakingType _currentMatchmakingGameType = MatchmakingType.Random2v2;
         private Coroutine _followLeaderHolder = null;
         private Coroutine _formingMatchHolder = null;
         private Coroutine _startGameHolder = null;
@@ -395,17 +395,17 @@ namespace Altzone.Scripts.Lobby
             if (!PhotonRealtimeClient.InRoom || PhotonRealtimeClient.CurrentRoom == null) return;
             if (PhotonRealtimeClient.LocalPlayer == null || !PhotonRealtimeClient.LocalPlayer.IsMasterClient) return;
 
-            GameType gameType;
+            MatchmakingType gameType;
             try
             {
-                gameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                gameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
             }
             catch
             {
                 return;
             }
 
-            if (gameType != GameType.Custom) return;
+            if (gameType != MatchmakingType.Custom) return;
             _canBattleStartCheckHolder = StartCoroutine(CheckIfBattleCanStart());
         }
 
@@ -424,8 +424,8 @@ namespace Altzone.Scripts.Lobby
 
                 if (CheckIfAllPlayersInPosition())
                 {
-                    GameType gameType = (GameType)room.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
-                    if (gameType == GameType.Custom)
+                    MatchmakingType gameType = (MatchmakingType)room.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
+                    if (gameType == MatchmakingType.Custom)
                     {
                         OnStartPlayingEvent(new StartPlayingEvent());
                     }
@@ -623,14 +623,14 @@ namespace Altzone.Scripts.Lobby
 
                 bool created = false;
                 // Use deterministic server-side join-or-create to avoid leader create races.
-                if ((GameType)roomGameTypeInt == GameType.Clan2v2)
+                if ((MatchmakingType)roomGameTypeInt == MatchmakingType.Clan2v2)
                 {
-                    created = PhotonRealtimeClient.JoinOrCreateMatchmakingRoom(GameType.Clan2v2, selected, clanName, clanId, soulhomeRank);
+                    created = PhotonRealtimeClient.JoinOrCreateMatchmakingRoom(MatchmakingType.Clan2v2, selected, clanName, clanId, soulhomeRank);
                     Debug.Log($"FormMatchFromQueue: JoinOrCreateMatchmakingRoom(Clan2v2) returned: {created}");
                 }
                 else
                 {
-                    created = PhotonRealtimeClient.JoinOrCreateMatchmakingRoom(GameType.Random2v2, selected);
+                    created = PhotonRealtimeClient.JoinOrCreateMatchmakingRoom(MatchmakingType.Random2v2, selected);
                     Debug.Log($"FormMatchFromQueue: JoinOrCreateMatchmakingRoom(Random2v2) returned: {created}");
                 }
 
@@ -887,7 +887,7 @@ namespace Altzone.Scripts.Lobby
             if (reservationFailed)
             {
                 // Perform requeue outside of try/catch/finally to allow yielding safely.
-                yield return StartCoroutine(RequeueToPersistentQueue((GameType)roomGameTypeInt, queuePremadeMode, queuePremadeUserId1, queuePremadeUsername1, queuePremadeUserId2, queuePremadeUsername2, queuePremadeTargetGameType));
+                yield return StartCoroutine(RequeueToPersistentQueue((MatchmakingType)roomGameTypeInt, queuePremadeMode, queuePremadeUserId1, queuePremadeUsername1, queuePremadeUserId2, queuePremadeUsername2, queuePremadeTargetGameType));
                 yield break;
             }
         }
@@ -1025,7 +1025,7 @@ namespace Altzone.Scripts.Lobby
         // is now fully deprecated in favor of centralized queue-based matchmaking.
 
         // Requeue the local player into the persistent queue room for the given game type.
-        private IEnumerator RequeueToPersistentQueue(GameType gameType, bool premadeMode = false, string premadeUserId1 = "", string premadeUsername1 = "", string premadeUserId2 = "", string premadeUsername2 = "", int premadeTargetGameType = -1)
+        private IEnumerator RequeueToPersistentQueue(MatchmakingType gameType, bool premadeMode = false, string premadeUserId1 = "", string premadeUsername1 = "", string premadeUserId2 = "", string premadeUsername2 = "", int premadeTargetGameType = -1)
         {
             try
             {
@@ -1191,10 +1191,10 @@ namespace Altzone.Scripts.Lobby
 
         private int GetQueueRequiredFollowerCount(int roomGameTypeInt)
         {
-            switch ((GameType)roomGameTypeInt)
+            switch ((MatchmakingType)roomGameTypeInt)
             {
-                case GameType.Random2v2:
-                case GameType.Clan2v2:
+                case MatchmakingType.Random2v2:
+                case MatchmakingType.Clan2v2:
                 default:
                     return 3;
             }
@@ -1654,7 +1654,7 @@ namespace Altzone.Scripts.Lobby
                 result.Add((leader.UserId, followerId));
             }
 
-            if ((GameType)roomGameTypeInt is GameType.Clan2v2)
+            if ((MatchmakingType)roomGameTypeInt is MatchmakingType.Clan2v2)
             {
 
                 List<Player> remainingPlayers = playersById.Values
@@ -1762,8 +1762,8 @@ namespace Altzone.Scripts.Lobby
 
         private bool IsTwoPlayerBlockQueueMode(int roomGameTypeInt)
         {
-            GameType gameType = (GameType)roomGameTypeInt;
-            return gameType == GameType.Random2v2 || gameType == GameType.Clan2v2;
+            MatchmakingType gameType = (MatchmakingType)roomGameTypeInt;
+            return gameType == MatchmakingType.Random2v2 || gameType == MatchmakingType.Clan2v2;
         }
 
         private List<string> SelectQueueFollowersFromTwoPlayerBlocks(
@@ -3024,11 +3024,11 @@ namespace Altzone.Scripts.Lobby
                         {
                             if (_formingMatchHolder == null && Time.time - start >= QueueReadyStartDelaySeconds)
                             {
-                                int loopGameTypeInt = (int)GameType.Random2v2;
+                                int loopGameTypeInt = (int)MatchmakingType.Random2v2;
                                 string loopClanName = string.Empty;
                                 string loopClanId = string.Empty;
                                 int loopSoulhomeRank = 0;
-                                try { loopGameTypeInt = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey); } catch { }
+                                try { loopGameTypeInt = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey); } catch { }
                                 try { loopClanName = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(PhotonBattleRoom.ClanNameKey, ""); } catch { }
                                 try { loopClanId = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(PhotonBattleRoom.ClanIdKey, ""); } catch { }
                                 try { loopSoulhomeRank = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.SoulhomeRank, 0); } catch { }
@@ -3210,11 +3210,11 @@ namespace Altzone.Scripts.Lobby
                         yield return null;
                     }
 
-                    int gameTypeInt = (int)GameType.Random2v2;
+                    int gameTypeInt = (int)MatchmakingType.Random2v2;
                     string clanName = string.Empty;
                     string clanId = string.Empty;
                     int soulhomeRank = 0;
-                    try { gameTypeInt = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey); } catch (Exception ex) { Debug.LogWarning($"QueueTimerCoroutine: failed to read game type: {ex.Message}"); }
+                    try { gameTypeInt = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey); } catch (Exception ex) { Debug.LogWarning($"QueueTimerCoroutine: failed to read game type: {ex.Message}"); }
                     try { clanName = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(PhotonBattleRoom.ClanNameKey, ""); } catch (Exception ex) { Debug.LogWarning($"QueueTimerCoroutine: failed to read clan name: {ex.Message}"); }
                     try { clanId = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(PhotonBattleRoom.ClanIdKey, ""); } catch (Exception ex) { Debug.LogWarning($"QueueTimerCoroutine: failed to read clan id: {ex.Message}"); }
                     try { soulhomeRank = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.SoulhomeRank, 0); } catch (Exception ex) { Debug.LogWarning($"QueueTimerCoroutine: failed to read soulhome rank: {ex.Message}"); }
@@ -3582,7 +3582,7 @@ namespace Altzone.Scripts.Lobby
             }
         }
 
-        private IEnumerator LeaveAndAutoRequeue(GameType gameType)
+        private IEnumerator LeaveAndAutoRequeue(MatchmakingType gameType)
         {
             try
             {
@@ -3679,7 +3679,7 @@ namespace Altzone.Scripts.Lobby
                 {
                     // Non-master: try to auto-join the largest available matchmaking room (skip for Custom game type)
                     Debug.Log($"LeaveAndAutoRequeue: non-master starting auto-join for {gameType}");
-                    if (gameType != GameType.Custom)
+                    if (gameType != MatchmakingType.Custom)
                     {
                         if (_autoJoinHolder != null)
                         {
@@ -3894,7 +3894,7 @@ namespace Altzone.Scripts.Lobby
         /// Leader-side matchmaking entry point.
         /// Flow: lock current room -> gather teammate/position context -> notify followers -> leave to lobby -> join or create a matchmaking room.
         /// </summary>
-        private IEnumerator StartMatchmaking(GameType gameType, bool broadcastRoomChange = true)
+        private IEnumerator StartMatchmaking(MatchmakingType gameType, bool broadcastRoomChange = true)
         {
             // remember which game type we're matchmaking for so failure handlers can requeue
             _currentMatchmakingGameType = gameType;
@@ -3919,7 +3919,7 @@ namespace Altzone.Scripts.Lobby
                     // Saving custom properties from the room to the variables
                     clanName = PhotonRealtimeClient.CurrentRoom.GetCustomProperty(PhotonBattleRoom.ClanNameKey, "");
                     clanId = PhotonRealtimeClient.CurrentRoom.GetCustomProperty(PhotonBattleRoom.ClanIdKey, "");
-                    if (gameType is GameType.Clan2v2 && string.IsNullOrEmpty(clanName))
+                    if (gameType is MatchmakingType.Clan2v2 && string.IsNullOrEmpty(clanName))
                     {
                         clanName = ServerManager.Instance.Clan.name;
                         clanId = ServerManager.Instance.Clan._id;
@@ -4029,7 +4029,7 @@ namespace Altzone.Scripts.Lobby
                 }
                 else
                 {
-                    if (gameType is GameType.Clan2v2)
+                    if (gameType is MatchmakingType.Clan2v2)
                     {
                         clanName = ServerManager.Instance.Clan.name;
                         clanId = ServerManager.Instance.Clan._id;
@@ -4151,7 +4151,7 @@ namespace Altzone.Scripts.Lobby
                 bool roomFound = false;
                 bool joinedExistingRoom = false;
                 // Use a shorter per-room timeout for Random2v2 to reduce delays when iterating many candidates.
-                float joinAttemptTimeout = gameType == GameType.Random2v2 ? 2f : 5f; // seconds to wait for a join to succeed before trying next room
+                float joinAttemptTimeout = gameType == MatchmakingType.Random2v2 ? 2f : 5f; // seconds to wait for a join to succeed before trying next room
 
                 if (CurrentRooms != null && CurrentRooms.Count > 0)
                 {
@@ -4161,13 +4161,13 @@ namespace Altzone.Scripts.Lobby
                     foreach (LobbyRoomInfo room in roomsList)
                     {
                         // Checking if the room has a game type and matchmaking key in the first place
-                        if (!room.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey) || !room.CustomProperties.ContainsKey(PhotonBattleRoom.IsMatchmakingKey))
+                        if (!room.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey) || !room.CustomProperties.ContainsKey(PhotonBattleRoom.IsMatchmakingKey))
                         {
                             continue;
                         }
 
                         // Checking that the game type matches and that the room is a matchmaking room
-                        if ((GameType)room.CustomProperties[PhotonBattleRoom.GameTypeKey] != gameType || (bool)room.CustomProperties[PhotonBattleRoom.IsMatchmakingKey] == false)
+                        if ((MatchmakingType)room.CustomProperties[PhotonBattleRoom.MatchmakingKey] != gameType || (bool)room.CustomProperties[PhotonBattleRoom.IsMatchmakingKey] == false)
                         {
                             continue;
                         }
@@ -4176,13 +4176,13 @@ namespace Altzone.Scripts.Lobby
                         bool shouldTryJoin = false;
                         switch (gameType)
                         {
-                            case GameType.Clan2v2:
+                            case MatchmakingType.Clan2v2:
                                 if ((string)room.CustomProperties[PhotonBattleRoom.ClanNameKey] != clanName && room.MaxPlayers - room.PlayerCount >= _teammates.Length + 1)
                                 {
                                     shouldTryJoin = true;
                                 }
                                 break;
-                            case GameType.Random2v2:
+                            case MatchmakingType.Random2v2:
                                 if (room.MaxPlayers - room.PlayerCount >= _teammates.Length + 1)
                                 {
                                     shouldTryJoin = !_isPremadeMatchmakingFlow || RoomHasSameSideCapacityForPremade(room);
@@ -4229,24 +4229,24 @@ namespace Altzone.Scripts.Lobby
                 {
                     switch (gameType)
                     {
-                        case GameType.Clan2v2:
+                        case MatchmakingType.Clan2v2:
                             if (_isPremadeMatchmakingFlow)
                             {
                                 PhotonRealtimeClient.JoinRandomOrCreateClan2v2Room(clanName, clanId, soulhomeRank, GetTeammateIds(), true);
                             }
                             else
                             {
-                                PhotonRealtimeClient.JoinOrCreateMatchmakingRoom(GameType.Clan2v2, GetTeammateIds(), clanName, clanId, soulhomeRank);
+                                PhotonRealtimeClient.JoinOrCreateMatchmakingRoom(MatchmakingType.Clan2v2, GetTeammateIds(), clanName, clanId, soulhomeRank);
                             }
                             break;
-                        case GameType.Random2v2:
+                        case MatchmakingType.Random2v2:
                             if (_isPremadeMatchmakingFlow)
                             {
                                 PhotonRealtimeClient.JoinRandomOrCreateRandom2v2Room(GetTeammateIds(), true);
                             }
                             else
                             {
-                                PhotonRealtimeClient.JoinOrCreateMatchmakingRoom(GameType.Random2v2, GetTeammateIds());
+                                PhotonRealtimeClient.JoinOrCreateMatchmakingRoom(MatchmakingType.Random2v2, GetTeammateIds());
                             }
                             break;
                     }
@@ -4388,7 +4388,7 @@ namespace Altzone.Scripts.Lobby
                 {
                     switch (gameType)
                     {
-                        case GameType.Clan2v2:
+                        case MatchmakingType.Clan2v2:
 
                             if (_teammates.Length == 0) {
                                 string mainClanName = PhotonRealtimeClient.CurrentRoom.GetCustomProperty(PhotonBattleRoom.ClanNameKey, "");
@@ -4422,7 +4422,7 @@ namespace Altzone.Scripts.Lobby
                             }
                             break;
 
-                        case GameType.Random2v2:
+                        case MatchmakingType.Random2v2:
                             if (_teammates.Length == 0) // If queuing solo
                             {
                                 StartCoroutine(ReserveFreePosition());
@@ -4802,10 +4802,10 @@ namespace Altzone.Scripts.Lobby
                         }
 
                         // Check if matchmaking timeout expired and fill remaining slots with bots (Random2v2 only)
-                        GameType currentGameType = GameType.Random2v2;
+                        MatchmakingType currentGameType = MatchmakingType.Random2v2;
                         try
                         {
-                            currentGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                            currentGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                         }
                         catch (Exception ex) { Debug.LogWarning($"WaitForMatchmakingPlayers: failed to read game type: {ex.Message}"); }
 
@@ -5129,8 +5129,8 @@ namespace Altzone.Scripts.Lobby
 
                                 if (!TryReservePremadePairToSameSide(pairUserId1, pairUserId2, out _))
                                 {
-                                    GameType requeueGameType = GameType.Random2v2;
-                                    try { requeueGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey); } catch { }
+                                    MatchmakingType requeueGameType = MatchmakingType.Random2v2;
+                                    try { requeueGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey); } catch { }
                                     Debug.LogWarning($"WaitForMatchmakingPlayers: could not keep queue duo ({pairUserId1},{pairUserId2}) on same side, requeueing.");
                                     StartCoroutine(LeaveAndAutoRequeue(requeueGameType));
                                     yield break;
@@ -5163,8 +5163,8 @@ namespace Altzone.Scripts.Lobby
                     {
                         if (!TryReservePremadePairToSameSide(premadeUserId1, premadeUserId2, out _))
                         {
-                            GameType requeueGameType = GameType.Random2v2;
-                            try { requeueGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey); } catch { }
+                            MatchmakingType requeueGameType = MatchmakingType.Random2v2;
+                            try { requeueGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey); } catch { }
                             Debug.LogWarning($"WaitForMatchmakingPlayers: could not keep premade pair ({premadeUserId1},{premadeUserId2}) on same side, requeueing.");
                             StartCoroutine(LeaveAndAutoRequeue(requeueGameType));
                             yield break;
@@ -5181,12 +5181,12 @@ namespace Altzone.Scripts.Lobby
                     try
                     {
                         bool queueFormedMatch = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<bool>(QueueFormedMatchKey, false);
-                        int queueGameType = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey, (int)GameType.Random2v2);
+                        int queueGameType = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey, (int)MatchmakingType.Random2v2);
                         if (queueFormedMatch && IsTwoPlayerBlockQueueMode(queueGameType))
                         {
                             if (!ValidateQueueTwoPlayerBlockComposition(PhotonRealtimeClient.CurrentRoom, out string blockValidationReason))
                             {
-                                GameType requeueGameType = (GameType)queueGameType;
+                                MatchmakingType requeueGameType = (MatchmakingType)queueGameType;
                                 Debug.LogWarning($"WaitForMatchmakingPlayers: invalid two-player block composition ({blockValidationReason}), requeueing.");
                                 StartCoroutine(LeaveAndAutoRequeue(requeueGameType));
                                 yield break;
@@ -5243,8 +5243,8 @@ namespace Altzone.Scripts.Lobby
                     }
 
                     // Checking that the clan names are in order
-                    GameType roomGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
-                    if (roomGameType == GameType.Clan2v2)
+                    MatchmakingType roomGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
+                    if (roomGameType == MatchmakingType.Clan2v2)
                     {
                         string primaryClan = string.Empty;
                         string primaryClanId = string.Empty;
@@ -5284,7 +5284,7 @@ namespace Altzone.Scripts.Lobby
                     }
 
                     // For Random2v2 ensure team names are set (they aren't set by the Clan2v2 block above)
-                    if (roomGameType == GameType.Random2v2)
+                    if (roomGameType == MatchmakingType.Random2v2)
                     {
                         if (string.IsNullOrWhiteSpace(_blueTeamName)) _blueTeamName = "Team Alpha";
                         if (string.IsNullOrWhiteSpace(_redTeamName)) _redTeamName = "Team Beta";
@@ -5328,7 +5328,7 @@ namespace Altzone.Scripts.Lobby
                     // When botfill is active in Random2v2, allow start even if bot position replication is still catching up.
                     int botCount = PhotonBattleRoom.GetBotCount();
                     bool roomIsFullWithBots = PhotonRealtimeClient.CurrentRoom.PlayerCount + botCount >= PhotonRealtimeClient.CurrentRoom.MaxPlayers;
-                    bool canStartWithBotFill = roomGameType == GameType.Random2v2 && botFillActive;
+                    bool canStartWithBotFill = roomGameType == MatchmakingType.Random2v2 && botFillActive;
                     if (roomIsFullWithBots || canStartWithBotFill)
                     {
                         if (_startGameHolder != null)
@@ -5350,7 +5350,7 @@ namespace Altzone.Scripts.Lobby
 
         // Follower safety-net: if countdown does not begin soon after joining matchmaking,
         // leave and requeue to avoid getting stuck in a stale room.
-        private IEnumerator MatchmakingJoinWatcher(GameType gameType, float timeoutSeconds)
+        private IEnumerator MatchmakingJoinWatcher(MatchmakingType gameType, float timeoutSeconds)
         {
             try
             {
@@ -5389,8 +5389,8 @@ namespace Altzone.Scripts.Lobby
                 }
 
                 // Timeout reached: countdown did not start; leave and requeue
-                GameType requeueGameType = GameType.Random2v2;
-                try { requeueGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey); } catch (Exception ex) { Debug.LogWarning($"MatchmakingJoinWatcher: failed to read game type: {ex.Message}"); }
+                MatchmakingType requeueGameType = MatchmakingType.Random2v2;
+                try { requeueGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey); } catch (Exception ex) { Debug.LogWarning($"MatchmakingJoinWatcher: failed to read game type: {ex.Message}"); }
                 Debug.Log($"MatchmakingJoinWatcher: countdown did not start within {timeoutSeconds}s in room '{PhotonRealtimeClient.CurrentRoom?.Name}'; leaving and requeueing for {requeueGameType}.");
 
                 _autoRequeueAttempts++;
@@ -5454,9 +5454,9 @@ namespace Altzone.Scripts.Lobby
                 try
                 {
                     if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null
-                        && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                        && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                     {
-                        if ((GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == GameType.Custom)
+                        if ((MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == MatchmakingType.Custom)
                         {
                             Debug.Log("FollowLeaderToNewRoom: current room is Custom, will not leave.");
                             yield break;
@@ -5533,11 +5533,11 @@ namespace Altzone.Scripts.Lobby
 
                             if (!newRoomJoined)
                             {
-                            GameType queueGameType = GameType.Random2v2;
+                            MatchmakingType queueGameType = MatchmakingType.Random2v2;
                             try
                             {
                                 if (leaderRoomName.StartsWith("Queue_", StringComparison.Ordinal)
-                                    && Enum.TryParse(leaderRoomName.Substring("Queue_".Length), out GameType parsedQueueType))
+                                    && Enum.TryParse(leaderRoomName.Substring("Queue_".Length), out MatchmakingType parsedQueueType))
                                 {
                                     queueGameType = parsedQueueType;
                                 }
@@ -5668,10 +5668,10 @@ namespace Altzone.Scripts.Lobby
                     {
                         if (queueRoomRequested)
                         {
-                            GameType queueGameType = GameType.Random2v2;
+                            MatchmakingType queueGameType = MatchmakingType.Random2v2;
                             if (!string.IsNullOrEmpty(leaderRoomName)
                                 && leaderRoomName.StartsWith("Queue_", StringComparison.Ordinal)
-                                && Enum.TryParse(leaderRoomName.Substring("Queue_".Length), out GameType parsedQueueType))
+                                && Enum.TryParse(leaderRoomName.Substring("Queue_".Length), out MatchmakingType parsedQueueType))
                             {
                                 queueGameType = parsedQueueType;
                             }
@@ -5726,9 +5726,9 @@ namespace Altzone.Scripts.Lobby
                             {
                                 try
                                 {
-                                    GameType queueGameType = GameType.Random2v2;
+                                    MatchmakingType queueGameType = MatchmakingType.Random2v2;
                                     if (leaderRoomName.StartsWith("Queue_", StringComparison.Ordinal)
-                                        && Enum.TryParse(leaderRoomName.Substring("Queue_".Length), out GameType parsedQueueType))
+                                        && Enum.TryParse(leaderRoomName.Substring("Queue_".Length), out MatchmakingType parsedQueueType))
                                     {
                                         queueGameType = parsedQueueType;
                                     }
@@ -5769,12 +5769,12 @@ namespace Altzone.Scripts.Lobby
         private IEnumerator LeaveMatchmaking()
         {
             // Safely read the matchmaking room game type; PhotonExtensions handles null room now.
-            GameType matchmakingRoomGameType = GameType.Random2v2;
+            MatchmakingType matchmakingRoomGameType = MatchmakingType.Random2v2;
             if (PhotonRealtimeClient.CurrentRoom != null)
             {
                 try
                 {
-                    matchmakingRoomGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                    matchmakingRoomGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                 }
                 catch (Exception ex)
                 {
@@ -5807,7 +5807,7 @@ namespace Altzone.Scripts.Lobby
             // Creating back the non-matchmaking room which the teammates can join (only for Clan2v2)
             switch (matchmakingRoomGameType)
             {
-                case GameType.Clan2v2:
+                case MatchmakingType.Clan2v2:
                 {
                     string clanName = PhotonRealtimeClient.LocalLobbyPlayer?.GetCustomProperty(PhotonBattleRoom.ClanNameKey, "");
                     string clanId = PhotonRealtimeClient.LocalLobbyPlayer?.GetCustomProperty(PhotonBattleRoom.ClanIdKey, "");
@@ -6275,8 +6275,10 @@ namespace Altzone.Scripts.Lobby
                 bool useCountdown = true;
                 try
                 {
+                    MatchmakingType roomMatchType = (MatchmakingType)room.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                     GameType roomGameType = (GameType)room.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
-                    useCountdown = roomGameType != GameType.Custom;
+                    useCountdown = roomMatchType != MatchmakingType.Custom;
+                    data.MatchmakingType = roomMatchType;
                     data.GameType = roomGameType;
                 }
                 catch (Exception ex)
@@ -6377,7 +6379,7 @@ namespace Altzone.Scripts.Lobby
             if (PhotonRealtimeClient.InMatchmakingRoom)
             {
                 OnFailedToStartMatchmakingGame?.Invoke();
-                GameType gameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                MatchmakingType gameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                 OnStopMatchmakingEvent(new(gameType));
             }
         }
@@ -6471,7 +6473,7 @@ namespace Altzone.Scripts.Lobby
                         PlayerCount = data.PlayerCount,
                         ProjectileInitialEmotion = (BattleEmotionState)data.ProjectileInitialEmotion,
                         IsTestMode = data.TestMode,
-                        IsTestFlipperGame = data.GameType == GameType.TestFlipperGame
+                        IsTestFlipperGame = data.GameType == GameType.BattleTestFlipperGame
                     }
                 };
 
@@ -6497,6 +6499,7 @@ namespace Altzone.Scripts.Lobby
 
                 _roomInfo = new()
                 {
+                    MatchmakingType = data.MatchmakingType,
                     GameType = data.GameType,
                     Player1Id = data.PlayerSlotUserIds[0],
                     Player1Name = data.PlayerSlotUserNames[0],
@@ -7351,18 +7354,18 @@ namespace Altzone.Scripts.Lobby
             {
                 if (data.Reason == GetKickedEvent.ReasonType.FullRoom)
                 {
-                    GameType requeueGameType = _currentMatchmakingGameType;
+                    MatchmakingType requeueGameType = _currentMatchmakingGameType;
                     try
                     {
                         if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null
-                            && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                            && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                         {
-                            requeueGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                            requeueGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                         }
                     }
                     catch (Exception ex) { Debug.LogWarning($"OnGetKickedEvent: failed to read room game type: {ex.Message}"); }
 
-                    if (requeueGameType == GameType.Random2v2 || requeueGameType == GameType.Clan2v2)
+                    if (requeueGameType == MatchmakingType.Random2v2 || requeueGameType == MatchmakingType.Clan2v2)
                     {
                         Debug.Log($"OnGetKickedEvent: room full, auto-requeueing for {requeueGameType}.");
                         StartCoroutine(LeaveAndAutoRequeue(requeueGameType));
@@ -7410,12 +7413,12 @@ namespace Altzone.Scripts.Lobby
             if (startCountdownInProgress)
             {
                 // If a player leaves during countdown, force all players to leave and requeue
-                GameType currentRoomGameType = GameType.Random2v2;
+                MatchmakingType currentRoomGameType = MatchmakingType.Random2v2;
                 try
                 {
                     if (PhotonRealtimeClient.CurrentRoom != null)
                     {
-                        currentRoomGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                        currentRoomGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                     }
                 }
                 catch (Exception ex) { Debug.LogWarning($"OnPlayerLeftRoom: failed to read current room game type: {ex.Message}"); }
@@ -7425,9 +7428,9 @@ namespace Altzone.Scripts.Lobby
                 try
                 {
                     if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null
-                        && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                        && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                     {
-                        isCustomRoom = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == GameType.Custom;
+                        isCustomRoom = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == MatchmakingType.Custom;
                     }
                 }
                 catch (Exception ex) { Debug.LogWarning($"OnPlayerLeftRoom: failed to determine if room is Custom: {ex.Message}"); }
@@ -7582,8 +7585,8 @@ namespace Altzone.Scripts.Lobby
             {
                 // If the game type is clan 2v2 and the player who left was a teammate we leave the room,
                 // since you can't play the game mode without 2 person team from the same clan
-                GameType roomGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
-                if (roomGameType == GameType.Clan2v2)
+                MatchmakingType roomGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
+                if (roomGameType == MatchmakingType.Clan2v2)
                 {
                     string ownClan = PhotonRealtimeClient.LocalPlayer.GetCustomProperty<string>(PhotonBattleRoom.ClanNameKey);
                     string otherPlayerClan = otherPlayer.GetCustomProperty<string>(PhotonBattleRoom.ClanNameKey);
@@ -7769,8 +7772,8 @@ namespace Altzone.Scripts.Lobby
             try
             {
                 if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null
-                    && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey)
-                    && (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == GameType.FriendLobby)
+                    && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey)
+                    && (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == MatchmakingType.FriendLobby)
                 {
                     string invitedUserId = PhotonRealtimeClient.CurrentRoom.GetCustomProperty<string>(PhotonBattleRoom.PremadeInvitedUserIdKey, string.Empty);
                     if (!string.IsNullOrEmpty(invitedUserId) && invitedUserId == PhotonRealtimeClient.LocalPlayer.UserId)
@@ -7829,8 +7832,8 @@ namespace Altzone.Scripts.Lobby
 
                     if (!PhotonRealtimeClient.LocalPlayer.IsMasterClient && !isQueueRoom)
                     {
-                        GameType roomGameType = GameType.Random2v2;
-                        try { roomGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey); } catch (Exception ex) { Debug.LogWarning($"OnJoinedRoom: failed to read room game type: {ex.Message}"); }
+                        MatchmakingType roomGameType = MatchmakingType.Random2v2;
+                        try { roomGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey); } catch (Exception ex) { Debug.LogWarning($"OnJoinedRoom: failed to read room game type: {ex.Message}"); }
                         bool queueFormedMatch = false;
                         int expectedFollowers = 0;
                         string[] expectedUsers = null;
@@ -7913,9 +7916,9 @@ namespace Altzone.Scripts.Lobby
                 try
                 {
                     if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null
-                        && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                        && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                     {
-                        inCustomRoom = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == GameType.Custom;
+                        inCustomRoom = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == MatchmakingType.Custom;
                     }
                 }
                 catch { }
@@ -8094,13 +8097,13 @@ namespace Altzone.Scripts.Lobby
             foreach (LobbyRoomInfo room in roomList)
             {
                 if (room == null || room.RemovedFromList || !room.IsOpen || room.CustomProperties == null) continue;
-                if (!room.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey)) continue;
+                if (!room.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey)) continue;
 
-                GameType gameType;
-                try { gameType = (GameType)room.CustomProperties[PhotonBattleRoom.GameTypeKey]; }
+                MatchmakingType gameType;
+                try { gameType = (MatchmakingType)room.CustomProperties[PhotonBattleRoom.MatchmakingKey]; }
                 catch { continue; }
 
-                if (gameType != GameType.FriendLobby) continue;
+                if (gameType != MatchmakingType.FriendLobby) continue;
 
                 string invitedUserId = room.CustomProperties.ContainsKey(PhotonBattleRoom.PremadeInvitedUserIdKey)
                     ? room.CustomProperties[PhotonBattleRoom.PremadeInvitedUserIdKey]?.ToString()
@@ -8147,11 +8150,11 @@ namespace Altzone.Scripts.Lobby
                     ? room.CustomProperties[PhotonBattleRoom.PremadeLeaderUsernameKey]?.ToString()
                     : string.Empty;
 
-                GameType targetGameType = GameType.Random2v2;
+                MatchmakingType targetGameType = MatchmakingType.Random2v2;
                 if (room.CustomProperties.ContainsKey(PhotonBattleRoom.PremadeTargetGameTypeKey))
                 {
-                    try { targetGameType = (GameType)Convert.ToInt32(room.CustomProperties[PhotonBattleRoom.PremadeTargetGameTypeKey]); }
-                    catch { targetGameType = GameType.Random2v2; }
+                    try { targetGameType = (MatchmakingType)Convert.ToInt32(room.CustomProperties[PhotonBattleRoom.PremadeTargetGameTypeKey]); }
+                    catch { targetGameType = MatchmakingType.Random2v2; }
                 }
 
                 InRoomInviteReceived inviteReceivedHandler = OnInRoomInviteReceived;
@@ -8235,12 +8238,12 @@ namespace Altzone.Scripts.Lobby
                 // If the failure is a full-game error, loop back to queue/requeue flow
                 if (isGameFull)
                 {
-                    GameType requeueGameType = _currentMatchmakingGameType;
+                    MatchmakingType requeueGameType = _currentMatchmakingGameType;
                     try
                     {
-                        if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                        if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                         {
-                            requeueGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                            requeueGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                         }
                     }
                     catch (Exception ex) { Debug.LogWarning($"OnJoinRoomFailed: failed to read current room game type: {ex.Message}"); }
@@ -8275,18 +8278,18 @@ namespace Altzone.Scripts.Lobby
                     Debug.Log("Received CancelGameStart");
                     // Parse optional requeue instruction: [bool requeue, int gameType]
                     bool requeueInstruction = false;
-                    GameType requeueGameType = GameType.Random2v2;
+                    MatchmakingType requeueGameType = MatchmakingType.Random2v2;
                     try
                     {
                         if (photonEvent.CustomData is object[] arr && arr.Length > 0)
                         {
                             if (arr[0] is bool b) requeueInstruction = b;
-                            if (arr.Length > 1 && arr[1] is int gi) requeueGameType = (GameType)gi;
+                            if (arr.Length > 1 && arr[1] is int gi) requeueGameType = (MatchmakingType)gi;
                         }
                         else if (photonEvent.CustomData is PhotonHashtable pht)
                         {
                             if (pht.ContainsKey("requeue")) requeueInstruction = (bool)pht["requeue"];
-                            if (pht.ContainsKey("gameType")) requeueGameType = (GameType)(int)pht["gameType"];
+                            if (pht.ContainsKey("gameType")) requeueGameType = (MatchmakingType)(int)pht["gameType"];
                         }
                     }
                     catch { }
@@ -8331,9 +8334,9 @@ namespace Altzone.Scripts.Lobby
                             try
                             {
                                 if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null
-                                    && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                                    && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                                 {
-                                    isCustomRoom = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == GameType.Custom;
+                                    isCustomRoom = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == MatchmakingType.Custom;
                                 }
                             }
                             catch { }
@@ -8637,9 +8640,9 @@ namespace Altzone.Scripts.Lobby
                     try
                     {
                         if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null
-                            && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                            && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                         {
-                            isCustomRoom = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == GameType.Custom;
+                            isCustomRoom = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == MatchmakingType.Custom;
                         }
                     }
                     catch { }
@@ -8854,8 +8857,8 @@ namespace Altzone.Scripts.Lobby
 
             try
             {
-                if (room != null && room.CustomProperties != null && room.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey)
-                    && (GameType)room.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == GameType.FriendLobby)
+                if (room != null && room.CustomProperties != null && room.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey)
+                    && (MatchmakingType)room.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == MatchmakingType.FriendLobby)
                 {
                     string invitedUserId = room.GetCustomProperty<string>(PhotonBattleRoom.PremadeInvitedUserIdKey, string.Empty);
                     if (!string.IsNullOrEmpty(invitedUserId) && newPlayer != null && newPlayer.UserId == invitedUserId)
@@ -8905,9 +8908,9 @@ namespace Altzone.Scripts.Lobby
                         try
                         {
                             if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null
-                                && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                                && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                             {
-                                isCustomRoom = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == GameType.Custom;
+                                isCustomRoom = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == MatchmakingType.Custom;
                             }
                         }
                         catch { }
@@ -8988,18 +8991,18 @@ namespace Altzone.Scripts.Lobby
                     OnGameStartCancelled?.Invoke();
 
                     // Decide game type for requeue
-                    GameType roomGameType = GameType.Random2v2;
+                    MatchmakingType roomGameType = MatchmakingType.Random2v2;
                     try
                     {
-                        if (room != null && room.CustomProperties != null && room.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                        if (room != null && room.CustomProperties != null && room.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                         {
-                            roomGameType = (GameType)room.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                            roomGameType = (MatchmakingType)room.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                         }
                     }
                     catch { }
 
                     // Only perform requeue for non-Custom matchmaking rooms
-                    if (roomGameType != GameType.Custom)
+                    if (roomGameType != MatchmakingType.Custom)
                     {
                         try { StartCoroutine(LeaveAndAutoRequeue(roomGameType)); } catch { }
                     }
@@ -9019,17 +9022,17 @@ namespace Altzone.Scripts.Lobby
                     try { StopMatchmakingCoroutines(); } catch { }
                     OnGameStartCancelled?.Invoke();
 
-                    GameType roomGameType = GameType.Random2v2;
+                    MatchmakingType roomGameType = MatchmakingType.Random2v2;
                     try
                     {
-                        if (room != null && room.CustomProperties != null && room.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                        if (room != null && room.CustomProperties != null && room.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                         {
-                            roomGameType = (GameType)room.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                            roomGameType = (MatchmakingType)room.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                         }
                     }
                     catch { }
 
-                    if (roomGameType != GameType.Custom)
+                    if (roomGameType != MatchmakingType.Custom)
                     {
                         try { StartCoroutine(LeaveAndAutoRequeue(roomGameType)); } catch { }
                         try
@@ -9136,9 +9139,9 @@ namespace Altzone.Scripts.Lobby
                     try
                     {
                         if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null
-                            && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                            && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                         {
-                            isCustomRoom = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == GameType.Custom;
+                            isCustomRoom = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == MatchmakingType.Custom;
                         }
                     }
                     catch { }
@@ -9150,12 +9153,12 @@ namespace Altzone.Scripts.Lobby
                         {
                             if (Time.time - _lastStartCancelTime < 15f)
                             {
-                                GameType roomGameType = GameType.Random2v2;
+                                MatchmakingType roomGameType = MatchmakingType.Random2v2;
                                 try
                                 {
-                                    if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.GameTypeKey))
+                                    if (PhotonRealtimeClient.CurrentRoom != null && PhotonRealtimeClient.CurrentRoom.CustomProperties != null && PhotonRealtimeClient.CurrentRoom.CustomProperties.ContainsKey(PhotonBattleRoom.MatchmakingKey))
                                     {
-                                        roomGameType = (GameType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                                        roomGameType = (MatchmakingType)PhotonRealtimeClient.CurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                                     }
                                 }
                                 catch { }
@@ -9335,10 +9338,10 @@ namespace Altzone.Scripts.Lobby
 
         public class StartMatchmakingEvent
         {
-            public readonly GameType SelectedGameType;
+            public readonly MatchmakingType SelectedGameType;
             public readonly bool IsPremadeInRoom;
 
-            public StartMatchmakingEvent(GameType gameType, bool isPremadeInRoom = false)
+            public StartMatchmakingEvent(MatchmakingType gameType, bool isPremadeInRoom = false)
             {
                 SelectedGameType = gameType;
                 IsPremadeInRoom = isPremadeInRoom;
@@ -9356,9 +9359,9 @@ namespace Altzone.Scripts.Lobby
             public readonly string LeaderUserId;
             public readonly string LeaderUserName;
             public readonly string InvitedUserId;
-            public readonly GameType TargetGameType;
+            public readonly MatchmakingType TargetGameType;
 
-            public InRoomInviteInfo(string roomName, string leaderUserId, string leaderUsername, string invitedUserId, GameType targetGameType)
+            public InRoomInviteInfo(string roomName, string leaderUserId, string leaderUsername, string invitedUserId, MatchmakingType targetGameType)
             {
                 RoomName = roomName;
                 LeaderUserId = leaderUserId;
@@ -9375,10 +9378,10 @@ namespace Altzone.Scripts.Lobby
 
         public class StopMatchmakingEvent
         {
-            public readonly GameType SelectedGameType;
+            public readonly MatchmakingType SelectedGameType;
             public readonly bool ForceLeave;
 
-            public StopMatchmakingEvent(GameType gameType, bool forceLeave = false)
+            public StopMatchmakingEvent(MatchmakingType gameType, bool forceLeave = false)
             {
                 SelectedGameType = gameType;
                 ForceLeave = forceLeave;
@@ -9422,6 +9425,7 @@ namespace Altzone.Scripts.Lobby
         public string[] PlayerSlotUserIds { get; set; }
         public string[] PlayerSlotUserNames { get; set; }
         public PlayerType[] PlayerSlotTypes { get; set; }
+        public MatchmakingType MatchmakingType { get; set; }
         public GameType GameType { get; set; }
         public Emotion ProjectileInitialEmotion { get; set; }
         public string MapId { get; set; }
@@ -9437,6 +9441,7 @@ namespace Altzone.Scripts.Lobby
             Serializer.Serialize(b.PlayerSlotUserIds, ref bytes);
             Serializer.Serialize(b.PlayerSlotUserNames, ref bytes);
             Serializer.Serialize(b.PlayerSlotTypes.Cast<int>().ToArray(), ref bytes);
+            Serializer.Serialize((int)b.MatchmakingType, ref bytes);
             Serializer.Serialize((int)b.GameType, ref bytes);
             Serializer.Serialize((int)b.ProjectileInitialEmotion, ref bytes);
             Serializer.Serialize(b.MapId, ref bytes);
@@ -9455,6 +9460,7 @@ namespace Altzone.Scripts.Lobby
             result.PlayerSlotUserIds = Serializer.DeserializeStringArray(data, ref offset);
             result.PlayerSlotUserNames = Serializer.DeserializeStringArray(data, ref offset);
             result.PlayerSlotTypes = Serializer.DeserializeIntArray(data, ref offset).Cast<PlayerType>().ToArray();
+            result.MatchmakingType = (MatchmakingType)Serializer.DeserializeInt(data, ref offset);
             result.GameType = (GameType)Serializer.DeserializeInt(data, ref offset);
             result.ProjectileInitialEmotion = (Emotion)Serializer.DeserializeInt(data, ref offset);
             result.MapId = Serializer.DeserializeString(data, ref offset);
@@ -9520,6 +9526,7 @@ namespace Altzone.Scripts.Lobby
 
     public class BattleRoomInfo
     {
+        public MatchmakingType MatchmakingType { get; set; }
         public GameType GameType { get; set; }
         public string Player1Id { get; set; }
         public string Player1Name { get; set; }

--- a/Assets/Altzone/Scripts/Photon/PhotonBattleRoom.cs
+++ b/Assets/Altzone/Scripts/Photon/PhotonBattleRoom.cs
@@ -41,6 +41,7 @@ namespace Altzone.Scripts.Battle.Photon
         public const string StartingEmotionKey = "e";
         public const string RoomNameKey = "n";
         public const string PasswordKey = "pw";
+        public const string MatchmakingKey = "mt";
         public const string GameTypeKey = "gt";
         public const string CustomGameModeKey = "cgm";
         public const string BotFillKey = "bf";

--- a/Assets/Altzone/Scripts/Photon/PhotonBattleRoom.cs
+++ b/Assets/Altzone/Scripts/Photon/PhotonBattleRoom.cs
@@ -43,7 +43,6 @@ namespace Altzone.Scripts.Battle.Photon
         public const string PasswordKey = "pw";
         public const string MatchmakingKey = "mt";
         public const string GameTypeKey = "gt";
-        public const string CustomGameModeKey = "cgm";
         public const string BotFillKey = "bf";
         public const string IsMatchmakingKey = "mm";
         public const string IsQueueKey = "iq";

--- a/Assets/Altzone/Scripts/Photon/PhotonRealtimeClient.cs
+++ b/Assets/Altzone/Scripts/Photon/PhotonRealtimeClient.cs
@@ -673,7 +673,7 @@ public static class PhotonRealtimeClient
         }
     }
 
-    private static RoomOptions GetRoomOptions(MatchmakingType lobbyType, MatchmakingType gametype = MatchmakingType.None, bool isMatchmaking = false, string mapId = "", Emotion startingEmotion = Emotion.Blank, string roomName = "", string password = "", string clanName = "", string clanId = "", int soulhomeRank = -1, int customGameMode = -1, bool showToFriends = false, bool showToClan = false, string leaderId = null)
+    private static RoomOptions GetRoomOptions(MatchmakingType lobbyType, MatchmakingType matchmakingType = MatchmakingType.None, bool isMatchmaking = false, string mapId = "", Emotion startingEmotion = Emotion.Blank, string roomName = "", string password = "", string clanName = "", string clanId = "", int soulhomeRank = -1, int customGameMode = -1, bool showToFriends = false, bool showToClan = false, string leaderId = null)
     {
         PhotonHashtable customRoomProperties = new PhotonHashtable
         {
@@ -684,14 +684,14 @@ public static class PhotonRealtimeClient
             { PhotonBattleRoom.PlayerPositionKey1, LocalPlayer.UserId }, // Local player always starts in slot 1 first when creating room
             { PhotonBattleRoom.PlayerPositionKey2, "" },
         };
-        if (gametype is MatchmakingType.None) { gametype = lobbyType; }
+        if (matchmakingType is MatchmakingType.None) { matchmakingType = lobbyType; }
 
         List<string> propertiesShowingToLobby = new() { PhotonBattleRoom.MatchmakingKey, PhotonBattleRoom.IsMatchmakingKey };
 
         if (lobbyType == MatchmakingType.FriendLobby)
         {
             customRoomProperties.Add(PhotonBattleRoom.PremadeModeKey, true);
-            customRoomProperties.Add(PhotonBattleRoom.PremadeTargetGameTypeKey, (int)gametype);
+            customRoomProperties.Add(PhotonBattleRoom.PremadeTargetGameTypeKey, (int)matchmakingType);
             customRoomProperties.Add(PhotonBattleRoom.PremadeLeaderUserIdKey, LocalPlayer.UserId);
             customRoomProperties.Add(PhotonBattleRoom.PremadeLeaderUsernameKey, LocalPlayer.NickName);
             customRoomProperties.Add(PhotonBattleRoom.PremadeInvitedUserIdKey, "");
@@ -897,12 +897,12 @@ public static class PhotonRealtimeClient
         );
     }
 
-    public static bool CreateInRoomPremadeLobbyRoom(MatchmakingType gameType= MatchmakingType.None, string[] expectedUsers = null)
+    public static bool CreateInRoomPremadeLobbyRoom(MatchmakingType matchmakingType= MatchmakingType.None, string[] expectedUsers = null)
     {
-        string roomName = $"FriendLobby_{LocalPlayer.UserId}_{gameType}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+        string roomName = $"FriendLobby_{LocalPlayer.UserId}_{matchmakingType}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
         RoomOptions roomOptions = GetRoomOptions(
             lobbyType: MatchmakingType.FriendLobby,
-            gametype: gameType,
+            matchmakingType: matchmakingType,
             roomName: roomName
         );
 

--- a/Assets/Altzone/Scripts/Photon/PhotonRealtimeClient.cs
+++ b/Assets/Altzone/Scripts/Photon/PhotonRealtimeClient.cs
@@ -711,12 +711,6 @@ public static class PhotonRealtimeClient
             propertiesShowingToLobby.Add(PhotonBattleRoom.PremadeLeaderUsernameKey);
         }
 
-        if (lobbyType == MatchmakingType.Custom && customGameMode >= 0)
-        {
-            customRoomProperties.Add(PhotonBattleRoom.CustomGameModeKey, customGameMode);
-            propertiesShowingToLobby.Add(PhotonBattleRoom.CustomGameModeKey);
-        }
-
         int maxPlayers;
 
         switch (lobbyType)
@@ -750,6 +744,12 @@ public static class PhotonRealtimeClient
         {
             customRoomProperties.Add(PhotonBattleRoom.RoomNameKey, roomName);
             // propertiesShowingToLobby.Add(PhotonBattleRoom.RoomNameKey); Commented out because maybe needed later
+        }
+
+        if (customGameMode >= 0)
+        {
+            customRoomProperties.Add(PhotonBattleRoom.GameTypeKey, customGameMode);
+            propertiesShowingToLobby.Add(PhotonBattleRoom.GameTypeKey);
         }
 
         if (!string.IsNullOrEmpty(password))
@@ -897,12 +897,13 @@ public static class PhotonRealtimeClient
         );
     }
 
-    public static bool CreateInRoomPremadeLobbyRoom(MatchmakingType matchmakingType= MatchmakingType.None, string[] expectedUsers = null)
+    public static bool CreateInRoomPremadeLobbyRoom(MatchmakingType matchmakingType= MatchmakingType.None, GameType gameType = GameType.BattlePingPong, string[] expectedUsers = null)
     {
         string roomName = $"FriendLobby_{LocalPlayer.UserId}_{matchmakingType}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
         RoomOptions roomOptions = GetRoomOptions(
             lobbyType: MatchmakingType.FriendLobby,
             matchmakingType: matchmakingType,
+            customGameMode: (int)gameType,
             roomName: roomName
         );
 

--- a/Assets/Altzone/Scripts/Photon/PhotonRealtimeClient.cs
+++ b/Assets/Altzone/Scripts/Photon/PhotonRealtimeClient.cs
@@ -673,22 +673,22 @@ public static class PhotonRealtimeClient
         }
     }
 
-    private static RoomOptions GetRoomOptions(GameType lobbyType, GameType gametype = GameType.None, bool isMatchmaking = false, string mapId = "", Emotion startingEmotion = Emotion.Blank, string roomName = "", string password = "", string clanName = "", string clanId = "", int soulhomeRank = -1, int customGameMode = -1, bool showToFriends = false, bool showToClan = false, string leaderId = null)
+    private static RoomOptions GetRoomOptions(MatchmakingType lobbyType, MatchmakingType gametype = MatchmakingType.None, bool isMatchmaking = false, string mapId = "", Emotion startingEmotion = Emotion.Blank, string roomName = "", string password = "", string clanName = "", string clanId = "", int soulhomeRank = -1, int customGameMode = -1, bool showToFriends = false, bool showToClan = false, string leaderId = null)
     {
         PhotonHashtable customRoomProperties = new PhotonHashtable
         {
-            { PhotonBattleRoom.GameTypeKey, lobbyType },
+            { PhotonBattleRoom.MatchmakingKey, lobbyType },
             { PhotonBattleRoom.IsMatchmakingKey, isMatchmaking },
             { PhotonBattleRoom.MapKey, mapId },
             { PhotonBattleRoom.StartingEmotionKey, startingEmotion },
             { PhotonBattleRoom.PlayerPositionKey1, LocalPlayer.UserId }, // Local player always starts in slot 1 first when creating room
             { PhotonBattleRoom.PlayerPositionKey2, "" },
         };
-        if (gametype is GameType.None) { gametype = lobbyType; }
+        if (gametype is MatchmakingType.None) { gametype = lobbyType; }
 
-        List<string> propertiesShowingToLobby = new() { PhotonBattleRoom.GameTypeKey, PhotonBattleRoom.IsMatchmakingKey };
+        List<string> propertiesShowingToLobby = new() { PhotonBattleRoom.MatchmakingKey, PhotonBattleRoom.IsMatchmakingKey };
 
-        if (lobbyType == GameType.FriendLobby)
+        if (lobbyType == MatchmakingType.FriendLobby)
         {
             customRoomProperties.Add(PhotonBattleRoom.PremadeModeKey, true);
             customRoomProperties.Add(PhotonBattleRoom.PremadeTargetGameTypeKey, (int)gametype);
@@ -711,7 +711,7 @@ public static class PhotonRealtimeClient
             propertiesShowingToLobby.Add(PhotonBattleRoom.PremadeLeaderUsernameKey);
         }
 
-        if (lobbyType == GameType.Custom && customGameMode >= 0)
+        if (lobbyType == MatchmakingType.Custom && customGameMode >= 0)
         {
             customRoomProperties.Add(PhotonBattleRoom.CustomGameModeKey, customGameMode);
             propertiesShowingToLobby.Add(PhotonBattleRoom.CustomGameModeKey);
@@ -722,11 +722,11 @@ public static class PhotonRealtimeClient
         switch (lobbyType)
         {
             default:
-            case GameType.Custom:
+            case MatchmakingType.Custom:
                 maxPlayers = 4;
                 break;
-            case GameType.Random2v2:
-            case GameType.Clan2v2:
+            case MatchmakingType.Random2v2:
+            case MatchmakingType.Clan2v2:
                 if (isMatchmaking)
                 {
                     maxPlayers = 4;
@@ -736,7 +736,7 @@ public static class PhotonRealtimeClient
                     maxPlayers = 2;
                 }
                 break;
-            case GameType.FriendLobby:
+            case MatchmakingType.FriendLobby:
                 maxPlayers = 2;
                 break;
         }
@@ -829,7 +829,7 @@ public static class PhotonRealtimeClient
 
     public static bool CreateRandom2v2LobbyRoom(string[] expectedUsers = null, bool isMatchmaking = false)
     {
-        RoomOptions roomOptions = GetRoomOptions(lobbyType:GameType.Random2v2, isMatchmaking: isMatchmaking);
+        RoomOptions roomOptions = GetRoomOptions(lobbyType:MatchmakingType.Random2v2, isMatchmaking: isMatchmaking);
 
         return CreateRoom(
             roomOptions: roomOptions,
@@ -840,7 +840,7 @@ public static class PhotonRealtimeClient
     public static bool CreateClan2v2LobbyRoom(string clanName, string clanId, int soulhomeRank, string[] expectedUsers = null, bool isMatchmaking = false)
     {
         RoomOptions roomOptions = GetRoomOptions(
-            lobbyType: GameType.Clan2v2,
+            lobbyType: MatchmakingType.Clan2v2,
             isMatchmaking: isMatchmaking,
             clanName: clanName,
             clanId: clanId,
@@ -878,7 +878,7 @@ public static class PhotonRealtimeClient
         }
 
         RoomOptions roomOptions = GetRoomOptions(
-            lobbyType: GameType.Custom,
+            lobbyType: MatchmakingType.Custom,
             mapId: mapId,
             startingEmotion: startingEmotion,
             roomName: displayName ?? roomName,
@@ -897,11 +897,11 @@ public static class PhotonRealtimeClient
         );
     }
 
-    public static bool CreateInRoomPremadeLobbyRoom(GameType gameType= GameType.None, string[] expectedUsers = null)
+    public static bool CreateInRoomPremadeLobbyRoom(MatchmakingType gameType= MatchmakingType.None, string[] expectedUsers = null)
     {
         string roomName = $"FriendLobby_{LocalPlayer.UserId}_{gameType}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
         RoomOptions roomOptions = GetRoomOptions(
-            lobbyType: GameType.FriendLobby,
+            lobbyType: MatchmakingType.FriendLobby,
             gametype: gameType,
             roomName: roomName
         );
@@ -913,7 +913,7 @@ public static class PhotonRealtimeClient
         );
     }
 
-    public static bool SendPremadeInvite(string invitedUserId, GameType targetGameType = GameType.Random2v2)
+    public static bool SendPremadeInvite(string invitedUserId, MatchmakingType targetGameType = MatchmakingType.Random2v2)
     {
         if (string.IsNullOrEmpty(invitedUserId))
         {
@@ -966,7 +966,7 @@ public static class PhotonRealtimeClient
 
         // Not in a room yet: create a premade friend lobby room with the invited user as expected user
         string roomName = $"FriendLobby_{LocalPlayer?.UserId}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
-        RoomOptions roomOptions = GetRoomOptions(lobbyType: GameType.FriendLobby, roomName: roomName);
+        RoomOptions roomOptions = GetRoomOptions(lobbyType: MatchmakingType.FriendLobby, roomName: roomName);
 
         try
         {
@@ -1025,7 +1025,7 @@ public static class PhotonRealtimeClient
         }
 
         RoomOptions roomOptions = GetRoomOptions(
-            lobbyType: GameType.Clan2v2,
+            lobbyType: MatchmakingType.Clan2v2,
             isMatchmaking: isMatchmaking,
             clanName: clanName,
             clanId: clanId,
@@ -1035,7 +1035,7 @@ public static class PhotonRealtimeClient
         EnterRoomArgs enterRoomArgs = GetEnterRoomArgs("", roomOptions, expectedUsers);
 
         JoinRandomRoomArgs joinRandomRoomArgs = new JoinRandomRoomArgs();
-        joinRandomRoomArgs.ExpectedCustomRoomProperties = new PhotonHashtable{ { PhotonBattleRoom.GameTypeKey, GameType.Clan2v2 }, { PhotonBattleRoom.ClanNameKey, clanName }, { PhotonBattleRoom.IsMatchmakingKey, isMatchmaking } };
+        joinRandomRoomArgs.ExpectedCustomRoomProperties = new PhotonHashtable{ { PhotonBattleRoom.MatchmakingKey, MatchmakingType.Clan2v2 }, { PhotonBattleRoom.ClanNameKey, clanName }, { PhotonBattleRoom.IsMatchmakingKey, isMatchmaking } };
         joinRandomRoomArgs.ExpectedMaxPlayers = roomOptions.MaxPlayers;
         joinRandomRoomArgs.Lobby = enterRoomArgs.Lobby;
         joinRandomRoomArgs.ExpectedUsers = expectedUsers;
@@ -1051,7 +1051,7 @@ public static class PhotonRealtimeClient
             return false;
         }
         RoomOptions roomOptions = GetRoomOptions(
-            lobbyType: GameType.Custom,
+            lobbyType: MatchmakingType.Custom,
             roomName: roomName, // For join random or create custom room we use GUID for room name so setting it to room options
             mapId: mapId,
             startingEmotion: startingEmotion,
@@ -1060,7 +1060,7 @@ public static class PhotonRealtimeClient
         EnterRoomArgs enterRoomArgs = GetEnterRoomArgs("", roomOptions, expectedUsers);
 
         JoinRandomRoomArgs joinRandomRoomArgs = new JoinRandomRoomArgs();
-        joinRandomRoomArgs.ExpectedCustomRoomProperties = new PhotonHashtable{ { PhotonBattleRoom.GameTypeKey, GameType.Custom } };
+        joinRandomRoomArgs.ExpectedCustomRoomProperties = new PhotonHashtable{ { PhotonBattleRoom.MatchmakingKey, MatchmakingType.Custom } };
         joinRandomRoomArgs.ExpectedMaxPlayers = roomOptions.MaxPlayers;
         joinRandomRoomArgs.Lobby = enterRoomArgs.Lobby;
         joinRandomRoomArgs.ExpectedUsers = expectedUsers;
@@ -1077,14 +1077,14 @@ public static class PhotonRealtimeClient
         }
 
         RoomOptions roomOptions = GetRoomOptions(
-            lobbyType: GameType.Random2v2,
+            lobbyType: MatchmakingType.Random2v2,
             isMatchmaking: isMatchmaking
         );
 
         EnterRoomArgs enterRoomArgs = GetEnterRoomArgs("", roomOptions, expectedUsers);
 
         JoinRandomRoomArgs joinRandomRoomArgs = new JoinRandomRoomArgs();
-        joinRandomRoomArgs.ExpectedCustomRoomProperties = new PhotonHashtable{ { PhotonBattleRoom.GameTypeKey, GameType.Random2v2 }, { PhotonBattleRoom.IsMatchmakingKey, isMatchmaking } };
+        joinRandomRoomArgs.ExpectedCustomRoomProperties = new PhotonHashtable{ { PhotonBattleRoom.MatchmakingKey, MatchmakingType.Random2v2 }, { PhotonBattleRoom.IsMatchmakingKey, isMatchmaking } };
         joinRandomRoomArgs.ExpectedMaxPlayers = roomOptions.MaxPlayers;
         joinRandomRoomArgs.Lobby = enterRoomArgs.Lobby;
         joinRandomRoomArgs.ExpectedUsers = expectedUsers;
@@ -1094,7 +1094,7 @@ public static class PhotonRealtimeClient
 
     // Server-side matchmaking room assignment using shared bucket properties.
     // Room names are allocated by the server when creating new rooms.
-    public static bool JoinOrCreateMatchmakingRoom(GameType gameType, string[] expectedUsers = null, string clanName = "", string clanId = "", int soulhomeRank = -1)
+    public static bool JoinOrCreateMatchmakingRoom(MatchmakingType gameType, string[] expectedUsers = null, string clanName = "", string clanId = "", int soulhomeRank = -1)
     {
         if (Client.Server != ServerConnection.MasterServer || !Client.IsConnectedAndReady)
         {
@@ -1102,11 +1102,11 @@ public static class PhotonRealtimeClient
             return false;
         }
 
-        RoomOptions roomOptions = GetRoomOptions(gameType, GameType.None, true, "", Emotion.Blank, "", "", clanName, clanId, soulhomeRank);
+        RoomOptions roomOptions = GetRoomOptions(gameType, MatchmakingType.None, true, "", Emotion.Blank, "", "", clanName, clanId, soulhomeRank);
         EnterRoomArgs enterRoomArgs = GetEnterRoomArgs("", roomOptions, expectedUsers);
 
         JoinRandomRoomArgs joinRandomRoomArgs = new JoinRandomRoomArgs();
-        var expectedProps = new PhotonHashtable{ { PhotonBattleRoom.GameTypeKey, gameType }, { PhotonBattleRoom.IsMatchmakingKey, true } };
+        var expectedProps = new PhotonHashtable{ { PhotonBattleRoom.MatchmakingKey, gameType }, { PhotonBattleRoom.IsMatchmakingKey, true } };
         if (!string.IsNullOrEmpty(clanName)) expectedProps.Add(PhotonBattleRoom.ClanNameKey, clanName);
         if (!string.IsNullOrEmpty(clanId)) expectedProps.Add(PhotonBattleRoom.ClanIdKey, clanId);
         if (soulhomeRank >= 0) expectedProps.Add(PhotonBattleRoom.SoulhomeRank, soulhomeRank);
@@ -1119,7 +1119,7 @@ public static class PhotonRealtimeClient
     }
 
     // Join or create a persistent queue room that can hold many players waiting for matches.
-    public static bool JoinOrCreateQueueRoom(GameType gameType, int maxQueueSize = 500)
+    public static bool JoinOrCreateQueueRoom(MatchmakingType gameType, int maxQueueSize = 500)
     {
         if (Client.Server != ServerConnection.MasterServer || !Client.IsConnectedAndReady)
         {
@@ -1130,7 +1130,7 @@ public static class PhotonRealtimeClient
         // Build minimal room options suitable for a queue room
         PhotonHashtable customRoomProperties = new PhotonHashtable
         {
-            { PhotonBattleRoom.GameTypeKey, gameType },
+            { PhotonBattleRoom.MatchmakingKey, gameType },
             { PhotonBattleRoom.IsMatchmakingKey, false },
             { PhotonBattleRoom.IsQueueKey, true }
         };
@@ -1145,7 +1145,7 @@ public static class PhotonRealtimeClient
             EmptyRoomTtl = ServerSettings.EmptyRoomTtlInSeconds * 1000,
             PublishUserId = true,
             CustomRoomProperties = customRoomProperties,
-            CustomRoomPropertiesForLobby = new string[] { PhotonBattleRoom.GameTypeKey, PhotonBattleRoom.IsQueueKey }
+            CustomRoomPropertiesForLobby = new string[] { PhotonBattleRoom.MatchmakingKey, PhotonBattleRoom.IsQueueKey }
         };
 
         EnterRoomArgs enterRoomArgs = GetEnterRoomArgs($"Queue_{gameType}", roomOptions, null);

--- a/Assets/MenuUi/Prefabs/UI Components/Battle Popup.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/Battle Popup.prefab
@@ -4778,7 +4778,7 @@ RectTransform:
   m_AnchorMin: {x: 0.85, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: -48.120026}
+  m_SizeDelta: {x: 0, y: -39.15004}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8576530089220829316
 CanvasRenderer:
@@ -8977,7 +8977,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &400308349062682705
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11457,7 +11457,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0.15, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: -48.120026}
+  m_SizeDelta: {x: 0, y: -39.15001}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7131637952194908805
 CanvasRenderer:

--- a/Assets/MenuUi/Prefabs/UI Components/Battle Popup.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/Battle Popup.prefab
@@ -4557,6 +4557,143 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1714868112840230438
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2295436099615059253}
+  - component: {fileID: 9109256859876679812}
+  - component: {fileID: 2564331792967620399}
+  m_Layer: 5
+  m_Name: GameType
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2295436099615059253
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714868112840230438}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4874668006867016235}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.05, y: 0.83}
+  m_AnchorMax: {x: 0.95, y: 0.88}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9109256859876679812
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714868112840230438}
+  m_CullTransparentMesh: 1
+--- !u!114 &2564331792967620399
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714868112840230438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: '#Pelimuoto#'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 394fb2628c0df214d92079770f57dd8e, type: 2}
+  m_sharedMaterial: {fileID: 4752717343592566078, guid: 394fb2628c0df214d92079770f57dd8e,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 48
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 48
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1748336550416512660
 GameObject:
   m_ObjectHideFlags: 0
@@ -5422,7 +5559,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &15072468070578721
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6292,7 +6429,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &4874668006867016235
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6306,6 +6443,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3758756102806641295}
+  - {fileID: 2295436099615059253}
   - {fileID: 4697395565309423292}
   - {fileID: 3962412108345378348}
   - {fileID: 1096968005318590124}
@@ -6389,7 +6527,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _title: {fileID: 7100896775920797250}
-  _gameType: {fileID: 0}
+  _gameType: {fileID: 2564331792967620399}
   _conflictText: {fileID: 2924516827518746523}
   _conflicts:
   - _finnishConflictText: "A ja B ovat molemmat tulisia luonteita. Sopivatko he yhteen
@@ -6810,7 +6948,7 @@ RectTransform:
   m_Father: {fileID: 2315689520699109490}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -6962,9 +7100,9 @@ RectTransform:
   m_Father: {fileID: 1155538765736967349}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -17, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &533628540212257550
 CanvasRenderer:
@@ -12400,7 +12538,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -811.51196}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &174028010994286647
 MonoBehaviour:
@@ -12617,7 +12755,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &4697395565309423292
 RectTransform:
   m_ObjectHideFlags: 0
@@ -15652,7 +15790,7 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -15662,27 +15800,27 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 210.03946
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64434
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6082567443366930256, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -15697,32 +15835,32 @@ PrefabInstance:
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 66.67982
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64434
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7139145698973672115, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -15777,7 +15915,7 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -15787,27 +15925,27 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 353.39908
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64434
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7797741711845899225, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -16197,7 +16335,7 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -16207,27 +16345,27 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 210.03946
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64431
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6020969734690887095, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -16247,32 +16385,32 @@ PrefabInstance:
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 66.67982
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64431
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7139145698973672115, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -16337,7 +16475,7 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -16347,27 +16485,27 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 353.39908
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64431
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7797741711845899225, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -17108,12 +17246,12 @@ PrefabInstance:
     - target: {fileID: 7483590805758421809, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 88.920044
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8463783555492997815, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -17720,12 +17858,12 @@ PrefabInstance:
     - target: {fileID: 7483590805758421809, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 58.687202
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8463783555492997815, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -18688,12 +18826,12 @@ PrefabInstance:
     - target: {fileID: 7483590805758421809, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 58.687195
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8463783555492997815, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -18881,12 +19019,12 @@ PrefabInstance:
     - target: {fileID: 7483590805758421809, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 58.687195
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8463783555492997815, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -19162,7 +19300,7 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -19172,27 +19310,27 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 210.03946
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64431
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6020969734690887095, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -19212,32 +19350,32 @@ PrefabInstance:
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 66.67982
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64431
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7139145698973672115, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -19302,7 +19440,7 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -19312,27 +19450,27 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 353.39908
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64431
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7797741711845899225, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -19962,7 +20100,7 @@ PrefabInstance:
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -19972,17 +20110,17 @@ PrefabInstance:
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 912
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 147.076
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -20022,12 +20160,12 @@ PrefabInstance:
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 466
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -83.538
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -20439,12 +20577,12 @@ PrefabInstance:
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -20759,92 +20897,92 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 222.76802
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 222.76802
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 476.28
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -111.38401
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 222.76802
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 222.76802
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 243.512
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -111.38401
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 222.76802
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 222.76802
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 709.0481
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -111.38401
       objectReference: {fileID: 0}
     - target: {fileID: 7797741711845899225, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -21459,12 +21597,12 @@ PrefabInstance:
     - target: {fileID: 7483590805758421809, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 58.687202
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8463783555492997815, guid: 1335c77fb45904842a7783f1ba479a62,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -21668,12 +21806,12 @@ PrefabInstance:
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -22991,7 +23129,7 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -23001,27 +23139,27 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 210.03946
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64434
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6082567443366930256, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -23036,22 +23174,22 @@ PrefabInstance:
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -23066,12 +23204,12 @@ PrefabInstance:
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 66.67982
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64434
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7139145698973672115, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -23126,7 +23264,7 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -23136,17 +23274,17 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 133.35963
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -23161,12 +23299,12 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 353.39908
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -97.64434
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7797741711845899225, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}

--- a/Assets/MenuUi/Prefabs/UI Components/Battle Popup.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/Battle Popup.prefab
@@ -305,7 +305,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 25.75
+  m_fontSize: 36
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -2887,7 +2887,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8151943761461288942
 RectTransform:
   m_ObjectHideFlags: 0
@@ -5422,7 +5422,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &15072468070578721
 RectTransform:
   m_ObjectHideFlags: 0
@@ -5435,9 +5435,9 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 8402482226732219697}
   - {fileID: 1954938854106881495}
   - {fileID: 7512609805384344912}
-  - {fileID: 8402482226732219697}
   m_Father: {fileID: 7093675246889126709}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -6093,7 +6093,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 30.3
+  m_fontSize: 36
   m_fontSizeBase: 55.15
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -6810,7 +6810,7 @@ RectTransform:
   m_Father: {fileID: 2315689520699109490}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -6962,7 +6962,7 @@ RectTransform:
   m_Father: {fileID: 1155538765736967349}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
@@ -7754,7 +7754,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 21.8
+  m_fontSize: 36
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -12400,7 +12400,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: -302.4096}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &174028010994286647
 MonoBehaviour:
@@ -13604,7 +13604,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &2269216928984931928
 RectTransform:
   m_ObjectHideFlags: 0
@@ -19605,32 +19605,32 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 210.03946
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -101.80021
       objectReference: {fileID: 0}
     - target: {fileID: 6082567443366930256, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -19640,32 +19640,32 @@ PrefabInstance:
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 66.67982
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -101.80021
       objectReference: {fileID: 0}
     - target: {fileID: 7432114284657142211, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -19685,32 +19685,32 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 353.39908
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -101.80021
       objectReference: {fileID: 0}
     - target: {fileID: 7797741711845899225, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -19799,7 +19799,7 @@ PrefabInstance:
     - target: {fileID: 4028375515925020952, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_fontSize
-      value: 24.9
+      value: 72
       objectReference: {fileID: 0}
     - target: {fileID: 4028375515925020952, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -19921,7 +19921,7 @@ PrefabInstance:
     - target: {fileID: 7811438372343880993, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_Type
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7811438372343880993, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -19962,7 +19962,7 @@ PrefabInstance:
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -19972,17 +19972,17 @@ PrefabInstance:
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 336.09998
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 42.260803
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -20022,12 +20022,12 @@ PrefabInstance:
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 536.14996
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -31.130402
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8279349774068130845, guid: 3db9db4cd4ab4f84b96799395497bcfa,
         type: 3}
@@ -20759,102 +20759,102 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 103.768
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 103.768
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 339.38995
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -51.884
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 103.768
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 103.768
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 235.62196
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -51.884
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 103.768
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 103.768
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 443.15796
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -51.884
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7797741711845899225, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 495.04196
+      value: 820.43207
       objectReference: {fileID: 0}
     - target: {fileID: 8163461842882552144, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_fontSize
-      value: 25.25
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 8163461842882552144, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -23414,32 +23414,32 @@ PrefabInstance:
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 210.03946
       objectReference: {fileID: 0}
     - target: {fileID: 5162689959517446653, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -101.80021
       objectReference: {fileID: 0}
     - target: {fileID: 6082567443366930256, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -23449,32 +23449,32 @@ PrefabInstance:
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 66.67982
       objectReference: {fileID: 0}
     - target: {fileID: 6691270648693797485, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -101.80021
       objectReference: {fileID: 0}
     - target: {fileID: 7432114284657142211, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
@@ -23494,32 +23494,32 @@ PrefabInstance:
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 133.35963
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 353.39908
       objectReference: {fileID: 0}
     - target: {fileID: 7615109156260062823, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -101.80021
       objectReference: {fileID: 0}
     - target: {fileID: 7797741711845899225, guid: 8e246b0a47c7e6b489fcb7b2eeb10763,
         type: 3}

--- a/Assets/MenuUi/Prefabs/UI Components/Battle Popup/RoomSlot.prefab
+++ b/Assets/MenuUi/Prefabs/UI Components/Battle Popup/RoomSlot.prefab
@@ -1,5 +1,142 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1149119581405317751
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9067789105510859967}
+  - component: {fileID: 7547750634235564004}
+  - component: {fileID: 708941395597493192}
+  m_Layer: 5
+  m_Name: Room name (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9067789105510859967
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1149119581405317751}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2151829709913189011}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.4, y: 0.2}
+  m_AnchorMax: {x: 0.8, y: 0.8}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7547750634235564004
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1149119581405317751}
+  m_CullTransparentMesh: 1
+--- !u!114 &708941395597493192
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1149119581405317751}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Pelityyppi
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ecff5251dfb671a42b33c27d895f275b, type: 2}
+  m_sharedMaterial: {fileID: 3258143769697088577, guid: ecff5251dfb671a42b33c27d895f275b,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 36
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &3652834263103924743
 GameObject:
   m_ObjectHideFlags: 0
@@ -219,7 +356,7 @@ PrefabInstance:
     - target: {fileID: 676561215496653827, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
       propertyPath: m_fontSize
-      value: 36
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 676561215496653827, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
@@ -250,7 +387,7 @@ PrefabInstance:
     - target: {fileID: 676561215496653827, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
       propertyPath: m_fontSizeMax
-      value: 36
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 676561215496653827, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
@@ -266,7 +403,7 @@ PrefabInstance:
     - target: {fileID: 676561215496653827, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
       propertyPath: m_enableAutoSizing
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 676561215496653827, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
@@ -467,22 +604,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8781344652289168645, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8781344652289168645, guid: 0cecd4c09312a86458e040444e8a8283,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0.02
       objectReference: {fileID: 0}
     - target: {fileID: 8781344652289168645, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 432
       objectReference: {fileID: 0}
     - target: {fileID: 8781344652289168645, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 216
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 7741526565642975645, guid: 0cecd4c09312a86458e040444e8a8283,
+        type: 3}
+      insertIndex: 1
+      addedObject: {fileID: 9067789105510859967}
     - targetCorrespondingSourceObject: {fileID: 7741526565642975645, guid: 0cecd4c09312a86458e040444e8a8283,
         type: 3}
       insertIndex: -1

--- a/Assets/MenuUi/Prefabs/Windows/BattleStory/BattleResultHandler.cs
+++ b/Assets/MenuUi/Prefabs/Windows/BattleStory/BattleResultHandler.cs
@@ -129,7 +129,7 @@ public class BattleResultHandler : MonoBehaviour
         _teamAlpha1PlayerPanel.SetActive(false);
         _teamBeta1PlayerPanel.SetActive(false);
 
-        if (info.GameType is GameType.Clan2v2)
+        if (info.MatchmakingType is MatchmakingType.Clan2v2)
         {
             _teamAlphaPanel.SetActive(true);
             _teamBetaPanel.SetActive(true);

--- a/Assets/MenuUi/Resources/GameTypeReference.asset
+++ b/Assets/MenuUi/Resources/GameTypeReference.asset
@@ -17,7 +17,8 @@ MonoBehaviour:
     Banner: {fileID: 21300000, guid: 0f29848d83e6e3949a191807264d256a, type: 3}
     Background: {fileID: 21300000, guid: 7b26f6cf383fe4d4285394b6b795d20f, type: 3}
     Middleground: {fileID: 21300000, guid: c7d45312a7e0c884684fb7f526da5dd6, type: 3}
-    gameType: 1
+    matchmakingType: 1
+    gameType: 0
     Enabled: 1
     FinnishName: "Ker\xE4ily 2v2"
     FinnishDescription: "Pelaa satunnaisten pelaajien kanssa satunnaistiimeiss\xE4"
@@ -27,7 +28,8 @@ MonoBehaviour:
     Banner: {fileID: 21300000, guid: 0f29848d83e6e3949a191807264d256a, type: 3}
     Background: {fileID: 21300000, guid: 7b26f6cf383fe4d4285394b6b795d20f, type: 3}
     Middleground: {fileID: 21300000, guid: c7d45312a7e0c884684fb7f526da5dd6, type: 3}
-    gameType: 3
+    matchmakingType: 2
+    gameType: 0
     Enabled: 1
     FinnishName: Duo 2v2
     FinnishDescription: Pelaa duon kanssa
@@ -37,26 +39,29 @@ MonoBehaviour:
     Banner: {fileID: 0}
     Background: {fileID: 0}
     Middleground: {fileID: 0}
-    gameType: 0
+    matchmakingType: -1
+    gameType: -1
     Enabled: 0
     FinnishName: 
     FinnishDescription: 
     EnglishName: 
     EnglishDescription: 
   - Icon: {fileID: 21300000, guid: 2c1ef5c1e2da228448095c34d1370feb, type: 3}
-    Banner: {fileID: 21300000, guid: 9438445216aac314daf2381661325c49, type: 3}
-    Background: {fileID: 21300000, guid: 2affc5251b93b4c4f86625bbd69e31e3, type: 3}
+    Banner: {fileID: 21300000, guid: 3741fd9807d98434e9a76c8839602e1c, type: 3}
+    Background: {fileID: 21300000, guid: a369d3faef59f964c8f2821726cdeb14, type: 3}
     Middleground: {fileID: 21300000, guid: c7d45312a7e0c884684fb7f526da5dd6, type: 3}
-    gameType: 2
+    matchmakingType: 0
+    gameType: 1
     Enabled: 0
-    FinnishName: Klaani 2v2
-    FinnishDescription: Pelaa toisia klaaneja vastaan
-    EnglishName: Clan 2v2
-    EnglishDescription: Play against other clans
+    FinnishName: Flipper Testi
+    FinnishDescription: Testaa Flipper pelimuotoa
+    EnglishName: FlipperMode Test
+    EnglishDescription: Test Flipper gamemode
   - Icon: {fileID: -872753631, guid: f612be18bdb2e2e478793c6bc3e4e0f9, type: 3}
     Banner: {fileID: 21300000, guid: 3741fd9807d98434e9a76c8839602e1c, type: 3}
     Background: {fileID: 21300000, guid: a369d3faef59f964c8f2821726cdeb14, type: 3}
     Middleground: {fileID: 21300000, guid: c7d45312a7e0c884684fb7f526da5dd6, type: 3}
+    matchmakingType: 0
     gameType: 0
     Enabled: 1
     FinnishName: Mukautettu
@@ -67,6 +72,7 @@ MonoBehaviour:
     Banner: {fileID: 21300000, guid: 9438445216aac314daf2381661325c49, type: 3}
     Background: {fileID: 21300000, guid: 2affc5251b93b4c4f86625bbd69e31e3, type: 3}
     Middleground: {fileID: 21300000, guid: d8f98be7e9df2aa4a8b7ce458bcd40e7, type: 3}
+    matchmakingType: -1
     gameType: 10
     Enabled: 1
     FinnishName: "Ry\xF6st\xF6 (Testi)"

--- a/Assets/MenuUi/Scripts/Lobby/BattleButton/BattleButton.cs
+++ b/Assets/MenuUi/Scripts/Lobby/BattleButton/BattleButton.cs
@@ -78,7 +78,7 @@ namespace MenuUi.Scripts.Lobby.BattleButton
                 StartCoroutine(_raidNavigation.Navigate());
                 return;
             }
-            SignalBus.OnBattlePopupRequestedSignal(_selectedMatchmakingType, _selectedMatchmakingType == MatchmakingType.FriendLobby? MatchmakingType.Clan2v2: MatchmakingType.None);
+            SignalBus.OnBattlePopupRequestedSignal(_selectedMatchmakingType, _selectedMatchmakingType == MatchmakingType.FriendLobby? MatchmakingType.Clan2v2: MatchmakingType.None, _selectedGameType);
         }
 
         public void UpdateGameType(GameTypeInfo gameTypeInfo)

--- a/Assets/MenuUi/Scripts/Lobby/BattleButton/BattleButton.cs
+++ b/Assets/MenuUi/Scripts/Lobby/BattleButton/BattleButton.cs
@@ -31,15 +31,18 @@ namespace MenuUi.Scripts.Lobby.BattleButton
 
         [SerializeField] private WindowNavigation _raidNavigation;
 
+        private const string SelectedMatchmakingKey = "BattleButtonMatchmaking";
         private const string SelectedGameTypeKey = "BattleButtonGameType";
 
-        private GameType _selectedGameType = GameType.Random2v2;
+        private MatchmakingType _selectedMatchmakingType = MatchmakingType.Random2v2;
+        private GameType _selectedGameType = GameType.BattlePingPong;
 
         private List<GameTypeOption> _gameTypeOptionList = new();
         private Button _button;
         private SwipeUI _swipe;
 
-        public GameType SelectedGameType { get => _selectedGameType;}
+        public MatchmakingType SelectedMatchmakingType { get => _selectedMatchmakingType; }
+        public GameType SelectedGameType { get => _selectedGameType; }
         public Button Button { get => _button;}
 
         private void Awake()
@@ -51,9 +54,9 @@ namespace MenuUi.Scripts.Lobby.BattleButton
             _button.onClick.AddListener(RequestBattlePopup);
 
             // Loading selected game type from player prefs Note: Only custom available for now
-            _selectedGameType = GameType.Custom; //(GameType)PlayerPrefs.GetInt(SelectedGameTypeKey, (int)_selectedGameType);
+            _selectedMatchmakingType = MatchmakingType.Custom; //(GameType)PlayerPrefs.GetInt(SelectedGameTypeKey, (int)_selectedGameType);
 
-            UpdateGameType(_gameTypeReference.GetGameTypeInfos().Find(x => x.gameType == _selectedGameType));
+            UpdateGameType(_gameTypeReference.GetGameTypeInfos().Find(x => x.matchmakingType == _selectedMatchmakingType && x.gameType == _selectedGameType));
 
             _openBattleUiEditorButton.transform.SetAsLastSibling();
             _openBattleUiEditorButton.onClick.AddListener(OnOpenBattleUiEditorButtonPressed);
@@ -75,7 +78,7 @@ namespace MenuUi.Scripts.Lobby.BattleButton
                 StartCoroutine(_raidNavigation.Navigate());
                 return;
             }
-            SignalBus.OnBattlePopupRequestedSignal(_selectedGameType, _selectedGameType == GameType.FriendLobby? GameType.Clan2v2: GameType.None);
+            SignalBus.OnBattlePopupRequestedSignal(_selectedMatchmakingType, _selectedMatchmakingType == MatchmakingType.FriendLobby? MatchmakingType.Clan2v2: MatchmakingType.None);
         }
 
         public void UpdateGameType(GameTypeInfo gameTypeInfo)
@@ -86,15 +89,17 @@ namespace MenuUi.Scripts.Lobby.BattleButton
             _gameTypeMiddleground.sprite = gameTypeInfo.Middleground;
             _gameTypeName.SetText(gameTypeInfo.Name);
             _gameTypeDescription.SetText(gameTypeInfo.Description);
+            _selectedMatchmakingType = gameTypeInfo.matchmakingType;
             _selectedGameType = gameTypeInfo.gameType;
 
             // Saving battle button selected game type to playerprefs
+            PlayerPrefs.SetInt(SelectedMatchmakingKey, (int)_selectedMatchmakingType);
             PlayerPrefs.SetInt(SelectedGameTypeKey, (int)_selectedGameType);
 
             // Setting selected visuals for option buttons
             foreach (GameTypeOption gameTypeOption in _gameTypeOptionList)
             {
-                bool selected = gameTypeOption.Info.gameType == _selectedGameType;
+                bool selected = gameTypeOption.Info.matchmakingType == _selectedMatchmakingType && gameTypeOption.Info.gameType == _selectedGameType;
                 gameTypeOption.SetSelected(selected);
             }
             
@@ -106,7 +111,7 @@ namespace MenuUi.Scripts.Lobby.BattleButton
         {
             foreach (GameTypeInfo gameTypeInfo in _gameTypeReference.GetGameTypeInfos())
             {
-                if (gameTypeInfo.gameType == _selectedGameType)
+                if (gameTypeInfo.matchmakingType == _selectedMatchmakingType && gameTypeInfo.gameType == _selectedGameType)
                 {
                     _gameTypeName.SetText(gameTypeInfo.Name);
                     _gameTypeDescription.SetText(gameTypeInfo.Description);
@@ -121,7 +126,7 @@ namespace MenuUi.Scripts.Lobby.BattleButton
                 {
                     if (gameTypeInfo.gameType == gameTypeOption.Info.gameType)
                     {
-                        bool selected = gameTypeInfo.gameType == _selectedGameType;
+                        bool selected = gameTypeOption.Info.matchmakingType == _selectedMatchmakingType && gameTypeOption.Info.gameType == _selectedGameType;
                         gameTypeOption.SetInfo(gameTypeInfo, selected);
                     }
                 }

--- a/Assets/MenuUi/Scripts/Lobby/BattleButton/GameTypeOption.cs
+++ b/Assets/MenuUi/Scripts/Lobby/BattleButton/GameTypeOption.cs
@@ -3,7 +3,7 @@ using UnityEngine.UI;
 
 using TMPro;
 
-using GameType = Altzone.Scripts.Lobby.GameType;
+using MatchmakingType = Altzone.Scripts.Lobby.MatchmakingType;
 
 using MenuUi.Scripts.ReferenceSheets;
 using MenuUi.Scripts.Signals;
@@ -63,7 +63,7 @@ namespace MenuUi.Scripts.Lobby.BattleButton
             _gameTypeInfo = info;
             SetSelected(selected);
 
-            if(info.gameType == GameType.Clan2v2)
+            if(info.matchmakingType == MatchmakingType.Clan2v2)
             {
                 ButtonComponent.interactable = false;
                 _settingsButton.gameObject.SetActive(false);

--- a/Assets/MenuUi/Scripts/Lobby/BattlePopupPanelManager.cs
+++ b/Assets/MenuUi/Scripts/Lobby/BattlePopupPanelManager.cs
@@ -74,8 +74,8 @@ public class BattlePopupPanelManager : MonoBehaviour
                 {
                     try
                     {
-                        int mode = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty(PhotonBattleRoom.CustomGameModeKey, (int)CustomGameMode.TwoVersusTwo);
-                        SwitchCustomRoom((CustomGameMode)mode);
+                        int mode = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty(PhotonBattleRoom.CustomGameModeKey, (int)GameType.BattlePingPong);
+                        SwitchCustomRoom((GameType)mode);
                     }
                     catch
                     {
@@ -221,11 +221,12 @@ public class BattlePopupPanelManager : MonoBehaviour
         return null;
     }
 
-    private void SwitchCustomRoom(CustomGameMode mode)
+    private void SwitchCustomRoom(GameType mode)
     {
         switch (mode)
         {
-            case CustomGameMode.TwoVersusTwo:
+            case GameType.BattlePingPong:
+            case GameType.BattleTestFlipperGame:
                 _custom2v2WaitingRoom.SetActive(true);
                 break;
             default:

--- a/Assets/MenuUi/Scripts/Lobby/BattlePopupPanelManager.cs
+++ b/Assets/MenuUi/Scripts/Lobby/BattlePopupPanelManager.cs
@@ -74,7 +74,7 @@ public class BattlePopupPanelManager : MonoBehaviour
                 {
                     try
                     {
-                        int mode = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty(PhotonBattleRoom.CustomGameModeKey, (int)GameType.BattlePingPong);
+                        int mode = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty(PhotonBattleRoom.GameTypeKey, (int)GameType.BattlePingPong);
                         SwitchCustomRoom((GameType)mode);
                     }
                     catch

--- a/Assets/MenuUi/Scripts/Lobby/BattlePopupPanelManager.cs
+++ b/Assets/MenuUi/Scripts/Lobby/BattlePopupPanelManager.cs
@@ -40,7 +40,7 @@ public class BattlePopupPanelManager : MonoBehaviour
         SignalBus.OnCustomRoomSettingsRequested -= OpenCustomRoomSettings;
     }
 
-    public void SwitchRoom(GameType gameType)
+    public void SwitchRoom(MatchmakingType gameType)
     {
         ClosePanels();
 
@@ -68,7 +68,7 @@ public class BattlePopupPanelManager : MonoBehaviour
 
         switch (gameType)
         {
-            case GameType.Custom:
+            case MatchmakingType.Custom:
                 // If already in a room, prefer showing the correct custom waiting room based on room's custom game mode
                 if (PhotonRealtimeClient.InRoom)
                 {
@@ -87,9 +87,9 @@ public class BattlePopupPanelManager : MonoBehaviour
                     ShowMainPanel();
                 }
                 break;
-            case GameType.FriendLobby:
-            case GameType.Clan2v2:
-            case GameType.Random2v2:
+            case MatchmakingType.FriendLobby:
+            case MatchmakingType.Clan2v2:
+            case MatchmakingType.Random2v2:
                 if (inMatchmakingOrQueue)
                 {
                     SwitchToMatchmakingPanel(isLeader);
@@ -137,7 +137,7 @@ public class BattlePopupPanelManager : MonoBehaviour
         // Ensure the create-room UI has its selectors initialized before showing
         if (_createCustomRoom != null)
         {
-            var createComp = _createCustomRoom.GetComponent<MenuUi.Scripts.Lobby.CreateRoom.CreateRoomCustom>();
+            var createComp = _createCustomRoom.GetComponent<CreateRoomCustom>();
             if (createComp != null && !createComp.IsCustomRoomOptionsReady)
             {
                 createComp.InitializeCustomRoomOptions();

--- a/Assets/MenuUi/Scripts/Lobby/CreateRoom/CreateRoomCustom.cs
+++ b/Assets/MenuUi/Scripts/Lobby/CreateRoom/CreateRoomCustom.cs
@@ -1,4 +1,5 @@
 using Altzone.Scripts.Common;
+using Altzone.Scripts.Lobby;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -53,7 +54,7 @@ namespace MenuUi.Scripts.Lobby.CreateRoom
         public bool ShowToFriends {  get { return _showToFriends.isOn; } }
         public bool ShowToClan { get {  return _showToClan.isOn; } }
         public Button CreateRoomButton { get { return _createRoom; } }
-        public CustomGameMode SelectedCustomGameMode { get { return _customBattleGameModeSelector.SelectedGameMode; } }
+        public GameType SelectedCustomGameMode { get { return _customBattleGameModeSelector.SelectedGameMode; } }
         public int SelectedCustomGameModeIndex { get { return (int)_customBattleGameModeSelector.SelectedGameMode; } }
         public bool CanCreateRoom => !IsPrivate || !string.IsNullOrWhiteSpace(RoomPassword);
 

--- a/Assets/MenuUi/Scripts/Lobby/CreateRoom/CustomBattleGameModeSelector.cs
+++ b/Assets/MenuUi/Scripts/Lobby/CreateRoom/CustomBattleGameModeSelector.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using Altzone.Scripts.Lobby;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -14,11 +16,13 @@ namespace MenuUi.Scripts.Lobby.CreateRoom
         [SerializeField] private TextMeshProUGUI _currentGameModeText;
         [SerializeField] private Button _nextButton;
         [SerializeField] private Button _previousButton;
+        private List<GameType> _gameTypes = new();
 
-        public CustomGameMode SelectedGameMode { get; private set; } = CustomGameMode.TwoVersusTwo;
+        public GameType SelectedGameMode { get; private set; } = GameType.BattlePingPong;
 
         private void Awake()
         {
+            InitializeGameTypes();
             _nextButton.onClick.AddListener(OnNextOptionClicked);
             _previousButton.onClick.AddListener(OnPreviousOptionClicked);
             _currentGameModeText.text = SelectedGameMode.GetString();
@@ -26,35 +30,37 @@ namespace MenuUi.Scripts.Lobby.CreateRoom
 
         private void OnNextOptionClicked()
         {
-            bool isLast = SelectedGameMode == Enum.GetValues(typeof(CustomGameMode)).Cast<CustomGameMode>().Last();
-            SelectedGameMode = isLast ? 0 : SelectedGameMode + 1;
+            if (_gameTypes.Count <= 1) return;
+            bool isLast = SelectedGameMode == _gameTypes.Last();
+            SelectedGameMode = isLast ? _gameTypes.First() : _gameTypes[_gameTypes.IndexOf(SelectedGameMode) + 1];
             _currentGameModeText.text = SelectedGameMode.GetString();
         }
 
         private void OnPreviousOptionClicked()
         {
-            bool isFirst = (int)SelectedGameMode <= 0;
-            SelectedGameMode = isFirst ? Enum.GetValues(typeof(CustomGameMode)).Cast<CustomGameMode>().Last() : SelectedGameMode - 1;
+            if (_gameTypes.Count <= 1) return;
+            bool isFirst = SelectedGameMode == _gameTypes.First();
+            SelectedGameMode = isFirst ? _gameTypes.Last() : _gameTypes[_gameTypes.IndexOf(SelectedGameMode) - 1];
             _currentGameModeText.text = SelectedGameMode.GetString();
         }
-    }
 
-    public enum CustomGameMode
-    {
-        OneVersusOne,
-        TwoVersusTwo,
-        Tournament
+        private void InitializeGameTypes()
+        {
+            _gameTypes = Enum.GetValues(typeof(GameType)).Cast<GameType>().ToList();
+            _gameTypes.Remove(GameType.None);
+            _gameTypes.Remove(GameType.Raid);
+        }
     }
 
     public static class CustomGameModeExtension
     {
-        public static string GetString(this CustomGameMode gameMode)
+        public static string GetString(this GameType gameMode)
         {
             return gameMode switch
             {
-                CustomGameMode.OneVersusOne => "1v1",
-                CustomGameMode.TwoVersusTwo => "2v2",
-                CustomGameMode.Tournament => "Turnaus",
+                GameType.BattlePingPong => "Peruspeli",
+                GameType.BattleTestFlipperGame => "Flipper testi",
+                GameType.Raid => "Ryöstö",
                 _ => ""
             };
         }

--- a/Assets/MenuUi/Scripts/Lobby/CreateRoom/CustomBattleGameModeSelector.cs
+++ b/Assets/MenuUi/Scripts/Lobby/CreateRoom/CustomBattleGameModeSelector.cs
@@ -51,18 +51,4 @@ namespace MenuUi.Scripts.Lobby.CreateRoom
             _gameTypes.Remove(GameType.Raid);
         }
     }
-
-    public static class CustomGameModeExtension
-    {
-        public static string GetString(this GameType gameMode)
-        {
-            return gameMode switch
-            {
-                GameType.BattlePingPong => "Peruspeli",
-                GameType.BattleTestFlipperGame => "Flipper testi",
-                GameType.Raid => "Ryöstö",
-                _ => ""
-            };
-        }
-    }
 }

--- a/Assets/MenuUi/Scripts/Lobby/InLobby/InLobbyController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InLobby/InLobbyController.cs
@@ -285,7 +285,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             // Starting creating room of a selected game type if the coroutine is not already running
             if (_creatingRoomCoroutineHolder != null) return;
             _roomSwitcher.ClosePanels();
-            _creatingRoomCoroutineHolder = StartCoroutine(_roomListingController.StartCreatingRoom(SelectedMatchmakingType, () =>
+            _creatingRoomCoroutineHolder = StartCoroutine(_roomListingController.StartCreatingRoom(SelectedMatchmakingType, SelectedGameType, () =>
             {
                 _creatingRoomCoroutineHolder = null;
             }));

--- a/Assets/MenuUi/Scripts/Lobby/InLobby/InLobbyController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InLobby/InLobbyController.cs
@@ -16,11 +16,11 @@ namespace MenuUi.Scripts.Signals
 {
     public static partial class SignalBus
     {
-        public delegate void BattlePopupRequestedHandler(MatchmakingType lobbygameType, MatchmakingType actualGameType);
+        public delegate void BattlePopupRequestedHandler(MatchmakingType lobbygameType, MatchmakingType actualGameType, GameType gameType);
         public static event BattlePopupRequestedHandler OnBattlePopupRequested;
-        public static void OnBattlePopupRequestedSignal(MatchmakingType lobbygameType, MatchmakingType actualGameType = MatchmakingType.None)
+        public static void OnBattlePopupRequestedSignal(MatchmakingType lobbygameType, MatchmakingType actualGameType = MatchmakingType.None, GameType gameType = GameType.BattlePingPong)
         {
-            OnBattlePopupRequested?.Invoke(lobbygameType, actualGameType);
+            OnBattlePopupRequested?.Invoke(lobbygameType, actualGameType, gameType);
         }
 
         public delegate void CloseBattlePopupRequestedHandler();
@@ -59,14 +59,15 @@ namespace MenuUi.Scripts.Lobby.InLobby
         private Coroutine _creatingRoomCoroutineHolder = null;
 
         public static InLobbyController Instance { get; private set; }
-        public static MatchmakingType SelectedGameType { get; private set; }
-        public static MatchmakingType SelectedPremadeTargetGameType { get; private set; } = MatchmakingType.Clan2v2;
+        public static MatchmakingType SelectedMatchmakingType { get; private set; }
+        public static GameType SelectedGameType { get; private set; }
+        public static MatchmakingType SelectedPremadeTargetMatchmakingType { get; private set; } = MatchmakingType.Clan2v2;
 
         public static void SetPremadeTargetGameType(MatchmakingType gameType)
         {
             if (gameType == MatchmakingType.Random2v2 || gameType == MatchmakingType.Clan2v2)
             {
-                SelectedPremadeTargetGameType = gameType;
+                SelectedPremadeTargetMatchmakingType = gameType;
             }
         }
 
@@ -168,21 +169,21 @@ namespace MenuUi.Scripts.Lobby.InLobby
         }*/
 
 
-        private void OpenWindow(MatchmakingType gameType, MatchmakingType actualGameType = MatchmakingType.None)
+        private void OpenWindow(MatchmakingType matchmakingType, MatchmakingType actualMatchmakingType = MatchmakingType.None, GameType gameType = GameType.BattlePingPong)
         {
             _popupContents.SetActive(true);
             // Ensure top info shows current values when popup opens
             RefreshTopInfo();
 
             // Checking if we are in room or matchmaking room depending on the game mode which would prevent changing the selected game type
-            switch (gameType)
+            switch (matchmakingType)
             {
                 case MatchmakingType.Custom:
                     if (PhotonRealtimeClient.InRoom)
                     {
-                        if (gameType == SelectedGameType)
+                        if (matchmakingType == SelectedMatchmakingType)
                         {
-                            _roomSwitcher.SwitchRoom(gameType);
+                            _roomSwitcher.SwitchRoom(matchmakingType);
                             return;
                         }
                         else
@@ -193,8 +194,9 @@ namespace MenuUi.Scripts.Lobby.InLobby
                         }
                     }
 
+                    SelectedMatchmakingType = matchmakingType;
                     SelectedGameType = gameType;
-                    _roomSwitcher.SwitchRoom(gameType);
+                    _roomSwitcher.SwitchRoom(matchmakingType);
                     return;
                 case MatchmakingType.Clan2v2:
                 case MatchmakingType.Random2v2:
@@ -214,7 +216,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
                         if (currRoom != null)
                         {
                             var gt = currRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
-                            currentRoomGameTypeMatches = gt == (int)gameType;
+                            currentRoomGameTypeMatches = gt == (int)matchmakingType;
                         }
                     }
                     catch { }
@@ -247,8 +249,8 @@ namespace MenuUi.Scripts.Lobby.InLobby
                         if (currRoom != null)
                         {
                             var gt = currRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
-                            currentFriendRoomMatches = gt == (int)gameType;
-                            SelectedPremadeTargetGameType = actualGameType;
+                            currentFriendRoomMatches = gt == (int)matchmakingType;
+                            SelectedPremadeTargetMatchmakingType = actualMatchmakingType;
                         }
                     }
                     catch { }
@@ -275,14 +277,15 @@ namespace MenuUi.Scripts.Lobby.InLobby
                     return;
             }
 
+            SelectedMatchmakingType = matchmakingType;
             SelectedGameType = gameType;
-            if(SelectedGameType == MatchmakingType.Random2v2) SelectedGameType = MatchmakingType.Clan2v2; //This line is for testing purposes, remove when you no longer want to force Clan2v2.
-            SelectedPremadeTargetGameType = actualGameType;
+            if (SelectedMatchmakingType == MatchmakingType.Random2v2) SelectedMatchmakingType = MatchmakingType.Clan2v2; //This line is for testing purposes, remove when you no longer want to force Clan2v2.
+            SelectedPremadeTargetMatchmakingType = actualMatchmakingType;
 
             // Starting creating room of a selected game type if the coroutine is not already running
             if (_creatingRoomCoroutineHolder != null) return;
             _roomSwitcher.ClosePanels();
-            _creatingRoomCoroutineHolder = StartCoroutine(_roomListingController.StartCreatingRoom(SelectedGameType, () =>
+            _creatingRoomCoroutineHolder = StartCoroutine(_roomListingController.StartCreatingRoom(SelectedMatchmakingType, () =>
             {
                 _creatingRoomCoroutineHolder = null;
             }));
@@ -372,7 +375,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
 
         private void OpenBattlePopupForInviteAccept()
         {
-            SelectedGameType = MatchmakingType.FriendLobby;
+            SelectedMatchmakingType = MatchmakingType.FriendLobby;
 
             if (_popupContents != null && !_popupContents.activeSelf)
             {

--- a/Assets/MenuUi/Scripts/Lobby/InLobby/InLobbyController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InLobby/InLobbyController.cs
@@ -16,9 +16,9 @@ namespace MenuUi.Scripts.Signals
 {
     public static partial class SignalBus
     {
-        public delegate void BattlePopupRequestedHandler(GameType lobbygameType, GameType actualGameType);
+        public delegate void BattlePopupRequestedHandler(MatchmakingType lobbygameType, MatchmakingType actualGameType);
         public static event BattlePopupRequestedHandler OnBattlePopupRequested;
-        public static void OnBattlePopupRequestedSignal(GameType lobbygameType, GameType actualGameType = GameType.None)
+        public static void OnBattlePopupRequestedSignal(MatchmakingType lobbygameType, MatchmakingType actualGameType = MatchmakingType.None)
         {
             OnBattlePopupRequested?.Invoke(lobbygameType, actualGameType);
         }
@@ -59,12 +59,12 @@ namespace MenuUi.Scripts.Lobby.InLobby
         private Coroutine _creatingRoomCoroutineHolder = null;
 
         public static InLobbyController Instance { get; private set; }
-        public static GameType SelectedGameType { get; private set; }
-        public static GameType SelectedPremadeTargetGameType { get; private set; } = GameType.Clan2v2;
+        public static MatchmakingType SelectedGameType { get; private set; }
+        public static MatchmakingType SelectedPremadeTargetGameType { get; private set; } = MatchmakingType.Clan2v2;
 
-        public static void SetPremadeTargetGameType(GameType gameType)
+        public static void SetPremadeTargetGameType(MatchmakingType gameType)
         {
-            if (gameType == GameType.Random2v2 || gameType == GameType.Clan2v2)
+            if (gameType == MatchmakingType.Random2v2 || gameType == MatchmakingType.Clan2v2)
             {
                 SelectedPremadeTargetGameType = gameType;
             }
@@ -168,7 +168,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
         }*/
 
 
-        private void OpenWindow(GameType gameType, GameType actualGameType = GameType.None)
+        private void OpenWindow(MatchmakingType gameType, MatchmakingType actualGameType = MatchmakingType.None)
         {
             _popupContents.SetActive(true);
             // Ensure top info shows current values when popup opens
@@ -177,12 +177,12 @@ namespace MenuUi.Scripts.Lobby.InLobby
             // Checking if we are in room or matchmaking room depending on the game mode which would prevent changing the selected game type
             switch (gameType)
             {
-                case GameType.Custom:
+                case MatchmakingType.Custom:
                     if (PhotonRealtimeClient.InRoom)
                     {
                         if (gameType == SelectedGameType)
                         {
-                            _roomSwitcher.SwitchRoom(GameType.Custom);
+                            _roomSwitcher.SwitchRoom(gameType);
                             return;
                         }
                         else
@@ -194,10 +194,10 @@ namespace MenuUi.Scripts.Lobby.InLobby
                     }
 
                     SelectedGameType = gameType;
-                    _roomSwitcher.SwitchRoom(GameType.Custom);
+                    _roomSwitcher.SwitchRoom(gameType);
                     return;
-                case GameType.Clan2v2:
-                case GameType.Random2v2:
+                case MatchmakingType.Clan2v2:
+                case MatchmakingType.Random2v2:
                     // Treat persistent queue rooms as matchmaking state so reopening the popup shows matchmaking panel
                     bool inQueueRoom = false;
                     try
@@ -213,7 +213,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
                         var currRoom = PhotonRealtimeClient.LobbyCurrentRoom;
                         if (currRoom != null)
                         {
-                            var gt = currRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                            var gt = currRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                             currentRoomGameTypeMatches = gt == (int)gameType;
                         }
                     }
@@ -239,14 +239,14 @@ namespace MenuUi.Scripts.Lobby.InLobby
                         }
                     }
                     break;
-                case GameType.FriendLobby:
+                case MatchmakingType.FriendLobby:
                     bool currentFriendRoomMatches = false;
                     try
                     {
                         var currRoom = PhotonRealtimeClient.LobbyCurrentRoom;
                         if (currRoom != null)
                         {
-                            var gt = currRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                            var gt = currRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                             currentFriendRoomMatches = gt == (int)gameType;
                             SelectedPremadeTargetGameType = actualGameType;
                         }
@@ -263,7 +263,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
                     {
                         if (currentFriendRoomMatches)
                         {
-                            _roomSwitcher.SwitchRoom(GameType.FriendLobby);
+                            _roomSwitcher.SwitchRoom(MatchmakingType.FriendLobby);
                             return;
                         }
 
@@ -276,7 +276,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             }
 
             SelectedGameType = gameType;
-            if(SelectedGameType == GameType.Random2v2) SelectedGameType = GameType.Clan2v2; //This line is for testing purposes, remove when you no longer want to force Clan2v2.
+            if(SelectedGameType == MatchmakingType.Random2v2) SelectedGameType = MatchmakingType.Clan2v2; //This line is for testing purposes, remove when you no longer want to force Clan2v2.
             SelectedPremadeTargetGameType = actualGameType;
 
             // Starting creating room of a selected game type if the coroutine is not already running
@@ -344,7 +344,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             if (inviteInfo == null || string.IsNullOrEmpty(inviteInfo.RoomName)) return;
 
             string inviterName = ResolveOnlinePlayerName(inviteInfo.LeaderUserName);
-            string targetMode = inviteInfo.TargetGameType == GameType.Clan2v2 ? "Clan 2v2" : "Random 2v2";
+            string targetMode = inviteInfo.TargetGameType == MatchmakingType.Clan2v2 ? "Clan 2v2" : "Random 2v2";
             string message = $"{inviterName} kutsui sinut Friend Lobby -huoneeseen.\n\nHaettava pelimuoto: {targetMode}.\n\nLiitytaanko huoneeseen?";
 
             bool popupShown = InviteDecisionPopupHandler.RequestInviteDecisionPrompt(
@@ -372,7 +372,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
 
         private void OpenBattlePopupForInviteAccept()
         {
-            SelectedGameType = GameType.FriendLobby;
+            SelectedGameType = MatchmakingType.FriendLobby;
 
             if (_popupContents != null && !_popupContents.activeSelf)
             {
@@ -380,7 +380,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             }
 
             RefreshTopInfo();
-            _roomSwitcher?.SwitchRoom(GameType.FriendLobby);
+            _roomSwitcher?.SwitchRoom(MatchmakingType.FriendLobby);
         }
 
         private string ResolveOnlinePlayerName(string userId)

--- a/Assets/MenuUi/Scripts/Lobby/InLobby/LobbyRoomListingController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InLobby/LobbyRoomListingController.cs
@@ -40,7 +40,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
 
         private PhotonRoomList _photonRoomList;
         private JoinIntent _pendingJoinIntent = JoinIntent.None;
-        private GameType _pendingQueueGameType = GameType.Random2v2;
+        private MatchmakingType _pendingQueueGameType = MatchmakingType.Random2v2;
         private Coroutine _queueRejoinHolder;
         private bool _createRoomRequestInFlight;
 
@@ -118,7 +118,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
         /// <param name="gameType">Game type of which room to create.</param>
         /// <param name="callback">Callback which is called after room is created.</param>
         /// <returns></returns>
-        public IEnumerator StartCreatingRoom(GameType gameType, Action callback)
+        public IEnumerator StartCreatingRoom(MatchmakingType gameType, Action callback)
         {
             if (_createRoomRequestInFlight)
             {
@@ -151,16 +151,16 @@ namespace MenuUi.Scripts.Lobby.InLobby
                 {
                     switch (gameType)
                     {
-                        case GameType.FriendLobby:
+                        case MatchmakingType.FriendLobby:
                             PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(InLobbyController.SelectedPremadeTargetGameType);
                             break;
-                        case GameType.Clan2v2:
+                        case MatchmakingType.Clan2v2:
                             yield return CreateClan2v2Room();
                             break;
-                        case GameType.Random2v2:
+                        case MatchmakingType.Random2v2:
                             yield return CreateRandom2v2Room();
                             break;
-                        case GameType.Custom:
+                        case MatchmakingType.Custom:
                             if (!_createRoomCustom.IsCustomRoomOptionsReady) _createRoomCustom.InitializeCustomRoomOptions();
                             CreateCustomRoom();
                             break;
@@ -264,12 +264,12 @@ namespace MenuUi.Scripts.Lobby.InLobby
                 {
                     // Join the persistent queue room instead of creating a matchmaking room immediately
                     _pendingJoinIntent = JoinIntent.QueueJoin;
-                    _pendingQueueGameType = GameType.Clan2v2;
-                    PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(GameType.Clan2v2);
+                    _pendingQueueGameType = MatchmakingType.Clan2v2;
+                    PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(MatchmakingType.Clan2v2);
                 }
             });
             yield return new WaitUntil(() => PhotonRealtimeClient.InRoom);
-            this.Publish(new LobbyManager.StartMatchmakingEvent(GameType.Clan2v2));
+            this.Publish(new LobbyManager.StartMatchmakingEvent(MatchmakingType.Clan2v2));
         }
 
         private IEnumerator CreateRandom2v2Room()  // soulhome value for matchmaking
@@ -280,12 +280,12 @@ namespace MenuUi.Scripts.Lobby.InLobby
                 {
                     // Join the persistent queue room instead of creating a matchmaking room immediately
                     _pendingJoinIntent = JoinIntent.QueueJoin;
-                    _pendingQueueGameType = GameType.Random2v2;
-                    PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(GameType.Random2v2);
+                    _pendingQueueGameType = MatchmakingType.Random2v2;
+                    PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(MatchmakingType.Random2v2);
                 }
             });
             yield return new WaitUntil(() => PhotonRealtimeClient.InRoom);
-            this.Publish(new LobbyManager.StartMatchmakingEvent(GameType.Random2v2));
+            this.Publish(new LobbyManager.StartMatchmakingEvent(MatchmakingType.Random2v2));
         }
 
         private void JoinRoom(string roomName)
@@ -376,13 +376,13 @@ namespace MenuUi.Scripts.Lobby.InLobby
             }
 
             // Only attempt to create a custom room automatically when the user was creating a custom room.
-            if (_pendingJoinIntent == JoinIntent.CustomCreate || (creatingTextActive && InLobbyController.SelectedGameType == GameType.Custom))
+            if (_pendingJoinIntent == JoinIntent.CustomCreate || (creatingTextActive && InLobbyController.SelectedGameType == MatchmakingType.Custom))
             {
                 CreateCustomRoom();
                 return;
             }
 
-            if (ShouldRejoinQueueAfterJoinFailed(returnCode, message, out GameType queueGameType))
+            if (ShouldRejoinQueueAfterJoinFailed(returnCode, message, out MatchmakingType queueGameType))
             {
                 if (LobbyManager.Instance != null && LobbyManager.Instance.IsJoinFailureAutoRequeueInFlight)
                 {
@@ -403,7 +403,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             PopupSignalBus.OnChangePopupInfoSignal("Liityminen epäonnistui: huone on täysi tai ei käytettävissä.");
         }
 
-        private bool ShouldRejoinQueueAfterJoinFailed(short returnCode, string message, out GameType queueGameType)
+        private bool ShouldRejoinQueueAfterJoinFailed(short returnCode, string message, out MatchmakingType queueGameType)
         {
             queueGameType = _pendingQueueGameType;
 
@@ -416,7 +416,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             {
                 queueGameType = _pendingQueueGameType;
             }
-            else if (InLobbyController.SelectedGameType == GameType.Random2v2 || InLobbyController.SelectedGameType == GameType.Clan2v2)
+            else if (InLobbyController.SelectedGameType == MatchmakingType.Random2v2 || InLobbyController.SelectedGameType == MatchmakingType.Clan2v2)
             {
                 queueGameType = InLobbyController.SelectedGameType;
             }
@@ -442,7 +442,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             return msg.Contains("game full") || msg.Contains("game closed") || msg.Contains("does not exist");
         }
 
-        private void StartQueueRejoin(GameType gameType)
+        private void StartQueueRejoin(MatchmakingType gameType)
         {
             if (_queueRejoinHolder != null)
             {
@@ -452,7 +452,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             _queueRejoinHolder = StartCoroutine(RejoinQueueWhenLobbyReady(gameType));
         }
 
-        private IEnumerator RejoinQueueWhenLobbyReady(GameType gameType)
+        private IEnumerator RejoinQueueWhenLobbyReady(MatchmakingType gameType)
         {
             try
             {
@@ -566,7 +566,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
                     return false;
                 }
 
-                if (!room.CustomProperties.TryGetValue(PhotonBattleRoom.GameTypeKey, out object gameTypeValue) || gameTypeValue is not int gameType || gameType != (int)GameType.Custom)
+                if (!room.CustomProperties.TryGetValue(PhotonBattleRoom.MatchmakingKey, out object gameTypeValue) || gameTypeValue is not int gameType || gameType != (int)MatchmakingType.Custom)
                 {
                     return false;
                 }

--- a/Assets/MenuUi/Scripts/Lobby/InLobby/LobbyRoomListingController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InLobby/LobbyRoomListingController.cs
@@ -115,10 +115,10 @@ namespace MenuUi.Scripts.Lobby.InLobby
         /// <summary>
         /// Coroutine to create a room after client is connected to lobby.
         /// </summary>
-        /// <param name="gameType">Game type of which room to create.</param>
+        /// <param name="matchmakingType">Game type of which room to create.</param>
         /// <param name="callback">Callback which is called after room is created.</param>
         /// <returns></returns>
-        public IEnumerator StartCreatingRoom(MatchmakingType gameType, Action callback)
+        public IEnumerator StartCreatingRoom(MatchmakingType matchmakingType, GameType gameType, Action callback)
         {
             if (_createRoomRequestInFlight)
             {
@@ -149,16 +149,16 @@ namespace MenuUi.Scripts.Lobby.InLobby
                 yield return null;
                 if (PhotonRealtimeClient.InLobby)
                 {
-                    switch (gameType)
+                    switch (matchmakingType)
                     {
                         case MatchmakingType.FriendLobby:
-                            PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(InLobbyController.SelectedPremadeTargetGameType);
+                            PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(InLobbyController.SelectedPremadeTargetMatchmakingType, gameType);
                             break;
                         case MatchmakingType.Clan2v2:
-                            yield return CreateClan2v2Room();
+                            yield return CreateClan2v2Room(gameType);
                             break;
                         case MatchmakingType.Random2v2:
-                            yield return CreateRandom2v2Room();
+                            yield return CreateRandom2v2Room(gameType);
                             break;
                         case MatchmakingType.Custom:
                             if (!_createRoomCustom.IsCustomRoomOptionsReady) _createRoomCustom.InitializeCustomRoomOptions();
@@ -256,7 +256,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             return null;
         }
 
-        private IEnumerator CreateClan2v2Room()  // soulhome value for matchmaking
+        private IEnumerator CreateClan2v2Room(GameType gameType)  // soulhome value for matchmaking
         {
             yield return GetClanData( clanData =>
             {
@@ -265,14 +265,14 @@ namespace MenuUi.Scripts.Lobby.InLobby
                     // Join the persistent queue room instead of creating a matchmaking room immediately
                     _pendingJoinIntent = JoinIntent.QueueJoin;
                     _pendingQueueGameType = MatchmakingType.Clan2v2;
-                    PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(MatchmakingType.Clan2v2);
+                    PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(MatchmakingType.Clan2v2, gameType);
                 }
             });
             yield return new WaitUntil(() => PhotonRealtimeClient.InRoom);
             this.Publish(new LobbyManager.StartMatchmakingEvent(MatchmakingType.Clan2v2));
         }
 
-        private IEnumerator CreateRandom2v2Room()  // soulhome value for matchmaking
+        private IEnumerator CreateRandom2v2Room(GameType gameType)  // soulhome value for matchmaking
         {
             yield return GetClanData(clanData =>
             {
@@ -281,7 +281,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
                     // Join the persistent queue room instead of creating a matchmaking room immediately
                     _pendingJoinIntent = JoinIntent.QueueJoin;
                     _pendingQueueGameType = MatchmakingType.Random2v2;
-                    PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(MatchmakingType.Random2v2);
+                    PhotonRealtimeClient.CreateInRoomPremadeLobbyRoom(MatchmakingType.Random2v2, gameType);
                 }
             });
             yield return new WaitUntil(() => PhotonRealtimeClient.InRoom);
@@ -376,7 +376,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             }
 
             // Only attempt to create a custom room automatically when the user was creating a custom room.
-            if (_pendingJoinIntent == JoinIntent.CustomCreate || (creatingTextActive && InLobbyController.SelectedGameType == MatchmakingType.Custom))
+            if (_pendingJoinIntent == JoinIntent.CustomCreate || (creatingTextActive && InLobbyController.SelectedMatchmakingType == MatchmakingType.Custom))
             {
                 CreateCustomRoom();
                 return;
@@ -416,9 +416,9 @@ namespace MenuUi.Scripts.Lobby.InLobby
             {
                 queueGameType = _pendingQueueGameType;
             }
-            else if (InLobbyController.SelectedGameType == MatchmakingType.Random2v2 || InLobbyController.SelectedGameType == MatchmakingType.Clan2v2)
+            else if (InLobbyController.SelectedMatchmakingType == MatchmakingType.Random2v2 || InLobbyController.SelectedMatchmakingType == MatchmakingType.Clan2v2)
             {
-                queueGameType = InLobbyController.SelectedGameType;
+                queueGameType = InLobbyController.SelectedMatchmakingType;
             }
             else
             {
@@ -513,7 +513,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
 
         public void SwitchToRoom()
         {
-            _roomSwitcher.SwitchRoom(InLobbyController.SelectedGameType);
+            _roomSwitcher.SwitchRoom(InLobbyController.SelectedMatchmakingType);
         }
 
         private void UpdateStatus()

--- a/Assets/MenuUi/Scripts/Lobby/InLobby/RoomSlot.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InLobby/RoomSlot.cs
@@ -1,5 +1,7 @@
 using Altzone.Scripts.Battle.Photon;
+using Altzone.Scripts.Lobby;
 using Altzone.Scripts.Lobby.Wrappers;
+using Photon.Client.StructWrapping;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -13,6 +15,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
     {
         [Header("GameObject references")]
         [SerializeField] private TMP_Text _roomName;
+        [SerializeField] private TMP_Text _roomGameType;
         [SerializeField] private TMP_Text _roomPlayerCount;
         [SerializeField] private Image _openStatusLockImage;
         [Header("Sprite references")]
@@ -28,6 +31,11 @@ namespace MenuUi.Scripts.Lobby.InLobby
         {
             _roomName.text = roomInfo.Name;
             _roomPlayerCount.text = $"{roomInfo.PlayerCount}/4";
+
+            if(roomInfo.CustomProperties.TryGetValue(PhotonBattleRoom.GameTypeKey, out int gameType))
+            {
+                _roomGameType.text = ((GameType)gameType).GetString();
+            }
 
             bool hasPassword = roomInfo.CustomProperties.ContainsKey(PhotonBattleRoom.PasswordKey);
 

--- a/Assets/MenuUi/Scripts/Lobby/InRoom/InRoomController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InRoom/InRoomController.cs
@@ -59,37 +59,37 @@ namespace MenuUi.Scripts.Lobby.InRoom
         private void OnEnable()
         {
             if (_startGameButton != null) _startGameButton.interactable = true;
-            if (_inviteOnlinePlayerButton != null) _inviteOnlinePlayerButton.interactable = InLobbyController.SelectedGameType == GameType.FriendLobby;
+            if (_inviteOnlinePlayerButton != null) _inviteOnlinePlayerButton.interactable = InLobbyController.SelectedGameType == MatchmakingType.FriendLobby;
 
             switch (InLobbyController.SelectedGameType)
             {
-                case GameType.Custom:
+                case MatchmakingType.Custom:
                     if (_title != null) StartCoroutine(SetRoomTitle());
                     if (_conflictText != null) StartCoroutine(CycleConflicts());
                     StartCustomRoomTimeoutMonitoring();
                     break;
-                case GameType.FriendLobby:
+                case MatchmakingType.FriendLobby:
                     if (_title != null) _title.text = "Friend Lobby";
                     if (_gameType) _gameType.text = InLobbyController.SelectedPremadeTargetGameType.ToString();
                     if (_noticeText != null) _noticeText.text = "Kutsu yksi online-pelaaja ja valitse haettava 2v2 pelimuoto.";
                     if (_sendInviteToFriendText != null) _sendInviteToFriendText.text = "Kutsu online-pelaaja";
                     EnsureInviteSelectorPanel();
                     break;
-                case GameType.Random2v2:
+                case MatchmakingType.Random2v2:
                     //if (_title != null) _title.text = "Keräily 2v2";
                     //if (_noticeText != null) _noticeText.text = "Tätä pelimuotoa voi mennä pelaamaan yksin tai kaverin kanssa (työn alla). Huom. Jos menet pelaamaan yksin, paikan valinnalla ei ole merkitystä.";
                     //if (_sendInviteToFriendText != null) _sendInviteToFriendText.text = "Lähetä kutsu kaverille";
                     _roomSwitcher.ClosePanels();
                     StartPlaying();
                     break;
-                case GameType.Clan2v2:
+                case MatchmakingType.Clan2v2:
                     if (_title != null) _title.text = "Klaani 2v2";
                     if (_noticeText != null) _noticeText.text = "Kutsun lähettäminen ei vielä toimi. Saman klaanin jäsen voi liittyä tähän huoneeseen menemällä peliin 2v2 klaanijäsenen kanssa.";
                     if (_sendInviteToFriendText != null) _sendInviteToFriendText.text = "Lähetä kutsu yhdelle klaanin jäsenelle";
                     break;
             }
 
-            if (InLobbyController.SelectedGameType == GameType.FriendLobby)
+            if (InLobbyController.SelectedGameType == MatchmakingType.FriendLobby)
             {
                 StartInviteLifecycleMonitoring();
             }
@@ -98,7 +98,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                 StopInviteLifecycleMonitoring();
             }
 
-            if (InLobbyController.SelectedGameType != GameType.Custom)
+            if (InLobbyController.SelectedGameType != MatchmakingType.Custom)
             {
                 StopCustomRoomTimeoutMonitoring();
             }
@@ -150,11 +150,11 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
             switch (InLobbyController.SelectedGameType)
             {
-                case GameType.Custom:
+                case MatchmakingType.Custom:
                     this.Publish(new LobbyManager.StartPlayingEvent());
                     break;
 
-                case GameType.FriendLobby:
+                case MatchmakingType.FriendLobby:
                     if (!PhotonRealtimeClient.InRoom || PhotonRealtimeClient.LobbyCurrentRoom == null)
                     {
                         RestoreStartButton();
@@ -175,10 +175,10 @@ namespace MenuUi.Scripts.Lobby.InRoom
                         return;
                     }
 
-                    GameType targetGameType = InLobbyController.SelectedPremadeTargetGameType;
-                    if (targetGameType != GameType.Random2v2 && targetGameType != GameType.Clan2v2)
+                    MatchmakingType targetGameType = InLobbyController.SelectedPremadeTargetGameType;
+                    if (targetGameType != MatchmakingType.Random2v2 && targetGameType != MatchmakingType.Clan2v2)
                     {
-                        targetGameType = GameType.Random2v2;
+                        targetGameType = MatchmakingType.Random2v2;
                     }
 
                     string localUserId = PhotonRealtimeClient.LocalLobbyPlayer?.UserId ?? string.Empty;
@@ -200,7 +200,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                     this.Publish(new LobbyManager.StartMatchmakingEvent(targetGameType, true));
                     break;
 
-                case GameType.Clan2v2:
+                case MatchmakingType.Clan2v2:
                     if (PhotonLobbyRoom.CountRealPlayers() == PhotonRealtimeClient.LobbyCurrentRoom.MaxPlayers)
                     {
                         // Prevent starting matchmaking when this room is actually a queue room
@@ -223,7 +223,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                         RestoreStartButton();
                     }
                     break;
-                case GameType.Random2v2:
+                case MatchmakingType.Random2v2:
                     // Prevent starting matchmaking when this room is a queue room
                     try
                     {
@@ -245,7 +245,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
         private void OnInviteOnlinePlayerButtonPressed()
         {
-            if (InLobbyController.SelectedGameType != GameType.FriendLobby) return;
+            if (InLobbyController.SelectedGameType != MatchmakingType.FriendLobby) return;
             StartCoroutine(InviteOnlinePlayerRoutine());
         }
 
@@ -312,7 +312,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
             string localUserId = GetLocalUserId();
             List<ClanMember> members = null;
-            if (InLobbyController.SelectedPremadeTargetGameType == GameType.Clan2v2)
+            if (InLobbyController.SelectedPremadeTargetGameType == MatchmakingType.Clan2v2)
             {
                 ClanData clan = null;
                 Storefront.Get().GetClanData(ServerManager.Instance.Player.clan_id, data => clan = data);
@@ -324,7 +324,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                 if (onlinePlayer == null || string.IsNullOrEmpty(onlinePlayer._id)) continue;
                 if (onlinePlayer._id == localUserId) continue;
                 if (IsPlayerAlreadyInCurrentRoom(onlinePlayer._id)) continue;
-                if (InLobbyController.SelectedPremadeTargetGameType == GameType.Clan2v2)
+                if (InLobbyController.SelectedPremadeTargetGameType == MatchmakingType.Clan2v2)
                 {
                     if(members.Find((m) => m.Id == onlinePlayer._id) == null) continue;
                 }
@@ -402,7 +402,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
             return true;
         }
 
-        private void ApplyPendingPremadeInviteSelection(string invitedUserId, string localUserId, string localUsername, GameType targetGameType)
+        private void ApplyPendingPremadeInviteSelection(string invitedUserId, string localUserId, string localUsername, MatchmakingType targetGameType)
         {
             PhotonRealtimeClient.LobbyCurrentRoom.SetCustomProperty(PhotonBattleRoom.PremadeModeKey, true);
             PhotonRealtimeClient.LobbyCurrentRoom.SetCustomProperty(PhotonBattleRoom.PremadeLeaderUserIdKey, localUserId);
@@ -540,9 +540,9 @@ namespace MenuUi.Scripts.Lobby.InRoom
         {
             try
             {
-                yield return new WaitUntil(() => PhotonRealtimeClient.InRoom || InLobbyController.SelectedGameType != GameType.Custom);
+                yield return new WaitUntil(() => PhotonRealtimeClient.InRoom || InLobbyController.SelectedGameType != MatchmakingType.Custom);
 
-                if (InLobbyController.SelectedGameType != GameType.Custom || !PhotonRealtimeClient.InRoom || PhotonRealtimeClient.LobbyCurrentRoom == null)
+                if (InLobbyController.SelectedGameType != MatchmakingType.Custom || !PhotonRealtimeClient.InRoom || PhotonRealtimeClient.LobbyCurrentRoom == null)
                 {
                     yield break;
                 }
@@ -550,7 +550,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                 bool isCustomRoom = false;
                 try
                 {
-                    isCustomRoom = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == (int)GameType.Custom;
+                    isCustomRoom = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == (int)MatchmakingType.Custom;
                 }
                 catch { }
 
@@ -561,7 +561,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
                 yield return new WaitForSecondsRealtime(CustomRoomTimeoutSeconds);
 
-                if (InLobbyController.SelectedGameType != GameType.Custom || !PhotonRealtimeClient.InRoom || PhotonRealtimeClient.LobbyCurrentRoom == null)
+                if (InLobbyController.SelectedGameType != MatchmakingType.Custom || !PhotonRealtimeClient.InRoom || PhotonRealtimeClient.LobbyCurrentRoom == null)
                 {
                     yield break;
                 }
@@ -573,7 +573,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
                 try
                 {
-                    isCustomRoom = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey) == (int)GameType.Custom;
+                    isCustomRoom = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey) == (int)MatchmakingType.Custom;
                 }
                 catch
                 {
@@ -613,11 +613,11 @@ namespace MenuUi.Scripts.Lobby.InRoom
                     continue;
                 }
 
-                GameType roomGameType = GameType.FriendLobby;
+                MatchmakingType roomGameType = MatchmakingType.FriendLobby;
                 bool failedToReadRoomGameType = false;
                 try
                 {
-                    roomGameType = (GameType)PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+                    roomGameType = (MatchmakingType)PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
                 }
                 catch
                 {
@@ -630,7 +630,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                     continue;
                 }
 
-                if (roomGameType != GameType.FriendLobby)
+                if (roomGameType != MatchmakingType.FriendLobby)
                 {
                     yield return delay;
                     continue;
@@ -714,7 +714,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
         {
             Debug.Log($"leavingRoom");
             PhotonRealtimeClient.LeaveRoom();
-            if (InLobbyController.SelectedGameType != GameType.Clan2v2) SignalBus.OnCloseBattlePopupRequestedSignal();
+            if (InLobbyController.SelectedGameType != MatchmakingType.Clan2v2) SignalBus.OnCloseBattlePopupRequestedSignal();
             //this.Publish(new LobbyManager.StartPlayingEvent());
         }
 

--- a/Assets/MenuUi/Scripts/Lobby/InRoom/InRoomController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InRoom/InRoomController.cs
@@ -65,7 +65,6 @@ namespace MenuUi.Scripts.Lobby.InRoom
             {
                 case MatchmakingType.Custom:
                     if (_title != null) StartCoroutine(SetRoomTitle());
-                    if (_gameType) _gameType.text = InLobbyController.SelectedPremadeTargetMatchmakingType.ToString();
                     if (_conflictText != null) StartCoroutine(CycleConflicts());
                     StartCustomRoomTimeoutMonitoring();
                     break;

--- a/Assets/MenuUi/Scripts/Lobby/InRoom/InRoomController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InRoom/InRoomController.cs
@@ -59,9 +59,9 @@ namespace MenuUi.Scripts.Lobby.InRoom
         private void OnEnable()
         {
             if (_startGameButton != null) _startGameButton.interactable = true;
-            if (_inviteOnlinePlayerButton != null) _inviteOnlinePlayerButton.interactable = InLobbyController.SelectedGameType == MatchmakingType.FriendLobby;
+            if (_inviteOnlinePlayerButton != null) _inviteOnlinePlayerButton.interactable = InLobbyController.SelectedMatchmakingType == MatchmakingType.FriendLobby;
 
-            switch (InLobbyController.SelectedGameType)
+            switch (InLobbyController.SelectedMatchmakingType)
             {
                 case MatchmakingType.Custom:
                     if (_title != null) StartCoroutine(SetRoomTitle());
@@ -70,7 +70,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                     break;
                 case MatchmakingType.FriendLobby:
                     if (_title != null) _title.text = "Friend Lobby";
-                    if (_gameType) _gameType.text = InLobbyController.SelectedPremadeTargetGameType.ToString();
+                    if (_gameType) _gameType.text = InLobbyController.SelectedPremadeTargetMatchmakingType.ToString();
                     if (_noticeText != null) _noticeText.text = "Kutsu yksi online-pelaaja ja valitse haettava 2v2 pelimuoto.";
                     if (_sendInviteToFriendText != null) _sendInviteToFriendText.text = "Kutsu online-pelaaja";
                     EnsureInviteSelectorPanel();
@@ -89,7 +89,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                     break;
             }
 
-            if (InLobbyController.SelectedGameType == MatchmakingType.FriendLobby)
+            if (InLobbyController.SelectedMatchmakingType == MatchmakingType.FriendLobby)
             {
                 StartInviteLifecycleMonitoring();
             }
@@ -98,7 +98,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                 StopInviteLifecycleMonitoring();
             }
 
-            if (InLobbyController.SelectedGameType != MatchmakingType.Custom)
+            if (InLobbyController.SelectedMatchmakingType != MatchmakingType.Custom)
             {
                 StopCustomRoomTimeoutMonitoring();
             }
@@ -148,7 +148,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
             //}
             _startGameButton.interactable = false;
 
-            switch (InLobbyController.SelectedGameType)
+            switch (InLobbyController.SelectedMatchmakingType)
             {
                 case MatchmakingType.Custom:
                     this.Publish(new LobbyManager.StartPlayingEvent());
@@ -175,7 +175,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                         return;
                     }
 
-                    MatchmakingType targetGameType = InLobbyController.SelectedPremadeTargetGameType;
+                    MatchmakingType targetGameType = InLobbyController.SelectedPremadeTargetMatchmakingType;
                     if (targetGameType != MatchmakingType.Random2v2 && targetGameType != MatchmakingType.Clan2v2)
                     {
                         targetGameType = MatchmakingType.Random2v2;
@@ -215,7 +215,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                             }
                         }
                         catch { }
-                        this.Publish(new LobbyManager.StartMatchmakingEvent(InLobbyController.SelectedGameType));
+                        this.Publish(new LobbyManager.StartMatchmakingEvent(InLobbyController.SelectedMatchmakingType));
                     }
                     else
                     {
@@ -236,7 +236,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                         }
                     }
                     catch { }
-                    this.Publish(new LobbyManager.StartMatchmakingEvent(InLobbyController.SelectedGameType));
+                    this.Publish(new LobbyManager.StartMatchmakingEvent(InLobbyController.SelectedMatchmakingType));
                     break;
             }
         }
@@ -245,7 +245,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
         private void OnInviteOnlinePlayerButtonPressed()
         {
-            if (InLobbyController.SelectedGameType != MatchmakingType.FriendLobby) return;
+            if (InLobbyController.SelectedMatchmakingType != MatchmakingType.FriendLobby) return;
             StartCoroutine(InviteOnlinePlayerRoutine());
         }
 
@@ -312,7 +312,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
             string localUserId = GetLocalUserId();
             List<ClanMember> members = null;
-            if (InLobbyController.SelectedPremadeTargetGameType == MatchmakingType.Clan2v2)
+            if (InLobbyController.SelectedPremadeTargetMatchmakingType == MatchmakingType.Clan2v2)
             {
                 ClanData clan = null;
                 Storefront.Get().GetClanData(ServerManager.Instance.Player.clan_id, data => clan = data);
@@ -324,7 +324,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                 if (onlinePlayer == null || string.IsNullOrEmpty(onlinePlayer._id)) continue;
                 if (onlinePlayer._id == localUserId) continue;
                 if (IsPlayerAlreadyInCurrentRoom(onlinePlayer._id)) continue;
-                if (InLobbyController.SelectedPremadeTargetGameType == MatchmakingType.Clan2v2)
+                if (InLobbyController.SelectedPremadeTargetMatchmakingType == MatchmakingType.Clan2v2)
                 {
                     if(members.Find((m) => m.Id == onlinePlayer._id) == null) continue;
                 }
@@ -387,7 +387,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                 return false;
             }
 
-            ApplyPendingPremadeInviteSelection(invitedUserId, localUserId, localUsername, InLobbyController.SelectedPremadeTargetGameType);
+            ApplyPendingPremadeInviteSelection(invitedUserId, localUserId, localUsername, InLobbyController.SelectedPremadeTargetMatchmakingType);
 
             try
             {
@@ -540,9 +540,9 @@ namespace MenuUi.Scripts.Lobby.InRoom
         {
             try
             {
-                yield return new WaitUntil(() => PhotonRealtimeClient.InRoom || InLobbyController.SelectedGameType != MatchmakingType.Custom);
+                yield return new WaitUntil(() => PhotonRealtimeClient.InRoom || InLobbyController.SelectedMatchmakingType != MatchmakingType.Custom);
 
-                if (InLobbyController.SelectedGameType != MatchmakingType.Custom || !PhotonRealtimeClient.InRoom || PhotonRealtimeClient.LobbyCurrentRoom == null)
+                if (InLobbyController.SelectedMatchmakingType != MatchmakingType.Custom || !PhotonRealtimeClient.InRoom || PhotonRealtimeClient.LobbyCurrentRoom == null)
                 {
                     yield break;
                 }
@@ -561,7 +561,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
 
                 yield return new WaitForSecondsRealtime(CustomRoomTimeoutSeconds);
 
-                if (InLobbyController.SelectedGameType != MatchmakingType.Custom || !PhotonRealtimeClient.InRoom || PhotonRealtimeClient.LobbyCurrentRoom == null)
+                if (InLobbyController.SelectedMatchmakingType != MatchmakingType.Custom || !PhotonRealtimeClient.InRoom || PhotonRealtimeClient.LobbyCurrentRoom == null)
                 {
                     yield break;
                 }
@@ -714,7 +714,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
         {
             Debug.Log($"leavingRoom");
             PhotonRealtimeClient.LeaveRoom();
-            if (InLobbyController.SelectedGameType != MatchmakingType.Clan2v2) SignalBus.OnCloseBattlePopupRequestedSignal();
+            if (InLobbyController.SelectedMatchmakingType != MatchmakingType.Clan2v2) SignalBus.OnCloseBattlePopupRequestedSignal();
             //this.Publish(new LobbyManager.StartPlayingEvent());
         }
 

--- a/Assets/MenuUi/Scripts/Lobby/InRoom/InRoomController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InRoom/InRoomController.cs
@@ -65,6 +65,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
             {
                 case MatchmakingType.Custom:
                     if (_title != null) StartCoroutine(SetRoomTitle());
+                    if (_gameType) _gameType.text = InLobbyController.SelectedPremadeTargetMatchmakingType.ToString();
                     if (_conflictText != null) StartCoroutine(CycleConflicts());
                     StartCustomRoomTimeoutMonitoring();
                     break;
@@ -730,8 +731,10 @@ namespace MenuUi.Scripts.Lobby.InRoom
             // Getting room name either from custom properties or from the room's name itself.
             string roomName = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<string>(PhotonLobbyRoom.RoomNameKey);
             bool testRoom = PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<bool>(PhotonLobbyRoom.TestModeKey);
+            string gameType = ((GameType)PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey)).GetString();
             if (string.IsNullOrEmpty(roomName)) roomName = PhotonRealtimeClient.LobbyCurrentRoom.Name;
             _title.text = _title.text = testRoom ? $"{roomName} (test)" : roomName;
+            _gameType.text = gameType;
         }
 
         private IEnumerator CycleConflicts()
@@ -745,8 +748,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                 if (selectedConflict == previousConflict) continue;
                 _conflictText.SetText(_conflicts[selectedConflict].ConlictText);
                 yield return new WaitForSecondsRealtime(7);
-            }
-            
+            }  
         }
     }
     [Serializable]

--- a/Assets/MenuUi/Scripts/Lobby/InRoom/RoomSetupManager.cs
+++ b/Assets/MenuUi/Scripts/Lobby/InRoom/RoomSetupManager.cs
@@ -288,7 +288,7 @@ namespace MenuUi.Scripts.Lobby.InRoom
                 return;
             }
             ResetState();
-            GameType roomGameType = (GameType)PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.GameTypeKey);
+            MatchmakingType roomGameType = (MatchmakingType)PhotonRealtimeClient.LobbyCurrentRoom.GetCustomProperty<int>(PhotonBattleRoom.MatchmakingKey);
 
             // We need local player to check against other players
             LobbyPlayer localPlayer = PhotonRealtimeClient.LocalLobbyPlayer;

--- a/Assets/MenuUi/Scripts/Lobby/MatchmakingPanel.cs
+++ b/Assets/MenuUi/Scripts/Lobby/MatchmakingPanel.cs
@@ -116,9 +116,9 @@ namespace MenuUi.Scripts.Lobby
             }
             catch { }
 
-            this.Publish(new LobbyManager.StopMatchmakingEvent(InLobbyController.SelectedGameType, true));
+            this.Publish(new LobbyManager.StopMatchmakingEvent(InLobbyController.SelectedMatchmakingType, true));
             bool isLeader = PhotonRealtimeClient.LocalLobbyPlayer != null && PhotonRealtimeClient.LocalLobbyPlayer.IsMasterClient;
-            if (!isLeader && InLobbyController.SelectedGameType != MatchmakingType.Clan2v2 && InLobbyController.SelectedGameType != MatchmakingType.FriendLobby)
+            if (!isLeader && InLobbyController.SelectedMatchmakingType != MatchmakingType.Clan2v2 && InLobbyController.SelectedMatchmakingType != MatchmakingType.FriendLobby)
             {
                 Signals.SignalBus.OnCloseBattlePopupRequestedSignal();
             }

--- a/Assets/MenuUi/Scripts/Lobby/MatchmakingPanel.cs
+++ b/Assets/MenuUi/Scripts/Lobby/MatchmakingPanel.cs
@@ -118,7 +118,7 @@ namespace MenuUi.Scripts.Lobby
 
             this.Publish(new LobbyManager.StopMatchmakingEvent(InLobbyController.SelectedGameType, true));
             bool isLeader = PhotonRealtimeClient.LocalLobbyPlayer != null && PhotonRealtimeClient.LocalLobbyPlayer.IsMasterClient;
-            if (!isLeader && InLobbyController.SelectedGameType != GameType.Clan2v2 && InLobbyController.SelectedGameType != GameType.FriendLobby)
+            if (!isLeader && InLobbyController.SelectedGameType != MatchmakingType.Clan2v2 && InLobbyController.SelectedGameType != MatchmakingType.FriendLobby)
             {
                 Signals.SignalBus.OnCloseBattlePopupRequestedSignal();
             }

--- a/Assets/MenuUi/Scripts/Lobby/MiniMatchmakingPanel.cs
+++ b/Assets/MenuUi/Scripts/Lobby/MiniMatchmakingPanel.cs
@@ -284,7 +284,7 @@ namespace MenuUi.Scripts.Lobby
             this.Publish(new LobbyManager.StopMatchmakingEvent(InLobbyController.SelectedGameType, true));
             // If caller is non-leader, close the battle popup to reset UI state (except Clan2v2)
             bool isLeader = PhotonRealtimeClient.LocalLobbyPlayer != null && PhotonRealtimeClient.LocalLobbyPlayer.IsMasterClient;
-            if (!isLeader && InLobbyController.SelectedGameType != GameType.Clan2v2 && InLobbyController.SelectedGameType != GameType.FriendLobby)
+            if (!isLeader && InLobbyController.SelectedGameType != MatchmakingType.Clan2v2 && InLobbyController.SelectedGameType != MatchmakingType.FriendLobby)
             {
                 Signals.SignalBus.OnCloseBattlePopupRequestedSignal();
             }

--- a/Assets/MenuUi/Scripts/Lobby/MiniMatchmakingPanel.cs
+++ b/Assets/MenuUi/Scripts/Lobby/MiniMatchmakingPanel.cs
@@ -281,10 +281,10 @@ namespace MenuUi.Scripts.Lobby
             }
             catch { }
 
-            this.Publish(new LobbyManager.StopMatchmakingEvent(InLobbyController.SelectedGameType, true));
+            this.Publish(new LobbyManager.StopMatchmakingEvent(InLobbyController.SelectedMatchmakingType, true));
             // If caller is non-leader, close the battle popup to reset UI state (except Clan2v2)
             bool isLeader = PhotonRealtimeClient.LocalLobbyPlayer != null && PhotonRealtimeClient.LocalLobbyPlayer.IsMasterClient;
-            if (!isLeader && InLobbyController.SelectedGameType != MatchmakingType.Clan2v2 && InLobbyController.SelectedGameType != MatchmakingType.FriendLobby)
+            if (!isLeader && InLobbyController.SelectedMatchmakingType != MatchmakingType.Clan2v2 && InLobbyController.SelectedMatchmakingType != MatchmakingType.FriendLobby)
             {
                 Signals.SignalBus.OnCloseBattlePopupRequestedSignal();
             }
@@ -294,7 +294,7 @@ namespace MenuUi.Scripts.Lobby
         {
             // Reopen the battle popup and hide this mini panel
             Hide();
-            Signals.SignalBus.OnBattlePopupRequestedSignal(InLobbyController.SelectedGameType);
+            Signals.SignalBus.OnBattlePopupRequestedSignal(InLobbyController.SelectedMatchmakingType);
         }
 
         private void OnGameCountdownUpdate(int secondsRemaining)

--- a/Assets/MenuUi/Scripts/Lobby/PhotonBattleLobbyRoom.cs
+++ b/Assets/MenuUi/Scripts/Lobby/PhotonBattleLobbyRoom.cs
@@ -25,7 +25,7 @@ namespace MenuUi.Scripts.Lobby
         public const string TeamBlueScoreKey = PhotonBattleRoom.TeamBlueScoreKey;
         public const string TeamRedScoreKey = PhotonBattleRoom.TeamRedScoreKey;
         public const string PasswordKey = PhotonBattleRoom.PasswordKey;
-        public const string GameTypeKey = PhotonBattleRoom.GameTypeKey;
+        public const string GameTypeKey = PhotonBattleRoom.MatchmakingKey;
         public const string MatchmakingKey = PhotonBattleRoom.IsMatchmakingKey;
         public const string SoulhomeRank = PhotonBattleRoom.SoulhomeRank;
         public const string SoulhomeRankVariance = PhotonBattleRoom.SoulhomeRankVariance;

--- a/Assets/MenuUi/Scripts/Lobby/RoomSearchPanelController.cs
+++ b/Assets/MenuUi/Scripts/Lobby/RoomSearchPanelController.cs
@@ -54,7 +54,7 @@ namespace MenuUi.Scripts.Lobby.InLobby
             foreach(LobbyRoomInfo roomInfo in _roomsData)
             {
                 bool gameTypePropertyExist = roomInfo.CustomProperties.TryGetValue(PhotonBattleLobbyRoom.GameTypeKey, out int gameType);
-                if (gameTypePropertyExist && gameType == (int)GameType.Custom)
+                if (gameTypePropertyExist && gameType == (int)MatchmakingType.Custom)
                 {
                     GameObject button = Instantiate(_slotPrefab, _content);
                     RoomSlot roomSlot = button.GetComponent<RoomSlot>();

--- a/Assets/MenuUi/Scripts/MainMenu/OnlinePlayersPanel/OnlinePlayersPanelItem.cs
+++ b/Assets/MenuUi/Scripts/MainMenu/OnlinePlayersPanel/OnlinePlayersPanelItem.cs
@@ -420,9 +420,9 @@ public class OnlinePlayersPanelItem : AltMonoBehaviour
                 Storefront.Get().GetClanData(ServerManager.Instance.Player.clan_id, data => clan = data);
                 List<ClanMember>members = clan.Members;
                 if (members.Find((m) => m.Id == Player._id) == null) 
-                    SignalBus.OnBattlePopupRequestedSignal(GameType.FriendLobby, GameType.Random2v2);
+                    SignalBus.OnBattlePopupRequestedSignal(MatchmakingType.FriendLobby, MatchmakingType.Random2v2);
                 else
-                    SignalBus.OnBattlePopupRequestedSignal(GameType.FriendLobby, GameType.Clan2v2);
+                    SignalBus.OnBattlePopupRequestedSignal(MatchmakingType.FriendLobby, MatchmakingType.Clan2v2);
             }
             catch (Exception ex)
             {

--- a/Assets/MenuUi/Scripts/ReferenceSheets/GameTypeReference.cs
+++ b/Assets/MenuUi/Scripts/ReferenceSheets/GameTypeReference.cs
@@ -58,6 +58,7 @@ namespace MenuUi.Scripts.ReferenceSheets
         public Sprite Banner;
         public Sprite Background;
         public Sprite Middleground;
+        public MatchmakingType matchmakingType;
         public GameType gameType;
         public bool Enabled;
         public string FinnishName;

--- a/Assets/Raid/Scripts/RaidMatchmakingController.cs
+++ b/Assets/Raid/Scripts/RaidMatchmakingController.cs
@@ -350,7 +350,7 @@ public class RaidMatchmakingController : MonoBehaviour, IConnectionCallbacks, IL
             CustomRoomProperties = customRoomProperties,
             CustomRoomPropertiesForLobby = new[]
             {
-                PhotonBattleRoom.GameTypeKey,
+                PhotonBattleRoom.MatchmakingKey,
                 RaidPhotonRoom.RaidMatchmakingKey,
                 RaidPhotonRoom.RaidClanCountsKey,
                 RaidPhotonRoom.RaidStateKey,


### PR DESCRIPTION
Added a way to choose in between the basic pingpong game mode and the new flipper mode that we are testing.
This can right now only be done in custom rooms.
Also split the old GameType enum into MatchmakingType and GameType enums.
MatchmakingType handles the what type of matchmaking we want to use. (Most of the old call for the GameType enum were moved to this)
GameType tells the Battle what is actually should be loading.